### PR TITLE
Fix pre rescaling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a typo in `nessai.gw.utils.NullDistanceConverter.from_uniform_parameter` that broke the method.
+- Fixed a bug in `nessai.reparameterisations.RescaleToBounds` when using `offset=True` and `pre_rescaling` where the prime prior bounds were incorrectly set.
 
 
 ## [0.3.0] Testing, testing and more testing - 2021-07-05


### PR DESCRIPTION
Fix a bug when using `RescaleToBounds` with `offset=True` and `pre_rescaling` where the prime prior bounds were incorrectly computed, leading to points outside the prior being accepted. 

This setting is not enabled by default and shouldn't affect most users.

Also added a test to check this behaviour.