### PR TITLE
Fix training jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `nessai.gw.utils.DistanceConverter` now inherits from `abc.ABC` and `to_uniform_parameter` and `from_uniform_parameter` are both abstract methods.
 - `nessai.proposal.rejection.RejectionProposal` now inherits from `nessai.proposal.analytic.AnalyticProposal`. Functionality is the same but the code will be easier to maintain since this removes several methods that were identical.
 - `nessai.proposal.base.Proposal` now inherits from `abc.ABC` and `draw` is an abstract method.
-- `noise_scale='adaptive'` option in `FlowModel` now correctly uses a standard deviation of 0.2 times the mean nearest neighbour separation as described in[Moss 2019](https://arxiv.org/abs/1903.10860). Note that this feature is disabled by default, so this does not change the default behaviour.
+- `noise_scale='adaptive'` option in `FlowModel` now correctly uses a standard deviation of 0.2 times the mean nearest neighbour separation as described in [Moss 2019](https://arxiv.org/abs/1903.10860). Note that this feature is disabled by default, so this does not change the default behaviour.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `nessai.gw.utils.DistanceConverter` now inherits from `abc.ABC` and `to_uniform_parameter` and `from_uniform_parameter` are both abstract methods.
 - `nessai.proposal.rejection.RejectionProposal` now inherits from `nessai.proposal.analytic.AnalyticProposal`. Functionality is the same but the code will be easier to maintain since this removes several methods that were identical.
 - `nessai.proposal.base.Proposal` now inherits from `abc.ABC` and `draw` is an abstract method.
+- `noise_scale='adaptive'` option in `FlowModel` now correctly uses a standard deviation of 0.2 times the mean nearest neighbour separation as described in[Moss 2019](https://arxiv.org/abs/1903.10860). Note that this feature is disabled by default, so this does not change the default behaviour.
 
 
 ### Fixed

--- a/nessai/flowmodel.py
+++ b/nessai/flowmodel.py
@@ -444,7 +444,7 @@ class FlowModel:
             val_size = self.val_size
 
         if self.noise_scale == 'adaptive':
-            noise_scale = 0.1 * np.std(compute_minimum_distances(samples))
+            noise_scale = 0.2 * np.mean(compute_minimum_distances(samples))
             logger.debug(f'Using adaptive scale: {noise_scale:.3f}')
         else:
             noise_scale = self.noise_scale


### PR DESCRIPTION
`noise_scale='adaptive'` was incorrectly computing the noise scale. This PR fixes the implementation.