### PR TITLE
Tweaks for proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `nessai.gw.utils.DistanceConverter` now inherits from `abc.ABC` and `to_uniform_parameter` and `from_uniform_parameter` are both abstract methods.
+- `nessai.proposal.rejection.RejectionProposal` now inherits from `nessai.proposal.analytic.AnalyticProposal`. Functionality is the same but the code will be easier to maintain since this removes several methods that were identical.
 
 
 ### Fixed

--- a/nessai/proposal/analytic.py
+++ b/nessai/proposal/analytic.py
@@ -10,11 +10,20 @@ from .base import Proposal
 
 
 class AnalyticProposal(Proposal):
-    """
-    Class for drawing samples from analytic priors.
+    """Class for drawing samples from analytic priors.
 
-    This assumes the `new_point` method of the model draws points
-    from the prior
+    Will be used when ``nessai`` is called with ``analytic_priors=True`` and
+    assumes the :py:meth:`nessai.model.Model.new_point` samples directly
+    from the prior. This method must be implemented by the user.
+
+    Parameters
+    ----------
+    args :
+        Arguments passed to the parent class.
+    poolsize : int, optional
+        Number of points drawn at once.
+    kwargs :
+        Keyword arguments passed to the parent class.
     """
     def __init__(self, *args, poolsize=1000, **kwargs):
         super(AnalyticProposal, self).__init__(*args, **kwargs)
@@ -28,7 +37,16 @@ class AnalyticProposal(Proposal):
 
     def populate(self, N=None):
         """
-        Populate the pool by drawing from the priors
+        Populate the pool by drawing from the priors.
+
+        Will also evaluate the likelihoods if the proposal contains a
+        multiprocessing pool.
+
+        Parameters
+        ----------
+        N : int, optional
+            Number of samples to draw. If not specified ``poolsize`` will be
+            used.
         """
         if N is None:
             N = self.poolsize
@@ -49,7 +67,8 @@ class AnalyticProposal(Proposal):
         old_sample : structured_array
             Old sample, this is not used in the proposal method
         kwargs :
-            Keyword arguments passed to ``populate``.
+            Keyword arguments passed to \
+                :py:meth:`~nessai.proposal.analytic.AnalyticProposal.populate`
         """
         if not self.populated:
             st = datetime.datetime.now()

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -2,27 +2,112 @@
 """
 Test the analytic proposal method.
 """
+import datetime
+import numpy as np
 import pytest
+from unittest.mock import Mock, create_autospec, patch
 
+from nessai.livepoint import numpy_array_to_live_points
 from nessai.proposal import AnalyticProposal
 
 
-@pytest.fixture(scope='function')
-def proposal(model):
-    return AnalyticProposal(model)
+@pytest.fixture
+def proposal():
+    return create_autospec(AnalyticProposal)
 
 
-def test_populate(proposal):
+def test_init(proposal):
+    """Test the init method."""
+    with patch('nessai.proposal.analytic.Proposal.__init__') as mock_super:
+        AnalyticProposal.__init__(proposal, 'model', poolsize=10, test=True)
+    mock_super.assert_called_once_with('model', test=True)
+    assert proposal._poolsize == 10
+    assert proposal.populated is False
+
+
+def test_poolsize(proposal):
+    """Test poolsize property"""
+    proposal._poolsize = 100
+    poolsize = AnalyticProposal.poolsize.__get__(proposal)
+    assert poolsize == 100
+
+
+@pytest.mark.parametrize('pool', [None, True])
+@pytest.mark.parametrize('N', [None, 5])
+def test_populate(proposal, pool, N):
     """Test the population process"""
-    N = 500
-    proposal.populate(N=N)
+    poolsize = 10
+    if N is None:
+        samples = numpy_array_to_live_points(
+            np.arange(poolsize)[:, np.newaxis], 'x'
+        )
+        log_p = np.arange(poolsize, 2 * poolsize)
+    else:
+        samples = numpy_array_to_live_points(np.arange(N)[:, np.newaxis], 'x')
+        log_p = np.arange(N, 2 * N)
+    proposal.pool = pool
+    proposal.poolsize = poolsize
+    proposal.model = Mock()
+    proposal.model.new_point = Mock(return_value=samples)
+    proposal.model.log_prior = Mock(return_value=log_p)
+    proposal.evaluate_likelihoods = Mock()
+    AnalyticProposal.populate(proposal, N=N)
 
