### PR TITLE
Fix docs generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 
 
 python:
-   version: 3.7
+   version: 3.8
    install:
    - method: pip
      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.ymldd# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+sphinx:
+   configuration: docs/conf.py
+
+
+python:
+   version: 3.7
+   install:
+   - method: pip
+     path: .
+   - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install git+https://git.ligo.org/michael.williams/bilby.git@add-nessai-sampl
 
 ## Documentation
 
-Documenation will be added to the ReadTheDocs shortly.
+Documenation is available at: [nessai.readthedocs.io](https://nessai.readthedocs.io/)
 
 ## Contributing
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../nessai/'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
@@ -32,10 +32,8 @@ release = 'v0.1.1'
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
-              'nbsphinx',
               'sphinx.ext.autosummary',
               'sphinx.ext.autosectionlabel',
-              'sphinx_tabs.tabs'
               ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,11 @@ release = 'v0.1.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.mathjax',
+extensions = ['sphinx.ext.mathjax',
               'numpydoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.autosectionlabel',
+              'autoapi.extension'
               ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -56,7 +56,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-
-# -- Configure autodoc -------------------------------------------------------
-autosummary_generate = True
-add_module_names = False
+# -- Configure autoapi -------------------------------------------------------
+autoapi_type = 'python'
+autoapi_dirs = ['../nessai/']
+autoapi_add_toctree_entry = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../nessai/'))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ The code is available at: https://github.com/mj-will/nessai.
 
 .. automodule:: nessai
    :members:
+   :undoc-members:
 
 .. toctree::
    :maxdepth: 1
@@ -31,6 +32,7 @@ The code is available at: https://github.com/mj-will/nessai.
    reparameterisations
    normalising-flows-configuration
    further-details
+   API reference </autoapi/nessai/index>
 
 .. toctree::
    :maxdepth: 1
@@ -38,10 +40,3 @@ The code is available at: https://github.com/mj-will/nessai.
 
    gaussian-example
    bilby-example
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+numpydoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 numpydoc
+sphinx-autoapi

--- a/docs/sampler-configuration.rst
+++ b/docs/sampler-configuration.rst
@@ -11,7 +11,7 @@ General configuration
 
 These are general settings which apply to the whole algorithm and are parsed to :mod:`~nessai.nestedsampler.NestedSampler`. However some of these settings, such as :code:`training_frequency` which defines how often the proposal method is retrained.
 
-.. autoclass:: nessai.nestedsampler.NestedSampler
+.. autoapiclass:: nessai.nestedsampler.NestedSampler
     :members: None
 
 
@@ -21,5 +21,5 @@ Proposal configuration
 The proposal configuration includes a variety of settings ranging from the hyper-parameters for the normalising flow to the size of pool used to store new samples. This also includes the reparameterisations which are essential to efficient sampling. All the available settings are listed below and there are dedicated pages that explain how to configure the :doc:`reparmeterisations<reparameterisations>` and :doc:`normalising
 flows<normalising-flows-configuration>`.
 
-.. autoclass:: nessai.proposal.flowproposal.FlowProposal
+.. autoapiclass:: nessai.proposal.flowproposal.FlowProposal
     :members: None


### PR DESCRIPTION
Switch to using `sphinx.autoapi` to simplify the process of generating the API docs.