### PR TITLE
Improve plotting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Plotting logX vs logL now returns the figure is `filename=None`
+- `NestedSampler.plot_state` now has the keyword argument `filename` and the figure is only saved if it is specified.
 
 ### Fixed
 
 - Fixed a bug when plotting the state plot from a saved instance of the sampler where the sampling time was changed based on the current time.
+- Fixed a bug when using `plot_trace`, `plot_1d_comparison` or `plot_live_points` with a single parameter
+- Total sampling time is now correctly displayed when producing a state plot from a saved sampler.
 
 
 ## [0.2.4] - 2021-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added code to catch errors when calling `plot_live_points` when `gwpy` is installed.
+
+### Changed
+
+- Plotting logX vs logL now returns the figure is `filename=None`
+
+### Fixed
+
+- Fixed a bug when plotting the state plot from a saved instance of the sampler where the sampling time was changed based on the current time.
+
+
 ## [0.2.4] - 2021-03-08
 
 This release includes a number of bug fixes, changes to make the `GWFlowProposal` consistent with `LegacyGWFlowProposal` and a number of new unit tests to improve test coverage.

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -64,7 +64,7 @@ class _NSintegralState:
         Increment the state of the evidence integrator
         Simply uses rectangle rule for initial estimate
         """
-        if(logL <= self.logLs[-1]):
+        if (logL <= self.logLs[-1]):
             logger.warning('NS integrator received non-monotonic logL.'
                            f'{self.logLs[-1]:.5f} -> {logL:.5f}')
         if nlive is None:
@@ -124,9 +124,9 @@ class _NSintegralState:
         if filename is not None:
             fig.savefig(filename, bbox_inches='tight')
             plt.close()
+            logger.info(f'Saved nested sampling plot as {filename}')
         else:
             return fig
-        logger.info(f'Saved nested sampling plot as {filename}')
 
 
 class NestedSampler:

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -360,8 +360,11 @@ class NestedSampler:
 
     @property
     def current_sampling_time(self):
-        return self.sampling_time \
-                + (datetime.datetime.now() - self.sampling_start_time)
+        if self.finalised:
+            return self.sampling_time
+        else:
+            return self.sampling_time \
+                    + (datetime.datetime.now() - self.sampling_start_time)
 
     @property
     def last_updated(self):

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -91,21 +91,32 @@ class _NSintegralState:
                                            np.array(self.log_vols))
         return self.logZ
 
-    def plot(self, filename):
+    def plot(self, filename=None):
         """
         Plot the logX vs logL
+
+        Parameters
+        ----------
+        filename : str, optional
+            Filename name for saving the figure. If not specified the figure
+            is returned.
         """
         fig = plt.figure()
         plt.plot(self.log_vols, self.logLs)
-        plt.title(f'logZ={self.logZ:.2f}'
+        plt.title(f'log Z={self.logZ:.2f} '
                   f'H={self.info[-1] * np.log2(np.e):.2f} bits')
         plt.grid(which='both')
-        plt.xlabel('log prior_volume')
-        plt.ylabel('log likelihood')
+        plt.xlabel('log prior-volume')
+        plt.ylabel('log-likelihood')
         plt.xlim([self.log_vols[-1], self.log_vols[0]])
         plt.yscale('symlog')
-        fig.savefig(filename)
-        logger.info('Saved nested sampling plot as {0}'.format(filename))
+
+        if filename is not None:
+            fig.savefig(filename, bbox_inches='tight')
+            plt.close()
+        else:
+            return fig
+        logger.info(f'Saved nested sampling plot as {filename}')
 
 
 class NestedSampler:

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -875,10 +875,16 @@ class NestedSampler:
         if train or force:
             self.train_proposal(force=force)
 
-    def plot_state(self):
+    def plot_state(self, filename=None):
         """
         Produce plots with the current state of the nested sampling run.
         Plots are saved to the output directory specifed at initialisation.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If specifie the figure will be saved, otherwise the figure is