-    assert proposal.samples.size == N
-    assert proposal.populated
+    if N is None:
+        N = poolsize
+    proposal.model.new_point.assert_called_once_with(N=N)
+    proposal.model.log_prior.assert_called_once_with(samples)
+    if pool is not None:
+        proposal.evaluate_likelihoods.assert_called_once()
+    else:
+        proposal.evaluate_likelihoods.assert_not_called()
+
+    np.testing.assert_array_equal(proposal.samples['logP'], log_p)
+    assert sorted(proposal.indices) == list(range(N))
+    assert proposal.populated is True
 
 
-def test_draw(model, proposal):
+@pytest.mark.parametrize('populated', [True, False])
+def test_draw(proposal, populated):
     """Test the draw method"""
+    N = 5
+    proposal.populated = populated
+    proposal.populate = Mock()
+    proposal.population_time = datetime.timedelta()
+    proposal.indices = [0, 1, 2, 3, 4]
+    proposal.samples = np.array([0, 1, 2, 3, 4])
+
+    sample = AnalyticProposal.draw(proposal, 1, N=N)
+
+    assert sample == 4
+
+    if not populated:
+        proposal.populate.assert_called_once_with(N=N)
+        assert proposal.population_time.total_seconds() > 0.
+    else:
+        proposal.populate.assert_not_called()
+        assert proposal.population_time.total_seconds() == 0.
+    assert proposal.indices == [0, 1, 2, 3]
+
+
+def test_draw_out_of_samples(proposal):
+    """Assert populated is set to false when the last sample is used."""
+    N = 5
+    proposal.populated = True
+    proposal.indices = [0]
+    proposal.samples = np.array([0, 1, 2, 3, 4])
+
+    sample = AnalyticProposal.draw(proposal, 1, N=N)
+
+    assert sample == 0
+    assert proposal.indices == []
+    assert proposal.populated is False
+
+
+@pytest.mark.integration_test
+def test_draw_intergration(model):
+    """Integration test for the draw method"""
+    proposal = AnalyticProposal(model)
     N = 10
     old_point = model.new_point()
     assert not proposal.populated
@@ -31,3 +116,13 @@ def test_draw(model, proposal):
     [proposal.draw(old_point) for _ in range(N - 1)]
     assert not proposal.indices
     assert not proposal.populated
+
+
+@pytest.mark.integration_test
+def test_populate_integration(model):
+    """Integration test for the populate methdo"""
+    proposal = AnalyticProposal(model)
+    N = 500
+    proposal.populate(N=N)
+    assert proposal.samples.size == N
+    assert proposal.populated is True

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -35,7 +35,7 @@ def test_poolsize(proposal):
 @pytest.mark.parametrize('pool', [None, True])
 @pytest.mark.parametrize('N', [None, 5])
 def test_populate(proposal, pool, N):
