### PR TITLE
Tweak logit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NestedSampler.configure_flow_proposal` now raises `ValueError` instead of `RuntimeError` if `flow_class` is an invalid string.
 - Raise a `ValueError` if `nessai.plot.plot_1d_comparison` is called with a labels list and the length does not match the number of sets of live points being compared.
 - `nessai.flow.base.BaseFlow` now also inherits from `abc.ABC` and methods that should be defined by the user are abstract methods.
-
+- Changed default to `fuzz=1e-12` in `nessai.utils.rescaling.logit` and `nessai.utils.rescaling.sigmoid` and improved stability.
 
 ### Fixed
 
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `nessai.reparameterisations.RescaleToBounds` when using `offset=True` and `pre_rescaling` where the prime prior bounds were incorrectly set. ([!97](https://github.com/mj-will/nessai/pull/97))
 - Fixed a bug that prevented disabling periodic checkpointing.
 - Fixed a bug when calling `nessai.plot.plot_1d_comparison` with live points that contain a field with only infinite values.
+- Fixed the log Jacobian determinant for `nessai.utils.rescaling.logit` and `nessai.utils.rescaling.sigmoid` which previously did not include the Jacobian for the fuzz when it was used.
 
 
 ## [0.3.0] Testing, testing and more testing - 2021-07-05

--- a/tests/test_utils/test_rescaling_utils.py
+++ b/tests/test_utils/test_rescaling_utils.py
@@ -183,23 +183,25 @@ def test_sigmoid_bounds(x, y, log_J):
     assert sigmoid(x, fuzz=0) == (y, log_J)
 
 
-@pytest.mark.parametrize("p", [1e-5, 0.5, 1 - 1e-5])
-def test_logit_sigmoid(p):
+@pytest.mark.parametrize("p", [1e-5, 0.5, 1.0 - 1e-5])
+@pytest.mark.parametrize("fuzz", [False, 1e-12])
+def test_logit_sigmoid(p, fuzz):
     """
     Test invertibility of sigmoid(logit(x))
     """
-    x = logit(p, fuzz=0)
-    y = sigmoid(x[0], fuzz=0)
-    np.testing.assert_equal(p, y[0])
-    np.testing.assert_almost_equal(x[1] + y[1], 0)
+    x = logit(p, fuzz=fuzz)
+    y = sigmoid(x[0], fuzz=fuzz)
+    np.testing.assert_almost_equal(p, y[0], decimal=10)
+    np.testing.assert_almost_equal(x[1] + y[1], 0.0, decimal=10)
 
 
-@pytest.mark.parametrize("p", [-10, -1, 0, 1, 10])
-def test_sigmoid_logit(p):
+@pytest.mark.parametrize("p", [-10.0, -1.0, 0.0, 1.0, 10.0])
+@pytest.mark.parametrize("fuzz", [False, 1e-12])
+def test_sigmoid_logit(p, fuzz):
     """
     Test invertibility of logit(sigmoid(x))
     """
-    x = sigmoid(p, fuzz=0)
-    y = logit(x[0], fuzz=0)
-    np.testing.assert_almost_equal(p, y[0])
-    np.testing.assert_almost_equal(x[1] + y[1], 0)
+    x = sigmoid(p, fuzz=fuzz)
+    y = logit(x[0], fuzz=fuzz)
+    np.testing.assert_almost_equal(p, y[0], decimal=10)
+    np.testing.assert_almost_equal(x[1] + y[1], 0.0, decimal=10)


### PR DESCRIPTION
This PR tweaks the logit and sigmoid rescaling functions to fix a bug and change the default fuzz.

## Fixes

The log-Jacobian did not previously include the constant for the fuzz factor rescaling, this has been fixed.

## Changes

Change the default to `fuzz=1e-12`