### PR TITLE
Fix null reparameterisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ tests for this reparameterisation.
 - Fixed a bug with `plot_live_points` when the hue parameter (`c`) was constant.
 - Fix `prior_sampling`
 - Fixed a bug with the reparmeterisation `Rescale` when `scale` was set to a negative number.
+- Fix a bug that prevented specifying `NullReparameterisation` (!80)
 
 
 ## [0.2.4] - 2021-03-08

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -942,8 +942,8 @@ class Angle(Reparameterisation):
 
 class ToCartesian(Angle):
     """Convert a paraemter to Cartesian coordinates"""
-    def __init__(self, mode='split', scale=np.pi, **kwargs):
-        super().__init__(scale=np.pi, **kwargs)
+    def __init__(self, mode='split', scale=np.pi, prior_bounds=None, **kwargs):
+        super().__init__(scale=np.pi, prior_bounds=prior_bounds, **kwargs)
 
         self.mode = mode
         if self.mode not in ['duplicate', 'split', 'half']:

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -1019,7 +1019,6 @@ class AnglePair(Reparameterisation):
         self.parameters = parameters
         self.prime_parameters = [f'{m}_{x}' for x in ['x', 'y', 'z']]
 
-        print(prior)
         if prior == 'isotropic' and self.chi:
             self.has_prime_prior = True
             logger.info(f'Prime prior enabled for {self.name}')

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -1180,5 +1180,6 @@ default_reparameterisations = {
     'angle-pair': (AnglePair, None),
     'to-cartesian': (ToCartesian, None),
     'none': (NullReparameterisation, None),
+    'null': (NullReparameterisation, None),
     None: (NullReparameterisation, None),
 }

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -45,7 +45,8 @@ def get_reparameterisation(reparameterisation):
     Returns
     -------
     :obj:`nessai.reparameteristaions.Reparmeterisation`
-        T
+        The class to use for the reparameterisation. The class is NOT
+        initialised.
     dict
         Keyword arguments for the specific reparameterisations.
     """
@@ -65,9 +66,11 @@ def get_reparameterisation(reparameterisation):
     elif (isinstance(reparameterisation, type) and
             issubclass(reparameterisation, Reparameterisation)):
         return reparameterisation, {}
+    elif reparameterisation is None:
+        return NullReparameterisation, {}
     else:
-        raise RuntimeError('Reparmeterisation must a str or class that '
-                           'inherits from `Reparameterisation`')
+        raise RuntimeError('Reparameterisation must be a str, None, or '
+                           'a class that inherits from `Reparameterisation`')
 
 
 class Reparameterisation:

--- a/tests/test_proposal/test_flowproposal/test_add_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_add_reparameterisations.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+Integration tests for adding the default reparameterisations
+"""
+import numpy as np
+import pytest
+from unittest.mock import create_autospec
+
+from nessai.model import Model
+from nessai.proposal import FlowProposal
+from nessai.reparameterisations import default_reparameterisations
+
+# General reparameterisations that do not need extra parameters
+general_reparameterisations = \
+    {k: v for k, v in default_reparameterisations.items()
+        if k not in ['scale', 'rescale', 'angle-pair']}
+
+
+@pytest.fixture(params=general_reparameterisations.keys())
+def reparameterisation(request):
+    return request.param
+
+
+@pytest.fixture
+def model():
+    m = create_autospec(Model)
+    m.names = ['x']
+    m.bounds = {'x': [-1, 1]}
+    m.reparameterisations = None
+    return m
+
+
+@pytest.mark.integration_test
+def test_configure_reparameterisations(tmpdir, model, reparameterisation):
+    """Test adding one of the default reparameterisations.
+
+    Only tests reparameterisations that don't need extra parameters.
+    """
+    proposal = FlowProposal(
+        model,
+        output=str(tmpdir.mkdir('test')),
+        poolsize=10,
+        reparameterisations={'x': reparameterisation}
+        )
+    proposal.set_rescaling()
+    assert proposal._reparameterisation is not None
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize('reparameterisation', ['scale', 'rescale'])
+def test_configure_reparameterisation_scale(tmpdir, model, reparameterisation):
+    """Test adding the `Rescale` reparameterisation"""
+    proposal = FlowProposal(
+        model,
+        output=str(tmpdir.mkdir('test')),
+        poolsize=10,
+        reparameterisations={
+            'x': {'reparameterisation': reparameterisation, 'scale': 2.0}
+        }
+        )
+    proposal.set_rescaling()
+    assert proposal._reparameterisation is not None
+
+
+@pytest.mark.integration_test
+def test_configure_reparameterisation_angle_pair(tmpdir, model):
+    """Test adding the `AnglePair` reparameterisation"""
+    model.names.append('y')
+    model.bounds = {'x': [0, 2 * np.pi], 'y': [-np.pi / 2, np.pi / 2]}
+    proposal = FlowProposal(
+        model,
+        output=str(tmpdir.mkdir('test')),
+        poolsize=10,
+        reparameterisations={
+            'x': {'reparameterisation': 'angle-pair', 'parameters': ['y']}
+        }
+        )
+    proposal.set_rescaling()
+    assert proposal._reparameterisation is not None


### PR DESCRIPTION
`NullReparameterisation` could be specified using names: `'none'` or `None` because this reparameterisation does not require prior bounds.

This PR fixes this by checking the signature of the reparameterisation to see if `prior_bounds` is a keyword argument.

Also adds an alternative name `'null'` for the `NullReparameterisation` and integration tests to ensure that all the reparameterisations included by default can be added to the proposal without raising an error.

Closes https://github.com/mj-will/nessai/issues/78