### PR TITLE
Avoid warning message for empty mean

### DIFF
--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -752,7 +752,10 @@ class NestedSampler:
         """
         Mean acceptance of the last nlive // 10 points
         """
-        return np.mean(self.acceptance_history)
+        if self.acceptance_history:
+            return np.mean(self.acceptance_history)
+        else:
+            return np.nan
 
     def check_proposal_switch(self):
         """


### PR DESCRIPTION
Tweaks `mean_acceptance` so that a warning isn't raised when the history is empty. The behaviour is identical to before since `np.mean([])` returns `np.nan`.