### PR TITLE
Fix hue bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ tests for this reparameterisation.
 - Fixed a bug when using unbounded priors related to `Model.verify_model`
 - Fix inversion-split with `RescaleToBounds`
 - Fixed `AugmentedGWFlowProposal`.
+- Fixed a bug with `plot_live_points` when the hue parameter (`c`) was constant.
 
 
 ## [0.2.4] - 2021-03-08

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -49,6 +49,10 @@ def plot_live_points(live_points, filename=None, bounds=None, c=None,
 
     if c is not None:
         hue = df[c]
+        if np.all(hue == hue[0]):
+            logger.warning(
+                f'Selected hue variable: {c} is constant! Disabling.')
+            hue = None
     else:
         hue = None
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -28,20 +28,24 @@ def test_plot_live_points_bounds(live_points, bounds, model):
     """Test generating a plot for a set of live points."""
     if bounds:
         bounds = model.bounds
-    plot.plot_live_points(live_points, bounds=bounds)
+    fig = plot.plot_live_points(live_points, bounds=bounds)
+    assert fig is not None
+    plt.close()
 
 
 @pytest.mark.parametrize('c', [None, 'x'])
 def test_plot_live_points_hue(live_points, c, model):
     """Test generating a plot for a set of live points with a hue."""
-    plot.plot_live_points(live_points, c=c)
+    fig = plot.plot_live_points(live_points, c=c)
+    assert fig is not None
     plt.close()
 
 
 def test_plot_live_points_constant_hue(live_points):
     """Test to make sure that constant hue is handled correctly"""
     live_points['logL'] = np.ones(live_points.size)
-    plot.plot_live_points(live_points, c='logL')
+    fig = plot.plot_live_points(live_points, c='logL')
+    assert fig is not None
     plt.close()
 
 
@@ -59,7 +63,8 @@ def test_plot_live_points_save(live_points, save, model, tmpdir):
 def test_plot_live_points_1d():
     """Test generating the live points plot for one parameter"""
     live_points = np.random.randn(100).view([('x', 'f8')])
-    plot.plot_live_points(live_points)
+    fig = plot.plot_live_points(live_points)
+    assert fig is not None
     plt.close()
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -15,7 +15,7 @@ from nessai.livepoint import numpy_array_to_live_points
 @pytest.fixture()
 def live_points(model):
     """Set of live points"""
-    return model.new_point(N=100)
+    return model.new_point(N=10)
 
 
 @pytest.fixture()
@@ -35,6 +35,13 @@ def test_plot_live_points_bounds(live_points, bounds, model):
 def test_plot_live_points_hue(live_points, c, model):
     """Test generating a plot for a set of live points with a hue."""
     plot.plot_live_points(live_points, c=c)
+    plt.close()
+
+
+def test_plot_live_points_constant_hue(live_points):
+    """Test to make sure that constant hue is handled correctly"""
+    live_points['logL'] = np.ones(live_points.size)
+    plot.plot_live_points(live_points, c='logL')
     plt.close()
 
 


### PR DESCRIPTION
Fixed a bug with `plot_live_points` when the hue parameter (`c`) was constant. it is set to `None` if this happens.

Also reduced the number of points being plotted to speed things up and since `plot_live_points` can return `None` add checks to make sure a figure is returned.