### PR TITLE
Tweak ns plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ tests for this reparameterisation.
 - Add tests for `NestedSampler`
 - Explicitly check prior bounds when using reparameterisations. This catches cases where infinite bounds are used and break some reparameterisations. (!82)
 - Add error when calling `FlowProposal.populate` without initialising the proposal.
+- Add `NestedSampler.plot_insertion_indices` to allow for easier plotting of insertion indices.
+- Add `filename` keyword argument to `NestedSampler.plot_trace`.
 
 ### Changed
 

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -951,15 +951,41 @@ class NestedSampler:
         else:
             return fig
 
-    def plot_trace(self):
+    def plot_trace(self, filename=None):
         """
-        Make trace plots for the nested samples
+        Make trace plots for the nested samples.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If filename is None, the figure is returned. Else the figure
+            is saved with that file name.
         """
         if self.nested_samples:
-            plot_trace(self.state.log_vols[1:], self.nested_samples,
-                       filename=f'{self.output}/trace.png')
+            fig = plot_trace(self.state.log_vols[1:], self.nested_samples,
+                             filename=filename)
+            return fig
         else:
             logger.warning('Could not produce trace plot. No nested samples!')
+
+    def plot_insertion_indices(self, filename=None, **kwargs):
+        """
+        Make a plot of all the insertion indices.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If filename is None, the figure is returned. Else the figure
+            is saved with that file name.
+        kwargs :
+            Keyword arguments passed to `nessai.plot.plot_indices`.
+        """
+        return plot_indices(
+            self.insertion_indices,
+            self.nlive,
+            filename=filename,
+            **kwargs
+        )
 
     def update_state(self, force=False):
         """
@@ -1004,7 +1030,7 @@ class NestedSampler:
 
             if self.plot:
                 self.plot_state(filename=f'{self.output}/state.png')
-                self.plot_trace()
+                self.plot_trace(filename=f'{self.output}/trace.png')
 
             if self.uninformed_sampling:
                 self.block_acceptance = 0.

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -991,7 +991,7 @@ class NestedSampler:
                 f"dZ: {self.condition:.3f} logZ: {self.state.logZ:.3f} "
                 f"+/- {np.sqrt(self.state.info[-1] / self.nlive):.3f} "
                 f"logLmax: {self.logLmax:.2f}")
-            self.checkpoint(periodic=not force)
+            self.checkpoint(periodic=True)
             if not force:
                 self.check_insertion_indices()
                 if self.plot:
@@ -1020,7 +1020,8 @@ class NestedSampler:
         ----------
         periodic : bool
             Indicates if the checkpoint is regular periodic checkpointing
-            or forced by a signal
+            or forced by a signal. If forces by a signal, it will show up on
+            the state plot.
         """
         if not periodic:
             self.checkpoint_iterations += [self.iteration]

--- a/tests/test_nested_sampler/test_manage_state.py
+++ b/tests/test_nested_sampler/test_manage_state.py
@@ -192,7 +192,7 @@ def test_update_state_force(mock_plot, sampler):
 
     NestedSampler.update_state(sampler, force=True)
 
-    sampler.checkpoint.assert_called_once_with(periodic=False)
+    sampler.checkpoint.assert_called_once_with(periodic=True)
     assert not mock_plot.called
     assert not sampler.called
     sampler.plot_trace.assert_called_once()


### PR DESCRIPTION
Some of the plotting functions in `NestedSampler` currently don't return the figures if they're not saved. This changes them so the default behaviour is to return the figure if it is not saved.

Also adds `NestedSampler.plot_insertion_indices` to allow users to more easily plot the insertion indices.