### PR TITLE
Allow codecov report to be uploaded for all versions of python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,6 @@ jobs:
         pytest --cov-report=xml --cov=nessai tests/
     - name: Upload coverage
       uses: codecov/codecov-action@v1
-      if: matrix.python-version == '3.8'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests


### PR DESCRIPTION
Codecov seems to support merging reports and there are a couple of places where the code is only tested in Python 3.6