### PR TITLE
Add scale only reparam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added code to catch errors when calling `plot_live_points` when `gwpy` is installed.
 - Add code coverage upload
 - Added an example of using unbounded priors, `bilby_unbounded_priors.py`
+- Added `Rescale` reparameterisation that just rescales by a constant and does not require prior bounds. Also add tests for this reparameterisation.
 
 ### Changed
 

--- a/examples/bilby_unbounded_priors.py
+++ b/examples/bilby_unbounded_priors.py
@@ -36,7 +36,7 @@ class SimpleGaussianLikelihood(bilby.Likelihood):
 
 # Define priors, we'll use Gaussians since they're unbounded.
 priors = dict(x=bilby.core.prior.Gaussian(0, 5, 'x'),
-              y=bilby.core.prior.Gaussian(0, 5, 'y'))
+              y=bilby.core.prior.Gaussian(0, 10, 'y'))
 
 # Instantiate the likleihood
 likelihood = SimpleGaussianLikelihood()
@@ -55,11 +55,16 @@ flow_config = dict(
 # `analytic_priors` enables faster initial sampling. See 'further details' in
 # the documentation for more details
 # We need to disable the rescaling since we can't rescle without bounds.
-# Alternatively a different reparmeterisation could be used.
+# Alternatively a different reparmeterisation could be used, in this case
+# we can used the 'Rescale' reparameterisation that rescales the inputs by
+# a constant, this is useful when we do not prior bounds we can use.
 result = bilby.run_sampler(outdir=outdir, label=label, resume=False, plot=True,
                            likelihood=likelihood, priors=priors,
                            sampler='nessai', nlive=1000,
                            maximum_uninformed=2000, flow_config=flow_config,
-                           rescale_parameters=False,
                            injection_parameters={'x': 0.0, 'y': 0.0},
+                           reparameterisations={
+                               'scale': {'parameters': ['x', 'y'],
+                                         'scale': [5, 10]}},
+                           proposal_plots='min',
                            analytic_priors=False, seed=1234)

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -341,6 +341,73 @@ class NullReparameterisation(Reparameterisation):
         return x, x_prime, log_j
 
 
+class Rescale(Reparameterisation):
+    """Reparameterisation that rescales the parameters by a constant factor
+    that does not depend on the prior bounds.
+
+    Parameters
+    ----------
+    scale : float
+        Scaling constant.
+    """
+    def __init__(self, parameters=None, scale=None, prior_bounds=None):
+        if scale is None:
+            raise RuntimeError('Must specify a scale!')
+        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+
+        if isinstance(scale, (int, float)):
+            self.scale = {p: float(scale) for p in self.parameters}
+        elif isinstance(scale, list):
+            if not len(scale) == len(self.parameters):
+                raise RuntimeError(
+                    'Scale list is a different length to the parameters.')
+            self.scale = {p: float(s) for p, s in zip(self.parameters, scale)}
+        elif isinstance(scale, dict):
+            if not set(self.parameters) == set(scale.keys()):
+                raise RuntimeError('Mismatched parameters with scale dict')
+            scale = {p: float(s) for p, s in scale.items()}
+            self.scale = scale
+        else:
+            raise TypeError(
+                'Scale input must be an instance of int, list or dict')
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        """
+        Apply the reparameterisation to convert from x-space
+        to x'-space
+
+        Parameters
+        ----------
+        x : structured array
+            Array
+        x_prime : structured array
+            Array to be update
+        log_j : Log jacobian to be updated
+        """
+        for p, pp in zip(self.parameters, self.prime_parameters):
+            x_prime[pp] = x[p] / self.scale[p]
+            log_j -= np.log(self.scale[p])
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        """
+        Apply the reparameterisation to convert from x-space
+        to x'-space
+
+        Parameters
+        ----------
+        x : structured array
+            Array
+        x_prime : structured array
+            Array to be update
+        log_j : Log jacobian to be updated
+        """
+        for p, pp in zip(self.parameters, self.prime_parameters):
+            x[p] = x_prime[pp] * self.scale[p]
+            log_j += np.log(self.scale[p])
+        return x, x_prime, log_j
+
+
 class RescaleToBounds(Reparameterisation):
     """Reparmeterisation that maps to the specified interval.
 
@@ -1102,6 +1169,8 @@ default_reparameterisations = {
     'inversion-duplicate': (RescaleToBounds, {'detect_edges': True,
                                               'boundary_inversion': True,
                                               'inversion_type': 'duplicate'}),
+    'scale': (Rescale, None),
+    'rescale': (Rescale, None),
     'angle': (Angle, {}),
     'angle-pi': (Angle, {'scale': 2.0, 'prior': 'uniform'}),
     'angle-2pi': (Angle, {'scale': 1.0, 'prior': 'uniform'}),

--- a/tests/test_reparameterisations/test_rescale.py
+++ b/tests/test_reparameterisations/test_rescale.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+Test the Rescale class.
+"""
+import numpy as np
+import pytest
+from unittest.mock import create_autospec
+
+from nessai.livepoint import numpy_array_to_live_points
+from nessai.reparameterisations import Rescale
+
+
+@pytest.fixture()
+def reparam():
+    return create_autospec(Rescale)
+
+
+@pytest.mark.parametrize('scale', [2, 2.0, [1, 2], {'x': 1, 'y': 2}])
+def test_init(scale):
+    """Test the init method with different input types"""
+    parameters = ['x', 'y']
+    prior_bounds = {'x': [-1, 1], 'y': [-1, 1]}
+
+    reparam = \
+        Rescale(parameters=parameters, scale=scale, prior_bounds=prior_bounds)
+
+    assert not set(reparam.scale.keys()) - set(parameters)
+    assert isinstance(reparam.scale['x'], float)
+
+
+@pytest.mark.parametrize('n', [1, 2])
+def test_reparameterise(reparam, n):
+    """Test the reparameterise method"""
+    reparam.parameters = ['x', 'y']
+    reparam.prime_parameters = ['x_prime', 'y_prime']
+    reparam.scale = {'x': 2.0, 'y': 4.0}
+    x = numpy_array_to_live_points(np.ones((n, 2)), reparam.parameters)
+    x_prime = numpy_array_to_live_points(
+        np.zeros((n, 2)), reparam.prime_parameters)
+    log_j = np.zeros(n)
+
+    x_out, x_prime_out, log_j_out = \
+        Rescale.reparameterise(reparam, x, x_prime, log_j)
+
+    assert np.array_equal(x, x_out)
+    assert np.array_equal(log_j_out, -np.log(8 * np.ones(n)))
+    assert (x_prime_out['x_prime'] == 0.5).all()
+    assert (x_prime_out['y_prime'] == 0.25).all()
+
+
+@pytest.mark.parametrize('n', [1, 2])
+def test_inverse_reparameterise(reparam, n):
+    """Test the reparameterise method"""
+    reparam.parameters = ['x', 'y']
+    reparam.prime_parameters = ['x_prime', 'y_prime']
+    reparam.scale = {'x': 2.0, 'y': 4.0}
+    x = numpy_array_to_live_points(np.zeros((n, 2)), reparam.parameters)
+    x_prime = numpy_array_to_live_points(
+        np.ones((n, 2)), reparam.prime_parameters)
+    log_j = np.zeros(n)
+
+    x_out, x_prime_out, log_j_out = \
+        Rescale.inverse_reparameterise(reparam, x, x_prime, log_j)
+
+    assert np.array_equal(x_prime, x_prime_out)
+    assert np.array_equal(log_j_out, np.log(8 * np.ones(n)))
+    assert (x_out['x'] == 2.0).all()
+    assert (x_out['y'] == 4.0).all()
+
+
+def test_init_no_scale():
+    """Make sure an error is raised if the scale is not given"""
+    with pytest.raises(RuntimeError) as excinfo:
+        Rescale(scale=None)
+    assert 'Must specify a scale!' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('scale', [[1], [1, 2, 3]])
+def test_init_incorrect_scale_list(scale):
+    """Make sure an error is raised if the scale is the incorrect length"""
+    parameters = ['x', 'y']
+    prior_bounds = {'x': [-1, 1], 'y': [-1, 1]}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        Rescale(parameters=parameters, scale=scale, prior_bounds=prior_bounds)
+
+    assert 'different length' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('scale', [{'x': 1}, {'x': 1, 'y': 1, 'z': 1}])
+def test_init_incorrect_scale_dict(scale):
+    """Make sure an error is raised if the scale keys to not match the \
+            parameters.
+    """
+    parameters = ['x', 'y']
+    prior_bounds = {'x': [-1, 1], 'y': [-1, 1]}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        Rescale(parameters=parameters, scale=scale, prior_bounds=prior_bounds)
+
+    assert 'Mismatched parameters' in str(excinfo.value)
+
+
+def test_init_incorrect_scale_type():
+    """Make sure an error is raised if the scale is the incorrect type"""
+    parameters = ['x', 'y']
+    prior_bounds = {'x': [-1, 1], 'y': [-1, 1]}
+
+    with pytest.raises(TypeError) as excinfo:
+        Rescale(parameters=parameters, scale='1', prior_bounds=prior_bounds)
+
+    assert 'Scale input must be' in str(excinfo.value)


### PR DESCRIPTION
Adds a reparameterisation called `Rescale` which rescales by a specified constant that is independent of the priors bounds. This is useful when using priors that are unbounded.

Also adds tests and updates the `bilby_unbounded_priors.py` example to use this reparameterisation.