### PR TITLE
Change fixture scope to function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ torch.manual_seed(170817)
 _requires_dependency_cache = dict()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def model():
     class TestModel(Model):
 
@@ -38,7 +38,7 @@ def model():
     return TestModel()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def flow_config():
     d = dict(
             max_epochs=5,


### PR DESCRIPTION
Some fixtures used `scope='session'` this was causing unexpected behaviour for variables that were changed in tests.