+            returned.
         """
 
         fig, ax = plt.subplots(6, 1, sharex=True, figsize=(12, 12))
@@ -959,8 +965,11 @@ class NestedSampler:
 
         fig.tight_layout()
         fig.subplots_adjust(top=0.95)
-        fig.savefig(f'{self.output}/state.png')
-        plt.close(fig)
+        if filename is not None:
+            fig.savefig(filename)
+            plt.close(fig)
+        else:
+            return fig
 
     def plot_trace(self):
         """
@@ -1014,7 +1023,7 @@ class NestedSampler:
                                            f'{self.iteration}.png'))
 
             if self.plot:
-                self.plot_state()
+                self.plot_state(filename=f'{self.output}/state.png')
                 self.plot_trace()
 
             if self.uninformed_sampling:

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -275,6 +275,9 @@ def plot_trace(log_x, nested_samples, labels=None, filename=None):
         is returned instead.
     """
     nested_samples = np.asarray(nested_samples)
+    if not nested_samples.dtype.names:
+        raise TypeError('Nested samples must be a structured array')
+
     names = nested_samples.dtype.names[:-2]
 
     if labels is None:

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -51,10 +51,18 @@ def plot_live_points(live_points, filename=None, bounds=None, c=None,
         hue = df[c]
     else:
         hue = None
-    fig = sns.PairGrid(df, corner=True, diag_sharey=False)
-    fig.map_diag(plt.hist, **pairplot_kwargs['diag_kws'])
-    fig.map_offdiag(sns.scatterplot, hue=hue,
-                    **pairplot_kwargs['plot_kws'])
+
+    try:
+        fig = sns.PairGrid(df, corner=True, diag_sharey=False)
+        fig.map_diag(plt.hist, **pairplot_kwargs['diag_kws'])
+        fig.map_offdiag(sns.scatterplot, hue=hue,
+                        **pairplot_kwargs['plot_kws'])
+    except TypeError as e:
+        plt.close()
+        logger.warning('Could not produce a plot of the live points. '
+                       'Check the version of Seaborn, Matplotlib and GWpy. '
+                       f'The error was: \n {e}')
+        return None
 
     if bounds is not None:
         for i, v in enumerate(bounds.values()):
@@ -117,7 +125,11 @@ def plot_1d_comparison(*live_points, parameters=None, labels=None,
     fig, axs = plt.subplots(len(parameters), 1, sharey=False,
                             figsize=(3, 3 * len(parameters)))
 
-    axs = axs.ravel()
+    if len(parameters) > 1:
+        axs = axs.ravel()
+    else:
+        axs = [axs]
+
     for i, f in enumerate(parameters):
         xmin = np.min([np.min(lp[f][np.isfinite(lp[f])])
                        for lp in live_points])
@@ -275,7 +287,10 @@ def plot_trace(log_x, nested_samples, labels=None, filename=None):
 
     fig, axes = plt.subplots(len(labels), 1, figsize=(5, 3 * len(labels)),
                              sharex=True)
-    axes = axes.ravel()
+    if len(labels) > 1:
+        axes = axes.ravel()
+    else:
+        axes = [axes]
 
     for i, name in enumerate(names):
         axes[i].plot(log_x, nested_samples[name], ',')

--- a/nessai/utils.py
+++ b/nessai/utils.py
@@ -811,6 +811,8 @@ def auto_bins(x, max_bins=50):
         Number of bins
     """
     x = np.asarray(x)
+    if not x.size:
+        raise RuntimeError('Input array is empty!')
     fd_bw = _hist_bin_fd(x)
     sturges_bw = _hist_bin_sturges(x)
     if fd_bw:
@@ -824,7 +826,6 @@ def auto_bins(x, max_bins=50):
         n_bins = 1
 
     nbins = min(n_bins, max_bins)
-    assert isinstance(nbins, int)
     return nbins
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from nessai import plot
+from nessai.livepoint import numpy_array_to_live_points
 
 
 @pytest.fixture()
@@ -39,6 +40,13 @@ def test_plot_live_points_save(live_points, save, model, tmpdir):
     else:
         filename = None
     plot.plot_live_points(live_points, filename=filename)
+    plt.close()
+
+
+def test_plot_live_points_1d():
+    """Test generating the live points plot for one parameter"""
+    live_points = np.random.randn(100).view([('x', 'f8')])
+    plot.plot_live_points(live_points)
     plt.close()
 
 