-    """Test the population process"""
+    """Test the populate process"""
     poolsize = 10
     if N is None:
         samples = numpy_array_to_live_points(
@@ -120,7 +120,7 @@ def test_draw_intergration(model):
 
 @pytest.mark.integration_test
 def test_populate_integration(model):
-    """Integration test for the populate methdo"""
+    """Integration test for the populate method"""
     proposal = AnalyticProposal(model)
     N = 500
     proposal.populate(N=N)

--- a/tests/test_proposal/test_rejection.py
+++ b/tests/test_proposal/test_rejection.py
@@ -2,35 +2,114 @@
 """
 Test the rejection proposal class.
 """
+import numpy as np
 import pytest
+from unittest.mock import Mock, create_autospec, patch
 
+from nessai.livepoint import numpy_array_to_live_points
 from nessai.proposal import RejectionProposal
 
 
-@pytest.fixture()
-def poolsize():
-    return 10
+@pytest.fixture
+def proposal():
+    return create_autospec(RejectionProposal)
 
 
-@pytest.fixture(scope='function')
-def proposal(model, poolsize):
-    return RejectionProposal(model, poolsize=poolsize)
+def test_init(proposal):
+    """Test the init method."""
+    with patch('nessai.proposal.rejection.AnalyticProposal.__init__') \
+            as mock_super:
+        RejectionProposal.__init__(proposal, 'model', poolsize=10, test=True)
+    mock_super.assert_called_once_with('model', poolsize=10, test=True)
+    assert proposal._checked_population is True
+    assert proposal.population_acceptance is None
 
 
-def test_populate(proposal, poolsize):
-    """Test the population process"""
-    proposal.populate(N=poolsize)
+@pytest.mark.parametrize('N', [None, 5])
+def test_draw_proposal(proposal, N):
+    """Assert `model.new_point` is called with the corred number of samples."""
+    points = np.array([1, 2])
+    proposal.poolsize = 10
+    proposal.model = Mock()
+    proposal.model.new_point = Mock(return_value=points)
+    samples = RejectionProposal.draw_proposal(proposal, N=N)
+    np.testing.assert_array_equal(samples, points)
+    if N is None:
+        proposal.model.new_point.assert_called_once_with(N=10)
+    else:
+        proposal.model.new_point.assert_called_once_with(N=5)
 
-    assert proposal.samples.size == poolsize
-    assert proposal.populated
+
+def test_log_proposal(proposal):
+    """Assert the correct method from the model is called"""
+    x = np.array([3, 4])
+    log_prob = np.array([1, 2])
+    proposal.model = Mock()
+    proposal.model.new_point_log_prob = Mock(return_value=log_prob)
+    out = RejectionProposal.log_proposal(proposal, x)
+    proposal.model.new_point_log_prob.assert_called_once_with(x)
+    np.testing.assert_array_equal(out, log_prob)
 
 
-def test_draw(model, proposal, poolsize):
-    """Test the draw method"""
-    old_point = model.new_point()
-    assert not proposal.populated
-    proposal.draw(old_point)
-    assert proposal.populated
-    [proposal.draw(old_point) for _ in range(poolsize - 1)]
-    assert not proposal.indices
-    assert not proposal.populated
+def test_compute_weights(proposal):
+    """Test the compute weights method"""
+    x = numpy_array_to_live_points(np.array([[1], [2], [3]]), 'x')
+    proposal.model = Mock()
+    proposal.model.log_prior = Mock(return_value=np.array([6, 6, 6]))
+    proposal.log_proposal = Mock(return_value=np.array([3, 4, np.nan]))
+    log_w = np.array([0, -1, np.nan])
+    out = RejectionProposal.compute_weights(proposal, x)
+
+    proposal.model.log_prior.assert_called_once_with(x)
+    proposal.log_proposal.assert_called_once_with(x)
+    np.testing.assert_array_equal(out, log_w)
+
+
+@pytest.mark.parametrize('pool', [None, True])
+@pytest.mark.parametrize('N', [None, 4])
+def test_populate(proposal, pool, N):
+    """Test the populate method"""
+    poolsize = 8
+    if N is None:
+        log_w = np.arange(poolsize)
+    else:
+        log_w = np.arange(N)
+    x = np.random.randn(log_w.size)
+    u = np.exp(log_w.copy() + 1)
+    # These points will have log_u ~ -inf so corresponding samples will be
+    # accepted.
+    u[::2] = 1e-10
+    samples = x[::2]
+    proposal.poolsize = poolsize
+    proposal.populated = False
+    proposal.draw_proposal = Mock(return_value=x)
+    proposal.compute_weights = Mock(return_value=log_w)
+    proposal.evaluate_likelihoods = Mock()
+    proposal.pool = pool
+
+    with patch('numpy.random.rand', return_value=u):
+        RejectionProposal.populate(proposal, N=N)
+
+    assert proposal.population_acceptance == 0.5
+    assert proposal.populated is True
+    np.testing.assert_array_equal(proposal.samples, samples)
+
+    if N is None:
+        N = poolsize
+    proposal.draw_proposal.assert_called_once_with(N=N)
+
+    if pool is not None:
+        proposal.evaluate_likelihoods.assert_called_once()
+    else:
+        proposal.evaluate_likelihoods.assert_not_called()
+    assert sorted(proposal.indices) == list(range(samples.size))
+
+
+@pytest.mark.integration_test
+def test_populate_integration(model):
+    """Integration test for the populate method"""
+    proposal = RejectionProposal(model)
+    N = 500
+    proposal.populate(N=N)
+    assert proposal.samples.size == N
+    assert proposal.populated is True


### PR DESCRIPTION
This PR tweaks `RejectionProposal` so that it inherits from `AnalyticProposal`. This allows us to remove several methods from `RejectionProposal` and make the code easier to maintain going forward.

It also improves the tests and doc-strings for `AnalyticProposal` and `RejectionProposal`.