### PR TITLE
Fix rescale bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ tests for this reparameterisation.
 - Fixed `AugmentedGWFlowProposal`.
 - Fixed a bug with `plot_live_points` when the hue parameter (`c`) was constant.
 - Fix `prior_sampling`
+- Fixed a bug with the reparmeterisation `Rescale` when `scale` was set to a negative number.
 
 
 ## [0.2.4] - 2021-03-08

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -386,7 +386,7 @@ class Rescale(Reparameterisation):
         """
         for p, pp in zip(self.parameters, self.prime_parameters):
             x_prime[pp] = x[p] / self.scale[p]
-            log_j -= np.log(self.scale[p])
+            log_j -= np.log(np.abs(self.scale[p]))
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -404,7 +404,7 @@ class Rescale(Reparameterisation):
         """
         for p, pp in zip(self.parameters, self.prime_parameters):
             x[p] = x_prime[pp] * self.scale[p]
-            log_j += np.log(self.scale[p])
+            log_j += np.log(np.abs(self.scale[p]))
         return x, x_prime, log_j
 
 

--- a/tests/test_reparameterisations/test_rescale.py
+++ b/tests/test_reparameterisations/test_rescale.py
@@ -33,7 +33,7 @@ def test_reparameterise(reparam, n):
     """Test the reparameterise method"""
     reparam.parameters = ['x', 'y']
     reparam.prime_parameters = ['x_prime', 'y_prime']
-    reparam.scale = {'x': 2.0, 'y': 4.0}
+    reparam.scale = {'x': -2.0, 'y': 4.0}
     x = numpy_array_to_live_points(np.ones((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
         np.zeros((n, 2)), reparam.prime_parameters)
@@ -44,7 +44,7 @@ def test_reparameterise(reparam, n):
 
     assert np.array_equal(x, x_out)
     assert np.array_equal(log_j_out, -np.log(8 * np.ones(n)))
-    assert (x_prime_out['x_prime'] == 0.5).all()
+    assert (x_prime_out['x_prime'] == -0.5).all()
     assert (x_prime_out['y_prime'] == 0.25).all()
 
 
@@ -74,13 +74,14 @@ def test_reparameterise_overflow(reparam, scale):
 
 @pytest.mark.parametrize('n', [1, 2])
 def test_inverse_reparameterise(reparam, n):
-    """Test the reparameterise method"""
+    """Test the inverse reparameterise method"""
     reparam.parameters = ['x', 'y']
     reparam.prime_parameters = ['x_prime', 'y_prime']
-    reparam.scale = {'x': 2.0, 'y': 4.0}
+    reparam.scale = {'x': -2.0, 'y': 4.0}
     x = numpy_array_to_live_points(np.zeros((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
         np.ones((n, 2)), reparam.prime_parameters)
+    x_prime['x_prime'] *= -1
     log_j = np.zeros(n)
 
     x_out, x_prime_out, log_j_out = \


### PR DESCRIPTION
Fix a bug with `nessai.reparameterisation.Rescale` when `scale` was set to a negative number. 

Also changes the tests to include a negative scale.