### PR TITLE
Move integral state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ tests for this reparameterisation.
 - `nessai.model.Model` now inherits from `abc.ABC` and `log_prior` and `log_likelihood` are now `abstractmethods`. This prevents the class from being used without redefining those methods.
 - Updated `AumgentedFlowProposal` to work with current version of `FlowProposal`
 - Fix random seed unit tests.
-- Move `_NSIntergralState` and some functions from `posterior.py` to a `evidence.py`
+- Move `_NSIntegralState` and some functions from `posterior.py` to `evidence.py`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ tests for this reparameterisation.
 - `nessai.model.Model` now inherits from `abc.ABC` and `log_prior` and `log_likelihood` are now `abstractmethods`. This prevents the class from being used without redefining those methods.
 - Updated `AumgentedFlowProposal` to work with current version of `FlowProposal`
 - Fix random seed unit tests.
+- Move `_NSIntergralState` and some functions from `posterior.py` to a `evidence.py`
 
 ### Fixed
 

--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""
+Functions realted to computing the evidence.
+"""
+import logging
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+logger = logging.getLogger(__name__)
+
+
+def logsubexp(x, y):
+    """
+    Helper function to compute the exponential
+    of a difference between two numbers
+
+    Computes: ``x + np.log1p(-np.exp(y-x))``
+
+    Parameters
+    ----------
+    x, y : float or array_like
+        Inputs
+    """
+    if np.any(x < y):
+        raise RuntimeError('cannot take log of negative number '
+                           f'{str(x)!s} - {str(y)!s}')
+
+    return x + np.log1p(-np.exp(y - x))
+
+
+def log_integrate_log_trap(log_func, log_support):
+    """
+    Trapezoidal integration of given log(func). Returns log of the integral.
+
+    Parameters
+    ----------
+    log_func : array_like
+        Log values of the function to integrate over.
+    log_support : array_like
+        Log prior-volumes for each value.
+
+    Returns
+    -------
+    float
+        Log of the result of the integral.
+    """
+    log_func_sum = np.logaddexp(log_func[:-1], log_func[1:]) - np.log(2)
+    log_dxs = logsubexp(log_support[:-1], log_support[1:])
+
+    return np.logaddexp.reduce(log_func_sum + log_dxs)
+
+
+class _NSIntegralState:
+    """
+    Stores the state of the nested sampling integrator
+
+    Parameters
+    ----------
+    nlive : int
+        Number of live points
+    track_gradients : bool, optional
+        If true the gradient of the change in logL w.r.t logX is saved each
+        time `increment` is called.
+    """
+    def __init__(self, nlive, track_gradients=True):
+        self.nlive = nlive
+        self.reset()
+        self.track_gradients = track_gradients
+
+    def reset(self):
+        """
+        Reset the sampler to its initial state at logZ = -infinity
+        """
+        self.logZ = -np.inf
+        self.oldZ = -np.inf
+        self.logw = 0
+        self.info = [0.]
+        # Start with a dummy sample enclosing the whole prior
+        self.logLs = [-np.inf]   # Likelihoods sampled
+        self.log_vols = [0.0]    # Volumes enclosed by contours
+        self.gradients = [0]
+
+    def increment(self, logL, nlive=None):
+        """
+        Increment the state of the evidence integrator
+        Simply uses rectangle rule for initial estimate
+        """
+        if (logL <= self.logLs[-1]):
+            logger.warning('NS integrator received non-monotonic logL.'
+                           f'{self.logLs[-1]:.5f} -> {logL:.5f}')
+        if nlive is None:
+            nlive = self.nlive
+        oldZ = self.logZ
+        logt = - 1.0 / nlive
+        Wt = self.logw + logL + np.log1p(-np.exp(logt))
+        self.logZ = np.logaddexp(self.logZ, Wt)
+        # Update information estimate
+        if np.isfinite(oldZ) and np.isfinite(self.logZ) and np.isfinite(logL):
+            info = np.exp(Wt - self.logZ) * logL \
+                  + np.exp(oldZ - self.logZ) \
+                  * (self.info[-1] + oldZ) \
+                  - self.logZ
+            if np.isnan(info):
+                info = 0
+            self.info.append(info)
+
+        # Update history
+        self.logw += logt
+        self.logLs.append(logL)
+        self.log_vols.append(self.logw)
+        if self.track_gradients:
+            self.gradients.append((self.logLs[-1] - self.logLs[-2])
+                                  / (self.log_vols[-1] - self.log_vols[-2]))
+
+    def finalise(self):
+        """
+        Compute the final evidence with more accurate integrator
+        Call at end of sampling run to refine estimate
+        """
+        # Trapezoidal rule
+        self.logZ = log_integrate_log_trap(np.array(self.logLs),
+                                           np.array(self.log_vols))
+        return self.logZ
+
+    def plot(self, filename=None):
+        """
+        Plot the logX vs logL
+
+        Parameters
+        ----------
+        filename : str, optional
+            Filename name for saving the figure. If not specified the figure
+            is returned.
+        """
+        fig = plt.figure()
+        plt.plot(self.log_vols, self.logLs)
+        plt.title(f'log Z={self.logZ:.2f} '
+                  f'H={self.info[-1] * np.log2(np.e):.2f} bits')
+        plt.grid(which='both')
+        plt.xlabel('log prior-volume')
+        plt.ylabel('log-likelihood')
+        plt.xlim([self.log_vols[-1], self.log_vols[0]])
+        plt.yscale('symlog')
+
+        if filename is not None:
+            fig.savefig(filename, bbox_inches='tight')
+            plt.close()
+            logger.info(f'Saved nested sampling plot as {filename}')
+        else:
+            return fig

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 from .livepoint import get_dtype, DEFAULT_FLOAT_DTYPE
 from .plot import plot_indices, plot_trace
-from .posterior import log_integrate_log_trap
+from .evidence import _NSIntegralState
 from .proposal import FlowProposal
 from .utils import (
     safe_file_dump,
@@ -27,106 +27,6 @@ sns.set()
 sns.set_style('ticks')
 
 logger = logging.getLogger(__name__)
-
-
-class _NSIntegralState:
-    """
-    Stores the state of the nested sampling integrator
-
-    Parameters
-    ----------
-    nlive : int
-        Number of live points
-    track_gradients : bool, optional
-        If true the gradient of the change in logL w.r.t logX is saved each
-        time `increment` is called.
-    """
-    def __init__(self, nlive, track_gradients=True):
-        self.nlive = nlive
-        self.reset()
-        self.track_gradients = track_gradients
-
-    def reset(self):
-        """
-        Reset the sampler to its initial state at logZ = -infinity
-        """
-        self.logZ = -np.inf
-        self.oldZ = -np.inf
-        self.logw = 0
-        self.info = [0.]
-        # Start with a dummy sample enclosing the whole prior
-        self.logLs = [-np.inf]   # Likelihoods sampled
-        self.log_vols = [0.0]    # Volumes enclosed by contours
-        self.gradients = [0]
-
-    def increment(self, logL, nlive=None):
-        """
-        Increment the state of the evidence integrator
-        Simply uses rectangle rule for initial estimate
-        """
-        if (logL <= self.logLs[-1]):
-            logger.warning('NS integrator received non-monotonic logL.'
-                           f'{self.logLs[-1]:.5f} -> {logL:.5f}')
-        if nlive is None:
-            nlive = self.nlive
-        oldZ = self.logZ
-        logt = - 1.0 / nlive
-        Wt = self.logw + logL + np.log1p(-np.exp(logt))
-        self.logZ = np.logaddexp(self.logZ, Wt)
-        # Update information estimate
-        if np.isfinite(oldZ) and np.isfinite(self.logZ) and np.isfinite(logL):
-            info = np.exp(Wt - self.logZ) * logL \
-                  + np.exp(oldZ - self.logZ) \
-                  * (self.info[-1] + oldZ) \
-                  - self.logZ
-            if np.isnan(info):
-                info = 0
-            self.info.append(info)
-
-        # Update history
-        self.logw += logt
-        self.logLs.append(logL)
-        self.log_vols.append(self.logw)
-        if self.track_gradients:
-            self.gradients.append((self.logLs[-1] - self.logLs[-2])
-                                  / (self.log_vols[-1] - self.log_vols[-2]))
-
-    def finalise(self):
-        """
-        Compute the final evidence with more accurate integrator
-        Call at end of sampling run to refine estimate
-        """
-        # Trapezoidal rule
-        self.logZ = log_integrate_log_trap(np.array(self.logLs),
-                                           np.array(self.log_vols))
-        return self.logZ
-
-    def plot(self, filename=None):
-        """
-        Plot the logX vs logL
-
-        Parameters
-        ----------
-        filename : str, optional
-            Filename name for saving the figure. If not specified the figure
-            is returned.
-        """
-        fig = plt.figure()
-        plt.plot(self.log_vols, self.logLs)
-        plt.title(f'log Z={self.logZ:.2f} '
-                  f'H={self.info[-1] * np.log2(np.e):.2f} bits')
-        plt.grid(which='both')
-        plt.xlabel('log prior-volume')
-        plt.ylabel('log-likelihood')
-        plt.xlim([self.log_vols[-1], self.log_vols[0]])
-        plt.yscale('symlog')
-
-        if filename is not None:
-            fig.savefig(filename, bbox_inches='tight')
-            plt.close()
-            logger.info(f'Saved nested sampling plot as {filename}')
-        else:
-            return fig
 
 
 class NestedSampler:

--- a/nessai/posterior.py
+++ b/nessai/posterior.py
@@ -1,49 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-Functions realted to computing the evidence and posterior samples.
+Functions realted to computing the posterior samples.
 """
 import numpy as np
 
