### PR TITLE
NS integral tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added code to catch errors when calling `plot_live_points` when `gwpy` is installed.
+- Added tests for `_NSIntegralState`.
 
 ### Changed
 
 - Plotting logX vs logL now returns the figure is `filename=None`
 - `NestedSampler.plot_state` now has the keyword argument `filename` and the figure is only saved if it is specified.
+- Changed name from `_NSintegralState` to `_NSIntegralState`.
 
 ### Fixed
 

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -29,7 +29,7 @@ sns.set_style('ticks')
 logger = logging.getLogger(__name__)
 
 
-class _NSintegralState:
+class _NSIntegralState:
     """
     Stores the state of the nested sampling integrator
 
@@ -282,7 +282,7 @@ class NestedSampler:
         self.logLmax = -np.inf
         self.nested_samples = []
         self.logZ = None
-        self.state = _NSintegralState(self.nlive, track_gradients=plot)
+        self.state = _NSIntegralState(self.nlive, track_gradients=plot)
         self.plot = plot
         self.resume_file = self.setup_output(output, resume_file)
         self.output = output

--- a/tests/test_ns_state.py
+++ b/tests/test_ns_state.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Test the object that handles the nested sampling evidence and prior volumes.
+"""
+import numpy as np
+import pytest
+
+from nessai.nestedsampler import _NSIntegralState
+
+
+@pytest.fixture()
+def nlive():
+    return 100
+
+
+def test_increment(nlive):
+    """Test the basic functionality of incrementing the evidence estimate"""
+    state = _NSIntegralState(nlive)
+    state.increment(-10)
+
+    assert state.logw == (-1 / nlive)
+    assert state.logZ != -np.inf
+    np.testing.assert_equal(state.logLs, [-np.inf, -10])
+
+
+def test_finalise(nlive):
+    """Test the check that finalise returns an improved logZ"""
+    state = _NSIntegralState(nlive)
+    state.increment(-10)
+    pre = state.logZ
+    state.finalise()
+    assert state.logZ != -np.inf
+    assert pre != state.logZ
+
+
+def test_info(nlive):
+    """Test to check the information increases as expected"""
+    state = _NSIntegralState(nlive)
+    state.increment(-10)
+    assert state.info == [0.]
+    state.increment(-5)
+    assert state.info[1] > 0
+
+
+def test_track_gradients(nlive):
+    """
+    Test to make sure gradients are not computed when tracking is disabled
+    """
+    state = _NSIntegralState(nlive, track_gradients=False)
+    state.increment(-10)
+    state.increment(-5)
+    assert len(state.gradients) == 1
+
+
+def test_variable_nlive(nlive):
+    """
+    Test to make sure that the using a different nlive changes the update
+    values.
+    """
+    state = _NSIntegralState(nlive)
+    state.increment(-10, nlive=50)
+    assert state.logw == (-1 / 50)
+
+
+def test_plot(nlive):
+    """Test the plotting function"""
+    state = _NSIntegralState(nlive)
+    state.increment(-10)
+    state.increment(-5)
+    fig = state.plot()
+    assert fig is not None
+
+
+def test_plot_w_filename(nlive, tmpdir):
+    """Test the plotting function with a filename specified"""
+    filename = str(tmpdir.mkdir('test'))
+    state = _NSIntegralState(nlive)
+    state.increment(-10)
+    state.increment(-5)
+    fig = state.plot(filename=filename)
+    assert fig is None


### PR DESCRIPTION
Correct use of camel case `_NSintegralState` to `_NSIntergralState` and add tests.

Note: this will break resuming runs that used previous versions of the code.