### PR TITLE
Fix proposal resume bug

### DIFF
--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -673,7 +673,10 @@ class NestedSampler:
             self._uninformed_proposal.initialise()
             flags[1] = True
 
-        if self.iteration < self.maximum_uninformed:
+        if (
+            self.iteration < self.maximum_uninformed
+            and self.uninformed_sampling
+        ):
             self.proposal = self._uninformed_proposal
         else:
             self.proposal = self._flow_proposal

--- a/tests/test_nested_sampler/test_core_sampling.py
+++ b/tests/test_nested_sampler/test_core_sampling.py
@@ -63,6 +63,7 @@ def test_intialise(sampler):
     sampler.condition = 1.0
     sampler.tolerance = 0.1
     sampler.initialised = False
+    sampler.uninformed_sampling = True
 
     NestedSampler.initialise(sampler)
 

--- a/tests/test_nested_sampler/test_flow.py
+++ b/tests/test_nested_sampler/test_flow.py
@@ -288,31 +288,3 @@ def test_train_proposal_memory(sampler):
     assert sampler.completed_training is True
     assert sampler.block_iteration == 0
     assert sampler.block_acceptance == 0
-
-
-def test_check_resume(sampler):
-    """Test check resume method"""
-    sampler.resumed = True
-    sampler._flow_proposal = MagicMock()
-    sampler._flow_proposal.populated = False
-    sampler._flow_proposal._resume_populated = True
-    sampler._flow_proposal.indices = [1, 2, 3]
-
-    NestedSampler.check_resume(sampler)
-
-    assert sampler.resumed is False
-    assert sampler._flow_proposal.populated is True
-
-
-def test_check_resume_no_indices(sampler):
-    """Test check resume method"""
-    sampler.resumed = True
-    sampler._flow_proposal = MagicMock()
-    sampler._flow_proposal.populated = False
-    sampler._flow_proposal._resume_populated = True
-    sampler._flow_proposal.indices = []
-
-    NestedSampler.check_resume(sampler)
-
-    assert sampler.resumed is False
-    assert sampler._flow_proposal.populated is False

--- a/tests/test_nested_sampler/test_proposal_config.py
+++ b/tests/test_nested_sampler/test_proposal_config.py
@@ -176,3 +176,20 @@ def test_proposal_no_switch(sampler):
     sampler.iteration = 10
     sampler.maximum_uninformed = 100
     assert NestedSampler.check_proposal_switch(sampler) is False
+
+
+def test_proposal_already_switched(sampler):
+    """Test switching when proposal is already switched"""
+    sampler.mean_acceptance = 0.5
+    sampler.uninformed_acceptance_threshold = 0.1
+    sampler.mean_block_acceptance = 0.5
+    sampler.iteration = 10
+    sampler.maximum_uninformed = 100
+    sampler._flow_proposal = MagicMock()
+    sampler._flow_proposal.ns_acceptance = 0.2
+    sampler.uninformed_sampling = False
+    sampler.proposal = sampler._flow_proposal
+    assert NestedSampler.check_proposal_switch(sampler, force=True) is True
+    assert sampler.proposal is sampler._flow_proposal
+    # If proposal was switched again, acceptance would change
+    assert sampler.proposal.ns_acceptance == 0.2

--- a/tests/test_nested_sampler/test_resume.py
+++ b/tests/test_nested_sampler/test_resume.py
@@ -50,6 +50,38 @@ def test_checkpoint(sampler, periodic):
         assert sampler.checkpoint_iterations == [10, 20]
 
 
