### PR TITLE
Add a random seed for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ tests for this reparameterisation.
 - Changed name from `_NSintegralState` to `_NSIntegralState`.
 - `nessai.model.Model` now inherits from `abc.ABC` and `log_prior` and `log_likelihood` are now `abstractmethods`. This prevents the class from being used without redefining those methods.
 - Updated `AumgentedFlowProposal` to work with current version of `FlowProposal`
+- Fix random seed unit tests.
 
 ### Fixed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 
+from numpy.random import seed
 import pytest
 from scipy.stats import norm
 import torch
 
 from nessai.model import Model
+
+
+seed(170817)
 
 _requires_dependency_cache = dict()
 


### PR DESCRIPTION
Some of the unit tests use random draws which cause them to occasionally fail. Whilst seeding the tests isn't necessarily the best solution, it's a quick way to deal with this. 

It might be worth looking at removing more of the calls random generators where possible in the future.