### PR TITLE
Use torch default dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The dtype for tensors passed to the flow is now set using `torch.get_default_dtype()` rather than always using `float32`.
+
 ## [0.3.1] Minor improvements and bug fixes - 2021-08-23
 
 This release has a few minor improvements and bug fixes. It also explicitly adds support for python 3.9, which worked previously but was not tested.

--- a/nessai/flows/realnvp.py
+++ b/nessai/flows/realnvp.py
@@ -89,7 +89,7 @@ class RealNVP(NFlow):
             if mask.ndim == 2 and not mask.shape[0] == num_layers:
                 raise RuntimeError('Mask does not match number of layers')
 
-            mask = torch.from_numpy(mask.astype('float32'))
+            mask = torch.from_numpy(mask).type(torch.get_default_dtype())
 
         if mask.dim() == 1:
             mask_array = torch.empty([num_layers, features])


### PR DESCRIPTION
Switch to using `torch.get_default_dtype()` to set the dtype for tensors passed to the flow. This allows for the use of higher precision if desired.

For example

```python
torch.set_default_dtype(torch.float64)
```
will set the default to float64 which will then be used during training.