### PR TITLE
Exclude slow integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov-report=xml --without-integration
+        pytest --cov-report=xml --without-integration --without-slow-integration
     - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
Slow integration tests were being run in the unit tests.