+def test_check_resume(sampler):
+    """Test check resume method"""
+    sampler.uninformed_sampling = False
+    sampler.check_proposal_switch = MagicMock()
+    sampler.resumed = True
+    sampler._flow_proposal = MagicMock()
+    sampler._flow_proposal.populated = False
+    sampler._flow_proposal._resume_populated = True
+    sampler._flow_proposal.indices = [1, 2, 3]
+
+    NestedSampler.check_resume(sampler)
+
+    sampler.check_proposal_switch.assert_called_once_with(force=True)
+    assert sampler.resumed is False
+    assert sampler._flow_proposal.populated is True
+
+
+def test_check_resume_no_indices(sampler):
+    """Test check resume method"""
+    sampler.uninformed_sampling = True
+    sampler.resumed = True
+    sampler._flow_proposal = MagicMock()
+    sampler._flow_proposal.populated = False
+    sampler._flow_proposal._resume_populated = True
+    sampler._flow_proposal.indices = []
+
+    NestedSampler.check_resume(sampler)
+
+    assert sampler.resumed is False
+    assert sampler._flow_proposal.populated is False
+
+
 def test_resume(model):
     """Test the resume method"""
     obj = MagicMock()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -3,10 +3,12 @@
 Integration tests for running the sampler with different configurations.
 """
 import os
-
-from nessai.flowsampler import FlowSampler
 import torch
 import pytest
+import numpy as np
+
+from nessai.flowsampler import FlowSampler
+
 
 torch.set_num_threads(1)
 
@@ -106,6 +108,36 @@ def test_sampling_resume(model, flow_config, tmpdir):
     fp = FlowSampler(model, output=output, resume=True,
                      flow_config=flow_config)
     assert fp.ns.iteration == 11
+    fp.ns.max_iteration = 21
+    fp.run()
+    assert fp.ns.iteration == 21
+    assert os.path.exists(
+        os.path.join(output, 'nested_sampler_resume.pkl.old'))
+
+
+@pytest.mark.slow_integration_test
+def test_sampling_resume_no_max_uninformed(model, flow_config, tmpdir):
+    """
+    Test resuming the sampler when there is no maximum iteration for
+    the uinformed sampling.
+
+    This test makes sure the correct proposal is loaded after resuming
+    and re-initialising the sampler.
+    """
+    output = str(tmpdir.mkdir('resume'))
+    fp = FlowSampler(model, output=output, resume=True, nlive=100, plot=False,
+                     flow_config=flow_config, training_frequency=10,
+                     maximum_uninformed=9, rescale_parameters=True,
+                     seed=1234, max_iteration=11, poolsize=10)
+    fp.run()
+    assert os.path.exists(os.path.join(output, 'nested_sampler_resume.pkl'))
+
+    fp = FlowSampler(model, output=output, resume=True,
+                     flow_config=flow_config)
+    assert fp.ns.iteration == 11
+    fp.ns.maximum_uninformed = np.inf
+    fp.ns.initialise()
+    assert fp.ns.proposal is fp.ns._flow_proposal
     fp.ns.max_iteration = 21
     fp.run()
     assert fp.ns.iteration == 21


### PR DESCRIPTION
Fixes an error that could occur when resuming the sampler with `maximum_uninformed=inf`.

## Error

```
Traceback (most recent call last):
  File "/var/lib/condor/execute/dir_31639/condor_exec.exe", line 8, in <module>
    sys.exit(main())
  File "/home/michael.williams/.conda/envs/o4mdc-nessai/lib/python3.8/site-packages/bilby_pipe/data_analysis.py", line 271, in main
    analysis.run_sampler()
  File "/home/michael.williams/.conda/envs/o4mdc-nessai/lib/python3.8/site-packages/bilby_pipe/data_analysis.py", line 234, in run_sampler
    self.result = bilby.run_sampler(
  File "/nfshome/store03/users/michael.williams/git_repos/bilby/bilby/core/sampler/__init__.py", line 185, in run_sampler
    result = sampler.run_sampler()
  File "/nfshome/store03/users/michael.williams/git_repos/bilby/bilby/core/sampler/nessai.py", line 142, in run_sampler
    out.run(save=True, plot=self.plot)
  File "/nfshome/store03/users/michael.williams/git_repos/nessai/nessai/flowsampler.py", line 112, in run
    self.ns.nested_sampling_loop()
  File "/nfshome/store03/users/michael.williams/git_repos/nessai/nessai/nestedsampler.py", line 1030, in nested_sampling_loop
    self.consume_sample()
  File "/nfshome/store03/users/michael.williams/git_repos/nessai/nessai/nestedsampler.py", line 562, in consume_sample
    self.check_state()
  File "/nfshome/store03/users/michael.williams/git_repos/nessai/nessai/nestedsampler.py", line 792, in check_state
    train, force = self.check_training()
  File "/nfshome/store03/users/michael.williams/git_repos/nessai/nessai/nestedsampler.py", line 712, in check_training
    not self.proposal.populating):
AttributeError: 'AnalyticProposal' object has no attribute 'populating'
```

## Cause

The sampler would call `initialise` and set the proposal to the `self._uninformed_proposal` when it should be `self._flow_proposal`.