### PR TITLE
Fix sampling unbounded priors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added code to catch errors when calling `plot_live_points` when `gwpy` is installed.
+- Added an example of using unbounded priors, `bilby_unbounded_priors.py`
 
 ### Changed
 
 - Plotting logX vs logL now returns the figure is `filename=None`
 - `NestedSampler.plot_state` now has the keyword argument `filename` and the figure is only saved if it is specified.
+- `nessai.model.Model` now inherits from `abc.ABC` and `log_prior` and `log_likelihood` are now `abstractmethods`. This prevents the class from being used without redefining those methods.
 
 ### Fixed
 
 - Fixed a bug when plotting the state plot from a saved instance of the sampler where the sampling time was changed based on the current time.
 - Fixed a bug when using `plot_trace`, `plot_1d_comparison` or `plot_live_points` with a single parameter
 - Total sampling time is now correctly displayed when producing a state plot from a saved sampler.
+- Fixed a bug when using unbounded priors related to `Model.verify_model`
 
 
 ## [0.2.4] - 2021-03-08

--- a/examples/bilby_unbounded_priors.py
+++ b/examples/bilby_unbounded_priors.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# Example of using Nessai with Bilby (Requires seperate installation)
+# with unbounded priors. We use bilby since the priors include a sample
+# method which is used to redefine `Model.new_point`. Without this we
+# would have to redefine the method ourselves.
+
+import bilby
+import numpy as np
+
+# The output from the sampler will be saved to:
+# '$(outdir)/$(label)_nessai/'
+# alongside the usual bilby outputs
+outdir = './outdir/'
+label = 'bilby_unbounded_priors'
+
+# Setup the bilby logger
+bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level='INFO')
+
+# Define a likelihood using Bilby
+
+
+class SimpleGaussianLikelihood(bilby.Likelihood):
+
+    def __init__(self):
+        """
+        A very simple Gaussian likelihood
+        """
+        super().__init__(parameters={'x': None, 'y': None})
+
+    def log_likelihood(self):
+        x = self.parameters['x']
+        y = self.parameters['y']
+        return -0.5*(x ** 2. + y ** 2.) - np.log(2.0 * np.pi)
+
+
+# Define priors, we'll use Gaussians since they're unbounded.
+priors = dict(x=bilby.core.prior.Gaussian(0, 5, 'x'),
+              y=bilby.core.prior.Gaussian(0, 5, 'y'))
+
+# Instantiate the likleihood
+likelihood = SimpleGaussianLikelihood()
+
+# Configure the normalisng flow
+flow_config = dict(
+        max_epochs=50,
+        patience=10,
+        model_config=dict(n_blocks=2, n_neurons=4, n_layers=2,
+                          device_tag='cpu',
+                          kwargs=dict(batch_norm_between_layers=True))
+        )
+
+# Run using bilby.run_sampler, any kwargs are parsed to the sampler
+# NOTE: when using Bilby if the priors can be sampled analytically  the flag
+# `analytic_priors` enables faster initial sampling. See 'further details' in
+# the documentation for more details
+# We need to disable the rescaling since we can't rescle without bounds.
+# Alternatively a different reparmeterisation could be used.
+result = bilby.run_sampler(outdir=outdir, label=label, resume=False, plot=True,
+                           likelihood=likelihood, priors=priors,
+                           sampler='nessai', nlive=1000,
+                           maximum_uninformed=2000, flow_config=flow_config,
+                           rescale_parameters=False,
+                           injection_parameters={'x': 0.0, 'y': 0.0},
+                           analytic_priors=False, seed=1234)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,12 +1,23 @@
 import numpy as np
 import pytest
+from scipy.stats import norm
 
+from nessai.livepoint import numpy_array_to_live_points
 from nessai.model import Model
+
+
+class EmptyModel(Model):
+
+    def log_prior(self, x):
+        return None
+
+    def log_likelihood(self, x):
+        return None
 
 
 @pytest.fixture(scope='function')
 def empty_model():
-    return Model()
+    return EmptyModel()
 
 
 def test_dims_no_names(empty_model):
@@ -73,12 +84,47 @@ def test_likelihood_evaluations(model):
     assert model.likelihood_evaluations == 1
 
 
