### PR TITLE
Allow lowercase flow class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `nessai.utils` into a submodule.
 - Change behaviour of `determine_rescaled_bounds` so that `rescale_bounds` is ignored when `inversion=True`. This matches the behaviour in `RescaledToBounds` where when boundary inversion is enabled, values are rescaled to $[0, 1]$ and then if no inversion if applied, changed to $[-1, 1]$.
 - Tweaked `detect_edges` so that `both` is returned in cases where the lower and upper regions contain zero probability.
+- `NestedSampler` no longer checks capitalisation of `flow_class` when determining which proposal class to use. E.g. `'FlowProposal'` and `'flowproposal'` are now both valid values.
+- `NestedSampler.configure_flow_proposal` now raises `ValueError` instead of `RuntimeError` if `flow_class` is an invalid string.
 
 
 ### Fixed

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -385,7 +385,7 @@ class NestedSampler:
 
         Parameters
         ----------
-        flow_class : None or obj
+        flow_class : None or obj or str
             Class to use for proposal. If None FlowProposal is used.
         flow_config : dict
             Configuration dictionary passed to the class.
@@ -401,20 +401,21 @@ class NestedSampler:
 
         if flow_class is not None:
             if isinstance(flow_class, str):
-                if flow_class == 'GWFlowProposal':
+                flow_class = flow_class.lower()
+                if flow_class == 'gwflowproposal':
                     from .gw.proposal import GWFlowProposal as flow_class
-                elif flow_class == 'AugmentedGWFlowProposal':
+                elif flow_class == 'augmentedgwflowproposal':
                     from .gw.proposal import (
                         AugmentedGWFlowProposal as flow_class)
-                elif flow_class == 'LegacyGWFlowProposal':
+                elif flow_class == 'legacygwflowproposal':
                     from .gw.legacy import LegacyGWFlowProposal as flow_class
-                elif flow_class == 'FlowProposal':
+                elif flow_class == 'flowproposal':
                     flow_class = FlowProposal
-                elif flow_class == 'AugmentedFlowProposal':
+                elif flow_class == 'augmentedflowproposal':
                     from .proposal import AugmentedFlowProposal
                     flow_class = AugmentedFlowProposal
                 else:
-                    raise RuntimeError(f'Unknown flow class: {flow_class}')
+                    raise ValueError(f'Unknown flow class: {flow_class}')
             elif not issubclass(flow_class, FlowProposal):
                 raise RuntimeError('Flow class must be string or class that '
                                    'inherits from FlowProposal')

--- a/tests/test_nested_sampler/test_proposal_config.py
+++ b/tests/test_nested_sampler/test_proposal_config.py
@@ -116,12 +116,21 @@ def test_no_flow_proposal_class(sampler):
     assert isinstance(sampler._flow_proposal, FlowProposal)
 
 
-@pytest.mark.parametrize('flow_class, result_class',
-                         [['FlowProposal', FlowProposal],
-                          ['AugmentedFlowProposal', AugmentedFlowProposal],
-                          ['GWFlowProposal', GWFlowProposal],
-                          ['AugmentedGWFlowProposal', AugmentedGWFlowProposal],
-                          ['LegacyGWFlowProposal', LegacyGWFlowProposal]])
+@pytest.mark.parametrize(
+    'flow_class, result_class',
+    [
+        ['FlowProposal', FlowProposal],
+        ['AugmentedFlowProposal', AugmentedFlowProposal],
+        ['GWFlowProposal', GWFlowProposal],
+        ['AugmentedGWFlowProposal', AugmentedGWFlowProposal],
+        ['LegacyGWFlowProposal', LegacyGWFlowProposal],
+        ['flowproposal', FlowProposal],
+        ['augmentedflowproposal', AugmentedFlowProposal],
+        ['gwflowproposal', GWFlowProposal],
+        ['augmentedgwflowproposal', AugmentedGWFlowProposal],
+        ['legacygwflowproposal', LegacyGWFlowProposal]
+    ]
+)
 def test_flow__class(flow_class, result_class, sampler):
     """Test the correct class is imported and used"""
     NestedSampler.configure_flow_proposal(sampler, flow_class, {}, False)
@@ -130,9 +139,9 @@ def test_flow__class(flow_class, result_class, sampler):
 
 def test_unknown_flow_class(sampler):
     """Test to check the error raised if an unknown class is used"""
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         NestedSampler.configure_flow_proposal(sampler, 'GWProposal', {}, False)
-    assert 'Unknown' in str(excinfo.value)
+    assert 'Unknown flow class' in str(excinfo.value)
 
 
 def test_flow_class_not_subclass(sampler):


### PR DESCRIPTION
Currently setting `flow_class='flowproposal'` raises an error because of missing uppercase letters. This changes to check the `lower()` version of the string and thus ignoring capitalisation.

Also noticed a `RuntimeError` is raised for invalid values of `flow_class`. Changed this to `ValueError`.