-
-def logsubexp(x, y):
-    """
-    Helper function to compute the exponential
-    of a difference between two numbers
-
-    Computes: ``x + np.log1p(-np.exp(y-x))``
-
-    Parameters
-    ----------
-    x, y : float or array_like
-        Inputs
-    """
-    if np.any(x < y):
-        raise RuntimeError('cannot take log of negative number '
-                           f'{str(x)!s} - {str(y)!s}')
-
-    return x + np.log1p(-np.exp(y - x))
-
-
-def log_integrate_log_trap(log_func, log_support):
-    """
-    Trapezoidal integration of given log(func). Returns log of the integral.
-
-    Parameters
-    ----------
-    log_func : array_like
-        Log values of the function to integrate over.
-    log_support : array_like
-        Log-evidences for each value.
-
-    Returns
-    -------
-    float
-        Log of the result of the integral.
-    """
-    log_func_sum = np.logaddexp(log_func[:-1], log_func[1:]) - np.log(2)
-    log_dxs = logsubexp(log_support[:-1], log_support[1:])
-
-    return np.logaddexp.reduce(log_func_sum + log_dxs)
+from .evidence import logsubexp, log_integrate_log_trap
 
 
 def compute_weights(samples, nlive):

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -5,12 +5,23 @@ Test the object that handles the nested sampling evidence and prior volumes.
 import numpy as np
 import pytest
 