@@ -101,6 +109,14 @@ def test_plot_1d_comparison_bounds(bounds, model):
     if bounds:
         bounds = model.bounds
     plot.plot_1d_comparison(l1, l2, bounds=bounds)
+    plt.close()
+
+
+def test_plot_1d_comparison_1d():
+    """Test generating a 1d comparison plot with only one parameter"""
+    l1 = np.random.randn(100).view([('x', 'f8')])
+    l2 = np.random.randn(100).view([('x', 'f8')])
+    plot.plot_1d_comparison(l1, l2)
     plt.close()
 
 
@@ -168,6 +184,28 @@ def test_trace_plot_save(nested_samples, save, tmpdir):
         filename = None
     plot.plot_trace(log_x, nested_samples, filename=filename)
     plt.close()
+
+
+def test_trace_plot_1d(nested_samples):
+    """Test trace plot with only one parameter"""
+    log_x = np.linspace(-10, 0, nested_samples.size)
+    nested_samples = numpy_array_to_live_points(
+        np.random.randn(log_x.size, 1), ['x'])
+    plot.plot_trace(log_x, nested_samples)
+    plt.close()
+
+
+def test_trace_plot_unstructured():
+    """
+    Test to check that trace_plot raises an error when the nested samples
+    are not a structured array.
+    """
+    log_x = np.linspace(-10, 0, 100)
+    nested_samples = np.random.randn(log_x.size, 2)
+    with pytest.raises(TypeError) as excinfo:
+        plot.plot_trace(log_x, nested_samples)
+    plt.close()
+    assert 'structured array' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('labels', [None, ['x', 'y']])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from unittest.mock import patch
 
 from nessai import plot
 from nessai.livepoint import numpy_array_to_live_points
@@ -48,6 +49,16 @@ def test_plot_live_points_1d():
     live_points = np.random.randn(100).view([('x', 'f8')])
     plot.plot_live_points(live_points)
     plt.close()
+
+
+def test_plot_live_points_error(live_points):
+    """
+    Test to make sure that an error is not raised if plotting fails
+    because of issues with seaborn and gwpy.
+    """
+    with patch('seaborn.scatterplot', side_effect=TypeError('Mock error')):
+        fig = plot.plot_live_points(live_points)
+    assert fig is None
 
 
 @pytest.mark.parametrize('parameters', [None, ['x', 'y']])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,3 +154,20 @@ def test_draw_truncated_gaussian_1d(r, var, fuzz):
                         loc=0, scale=sigma)
     _, p = stats.kstest(np.squeeze(s), d.cdf)
     assert p >= 0.05
+
+
+def test_auto_bins_max_bins():
+    """Test the autobin function returns the max bins"""
+    assert utils.auto_bins(np.random.rand(100), max_bins=2) <= 2
+
+
+def test_auto_bins_single_point():
+    """Test to ensure the function produces a result with one sample"""
+    assert utils.auto_bins(np.random.rand()) >= 1
+
+
+def test_auto_bins_no_samples():
+    """Test to ensure the function produces a result with one sample"""
+    with pytest.raises(RuntimeError) as excinfo:
+        assert utils.auto_bins([])
+    assert 'Input array is empty!' in str(excinfo.value)


### PR DESCRIPTION
The PR includes a few small changes to improve some of the plotting functions:

* `plot_trace` and `plot_1d_comparison` and `plot_live_points` now work when plotting a single parameter
* `plot_trace` now raises a more informative error when plotting fails because of an unstructured array
*  `auto_bins` now raises an error if the input array is empty
*  An exception block has been added to `plot_live_points` to catch errors caused by `gwpy`, see https://github.com/mj-will/nessai/issues/46
* The logX vs LogL plot produce by the nested sampling state is now consistent with other plotting functions.
*  `NestedSampler.plot_state` is also now consistent with other plotting functions.
* The total sampling time is now correctly displayed when producing a state plot from a saved instance of the sampler.
* Gradients for dlogL/dlogX are now only saved in `plot=True` when an instance of `NestedSampler` is created.

Tests have been added for all these changes /  new features excluding the changes to `_NSintegralState` which will be added in a separate PR.