### PR TITLE
Make base flow abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NestedSampler` no longer checks capitalisation of `flow_class` when determining which proposal class to use. E.g. `'FlowProposal'` and `'flowproposal'` are now both valid values.
 - `NestedSampler.configure_flow_proposal` now raises `ValueError` instead of `RuntimeError` if `flow_class` is an invalid string.
 - Raise a `ValueError` if `nessai.plot.plot_1d_comparison` is called with a labels list and the length does not match the number of sets of live points being compared.
+- `nessai.flow.base.BaseFlow` now also inherits from `abc.ABC` and methods that should be defined by the user are abstract methods.
 
 
 ### Fixed

--- a/nessai/flows/base.py
+++ b/nessai/flows/base.py
@@ -2,10 +2,11 @@
 """
 Base objects for implementing normalising flows.
 """
+from abc import ABC, abstractmethod
 from torch.nn import Module
 
 
-class BaseFlow(Module):
+class BaseFlow(Module, ABC):
     """
     Base class for all normalising flows.
 
@@ -18,6 +19,7 @@ class BaseFlow(Module):
         self.device = device
         super().to(device)
 
+    @abstractmethod
     def forward(self, x, context=None):
         """
         Apply the forward transformation and return samples in the
@@ -33,6 +35,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def inverse(self, z, context=None):
         """
         Apply the inverse transformation and return samples in the
@@ -48,6 +51,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def sample(self, n, context=None):
         """
         Generate n samples in the data space
@@ -59,6 +63,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def log_prob(self, x, context=None):
         """
         Compute the log probability for a set of samples in the data space
@@ -70,6 +75,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def base_distribution_log_prob(self, z, context=None):
         """
         Computes the log probability of samples in the latent for
@@ -82,6 +88,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def forward_and_log_prob(self, x, context=None):
         """
         Apply the forward transformation and compute the log probability
@@ -96,6 +103,7 @@ class BaseFlow(Module):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def sample_and_log_prob(self, n, context=None):
         """
         Generates samples from the flow, together with their log probabilities

--- a/nessai/flows/base.py
+++ b/nessai/flows/base.py
@@ -142,16 +142,19 @@ class NFlow(BaseFlow):
     """
     def __init__(self, transform, distribution):
         super().__init__()
+        from nflows.transforms import Transform
+        from nflows.distributions import Distribution
 
-        for method in ['forward', 'inverse']:
-            if not hasattr(transform, method):
-                raise RuntimeError(
-                    f'Transform does not have `{method}` method')
+        if not isinstance(transform, Transform):
+            raise TypeError(
+                'transform must inherit from `nflows.transforms.Transform'
+            )
 
-        for method in ['log_prob', 'sample']:
-            if not hasattr(distribution, method):
-                raise RuntimeError(
-                    f'Distribution does not have `{method}` method')
+        if not isinstance(distribution, Distribution):
+            raise TypeError(
+                'distribution must inherit from '
+                '`nflows.transforms.Distribution'
+            )
 
         self._transform = transform
         self._distribution = distribution

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -5,7 +5,8 @@ Test the base flow class
 import pytest
 from unittest.mock import create_autospec, patch
 
-from nessai.flows import BaseFlow
+from nessai.flows import BaseFlow, NFlow
+from nflows.transforms import Transform
 
 
 @pytest.fixture
@@ -39,3 +40,23 @@ def test_base_flow_to(flow):
         BaseFlow.to(flow, 'cpu')
     super_init.assert_called_once_with('cpu')
     assert flow.device == 'cpu'
+
+
+def test_nflow_base_transform():
+    """Assert an error is raised if the transform class is invalid."""
+    class Test:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        NFlow(Test(), Test())
+    assert 'transform must inherit' in str(excinfo.value)
+
+
+def test_nflow_base_distribution():
+    """Assert an error is raised if the distribution class is invalid."""
+    class Test:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        NFlow(Transform(), Test())
+    assert 'distribution must inherit' in str(excinfo.value)

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -3,17 +3,30 @@
 Test the base flow class
 """
 import pytest
+from unittest.mock import create_autospec
 
 from nessai.flows import BaseFlow
 
 
-@pytest.mark.parametrize('method', ['forward', 'inverse', 'sample', 'log_prob',
-                                    'base_distribution_log_prob',
-                                    'forward_and_log_prob',
-                                    'sample_and_log_prob'])
-def test_base_flow_methods(method):
+@pytest.fixture
+def flow():
+    return create_autospec(BaseFlow)
+
+
+def test_base_flow_abstract_methods():
+    """Assert an error is raised if the methods are not implemented."""
+    with pytest.raises(TypeError) as excinfo:
+        BaseFlow()
+    assert 'instantiate abstract class BaseFlow with abstract method' \
+        in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    'method',
+    ['forward', 'inverse', 'sample', 'log_prob', 'base_distribution_log_prob',
+     'forward_and_log_prob', 'sample_and_log_prob']
+)
+def test_base_flow_methods(method, flow):
     """Test to make sure all of the method in the base class raise errors"""
-    m = getattr(BaseFlow(), method)
-    assert m
     with pytest.raises(NotImplementedError):
-        m(None)
+        getattr(BaseFlow, method)(flow, None)

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -3,7 +3,7 @@
 Test the base flow class
 """
 import pytest
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, patch
 
 from nessai.flows import BaseFlow
 
@@ -30,3 +30,12 @@ def test_base_flow_methods(method, flow):
     """Test to make sure all of the method in the base class raise errors"""
     with pytest.raises(NotImplementedError):
         getattr(BaseFlow, method)(flow, None)
+
+
+def test_base_flow_to(flow):
+    """Assert the to method works as intended"""
+    flow.device = None
+    with patch('nessai.flows.base.Module.to') as super_init:
+        BaseFlow.to(flow, 'cpu')
+    super_init.assert_called_once_with('cpu')
+    assert flow.device == 'cpu'


### PR DESCRIPTION
Makes the methods in `nessai.flows.base.BaseFlow` abstract methods so a class cannot be instantiated if the methods are not defined.