-from nessai.nestedsampler import _NSIntegralState
+from nessai.evidence import (
+    _NSIntegralState,
+    logsubexp,
+)
 
 
 @pytest.fixture()
 def nlive():
     return 100
+
+
+def test_logsubexp_negative():
+    """
+    Test behaviour of logsubexp for x < y
+    """
+    with pytest.raises(Exception):
+        logsubexp(1, 2)
 
 
 def test_increment(nlive):

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -1,13 +1,26 @@
-import pytest
+# -*- coding: utf-8 -*-
+"""
+Test functions related to drawing posterior samples
+"""
+import numpy as np
 
-from nessai.posterior import (
-        logsubexp
-        )
+from nessai.livepoint import numpy_array_to_live_points
+from nessai.posterior import compute_weights, draw_posterior_samples
 
 
-def test_logsubexp_negative():
-    """
-    Test behaviour of logsubexp for x < y
-    """
-    with pytest.raises(Exception):
-        logsubexp(1, 2)
+def test_compute_weights():
+    """Test computing the weights for set of likleihood values"""
+    log_l = np.random.randn(20)
+
+    log_z, log_w = compute_weights(log_l, 10)
+
+    assert len(log_w) == len(log_l)
+    assert np.isfinite(log_z)
+
+
+def test_draw_posterior_samples():
+    """Test drawing posterior samples."""
+    samples = numpy_array_to_live_points(np.random.randn(20, 1), ['x'])
+    samples['logL'] = np.log(np.random.rand(20))
+    p = draw_posterior_samples(samples, 10)
+    assert np.isin(p, samples).all()


### PR DESCRIPTION
This MR moves `_NSIntegralState` to a separate submodule called `evidence.py`. This is motivated by changes for importance sampling that may require a state that inherits from this class.

I've also moved some of the functions from `posterior.py` to `evidence.py` since these make more sense there.

Also added a couple of simple tests for the remaining functions in `posterior.py`