+def test_missing_log_prior():
+    """
+    Test to ensure a model cannot be instantiated without a log-prior method.
+    """
+    class TestModel(Model):
+
+        def __init__(self):
+            self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
+            self.names = ['x', 'y']
+
+        def log_likelihood(self, x):
+            return x
+
+    with pytest.raises(TypeError):
+        TestModel()
+
+
+def test_missing_log_likelihood():
+    """
+    Test to ensure a model cannot be instantiated without a log-likelihood
+    method.
+    """
+    class TestModel(Model):
+
+        def __init__(self):
+            self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
+            self.names = ['x', 'y']
+
+        def log_prior(self, x):
+            return 0.
+
+    with pytest.raises(TypeError):
+        TestModel()
+
+
 def test_verify_new_point():
     """
     Test `Model.verify_model` and ensure a model with an ill-defined
     prior function raises the correct error
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
@@ -95,30 +141,13 @@ def test_verify_new_point():
     assert 'valid point' in str(excinfo.value)
 
 
-def test_verify_log_prior():
-    """
-    Test `Model.verify_model` and ensure a model without a log-prior
-    function raises the correct error
-    """
-    class TestModel(Model):
-
-        def __init__(self):
-            self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
-            self.names = ['x', 'y']
-
-    model = TestModel()
-
-    with pytest.raises(RuntimeError):
-        model.verify_model()
-
-
 @pytest.mark.parametrize("log_p", [np.inf, -np.inf])
 def test_verify_log_prior_finite(log_p):
     """
     Test `Model.verify_model` and ensure a model with a log-prior that
     only returns inf function raises the correct error
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
@@ -133,24 +162,51 @@ def test_verify_log_prior_finite(log_p):
         model.verify_model()
 
 
-def test_verify_log_likelihood():
+def test_verify_log_prior_none():
     """
-    Test `Model.verify_model` and ensure a model without a log-likelihood
-    function raises the correct error
+    Test `Model.verify_model` and ensure a model with a log-prior that
+    only returns None raises an error.
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
             self.names = ['x', 'y']
 
         def log_prior(self, x):
-            return 0.
+            return None
 
     model = TestModel()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
+
+    assert 'Log-prior' in str(excinfo.value)
+
+
+def test_verify_log_likelihood_none():
+    """
+    Test `Model.verify_model` and ensure a model with a log-likelihood that
+    only returns None raises an error.
+    """
+    class TestModel(EmptyModel):
+
+        def __init__(self):
+            self.bounds = {'x': [-5, 5], 'y': [-5, 5]}
+            self.names = ['x', 'y']
+
+        def log_prior(self, x):
+            return 0
+
+        def log_likelihood(self, x):
+            return None
+
+    model = TestModel()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        model.verify_model()
+
+    assert 'Log-likelihood' in str(excinfo.value)
 
 
 def test_verify_no_names():
@@ -158,7 +214,7 @@ def test_verify_no_names():
     Test `Model.verify_model` and ensure a model without names
     function raises the correct error
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.names = []
@@ -175,7 +231,7 @@ def test_verify_no_bounds():
     Test `Model.verify_model` and ensure a model without bounds
     function raises the correct error
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.names = ['x', 'y']
@@ -194,7 +250,7 @@ def test_verify_incomplete_bounds():
     Test `Model.verify_model` and ensure a model without bounds
     function raises the correct error
     """
-    class TestModel(Model):
+    class TestModel(EmptyModel):
 
         def __init__(self):
             self.names = ['x', 'y']
@@ -204,3 +260,50 @@ def test_verify_incomplete_bounds():
 
     with pytest.raises(RuntimeError):
         model.verify_model()
+
+
+def test_unbounded_priors_wo_new_point():
+    """Test `Model.verify_model` with unbounded priors"""
+
+    class TestModel(Model):
+
+        def __init__(self):
+            self.names = ['x', 'y']
+            self.bounds = {'x': [-5, 5], 'y': [-np.inf, np.inf]}
+
+        def log_prior(self, x):
+            return -np.log(10) * np.ones(x.size) + norm.logpdf(x['y'])
+
+        def log_likelihood(self, x):
+            return np.ones(x.size)
+
+    model = TestModel()
+    with pytest.raises(RuntimeError) as excinfo:
+        model.verify_model()
+
+    assert 'Could not draw a new point' in str(excinfo.value)
+
+
+def test_unbounded_priors_w_new_point():
+    """Test `Model.verify_model` with unbounded priors"""
+
+    class TestModel(Model):
+
+        def __init__(self):
+            self.names = ['x', 'y']
+            self.bounds = {'x': [-5, 5], 'y': [-np.inf, np.inf]}
+
+        def new_point(self, N=1):
+            return numpy_array_to_live_points(
+                    np.concatenate([np.random.uniform(-5, 5, (N, 1)),
+                                    norm.rvs(size=(N, 1))], axis=1),
+                    self.names)
+
+        def log_prior(self, x):
+            return -np.log(10) * np.ones(x.size) + norm.logpdf(x['y'])
+
+        def log_likelihood(self, x):
+            return np.ones(x.size)
+
+    model = TestModel()
+    model.verify_model()


### PR DESCRIPTION
This PR fixes `verify_model` to allow for sampling models with unbounded priors. This requires the user to redefine `Model.new_point`.

Also adds an example of sampling a model with Gaussian priors.