### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,6 @@ name: Integration tests
 on:
   workflow_run:
     workflows: ["Unit tests"]
-    branches: [main]
     types:
       - completed
       - requested

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,31 @@
+name: Integration tests
+
+on:
+  workflow_run:
+    workflows: ["Unit tests"]
+    branches: [main]
+    types:
+      - completed
+      - requested
+
+
+jobs:
+  integration-tests:
+    name: Build and run integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r dev_requirements.txt
+        pip install -e .
+    - name: Run integration tests with pytest
+      run: |
+        pytest tests/ -m "integration_test or slow_integration_test"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Unit tests"]
     types:
       - completed
-      - requested
 
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: Tests
+name: Unit tests
 
 on:
   push:
@@ -10,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  unittests:
 
     runs-on: ubuntu-latest
     strategy:
@@ -38,7 +35,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov-report=xml --cov=nessai tests/
+        pytest --cov-report=xml --cov=nessai tests/ --without-integration
     - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,7 @@ pytest
 pytest-timeout
 pytest-rerunfailures
 pytest-cov
+pytest-integration
 pre-commit
 lalsuite
 bilby

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,12 +33,14 @@ tests_require =
     pytest
     pytest-timeout
     pytest-rerunfailures
+    pytest-integration
 
 [options.extras_require]
 dev =
     pytest
     pytest-timeout
     pytest-rerunfailures
+    pytest-integration
     pre-commit
 docs =
     sphinx

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+"""
+Integration tests for running the sampler with different configurations.
+"""
 import os
 
 from nessai.flowsampler import FlowSampler
@@ -7,6 +11,7 @@ import pytest
 torch.set_num_threads(1)
 
 
+@pytest.mark.slow_integration_test
 def test_sampling_with_rescale(model, flow_config, tmpdir):
     """
     Test sampling with rescaling. Checks that flow is trained.
@@ -21,6 +26,7 @@ def test_sampling_with_rescale(model, flow_config, tmpdir):
     assert fp.ns.proposal.training_count == 1
 
 
+@pytest.mark.slow_integration_test
 def test_sampling_without_rescale(model, flow_config, tmpdir):
     """
     Test sampling without rescaling. Checks that flow is trained.
@@ -35,6 +41,7 @@ def test_sampling_without_rescale(model, flow_config, tmpdir):
     assert fp.ns.proposal.training_count == 1
 
 
+@pytest.mark.slow_integration_test
 def test_sampling_with_maf(model, flow_config, tmpdir):
     """
     Test sampling with MAF. Checks that flow is trained but does not
@@ -51,6 +58,7 @@ def test_sampling_with_maf(model, flow_config, tmpdir):
     assert fp.ns.proposal.training_count == 1
 
 
+@pytest.mark.slow_integration_test
 @pytest.mark.parametrize('analytic', [False, True])
 def test_sampling_uninformed(model, flow_config, tmpdir, analytic):
     """
@@ -65,6 +73,7 @@ def test_sampling_uninformed(model, flow_config, tmpdir, analytic):
     fp.run()
 
 
+@pytest.mark.slow_integration_test
 def test_sampling_with_n_pool(model, flow_config, tmpdir):
     """
     Test running the sampler with multiprocessing.
@@ -81,6 +90,7 @@ def test_sampling_with_n_pool(model, flow_config, tmpdir):
     assert os.path.exists(output + '/result.json')
 
 
+@pytest.mark.slow_integration_test
 def test_sampling_resume(model, flow_config, tmpdir):
     """
     Test resuming the sampler.


### PR DESCRIPTION
The PR moves to using `pytest-integration` for separating tests into unit tests and integration tests.

Integration tests are only run if the unit tests pass.

This will decrease code coverage since integration tests are not included in the coverage report.