### PR TITLE
Remove symlog scale logX vs logL plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The dtype for tensors passed to the flow is now set using `torch.get_default_dtype()` rather than always using `float32`.
 - Incorrect values for `mask` in `nessai.flows.realnvp.RealNVP` now raise `ValueError` and improved the error messages returned by all the exceptions in the class.
+- Change scale of y-axis of the log-prior volume vs. log-likelihood plot from `symlog` to the default linear axis.
 
 
 ## [0.3.1] Minor improvements and bug fixes - 2021-08-23

--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -141,7 +141,6 @@ class _NSIntegralState:
         plt.xlabel('log prior-volume')
         plt.ylabel('log-likelihood')
         plt.xlim([self.log_vols[-1], self.log_vols[0]])
-        plt.yscale('symlog')
 
         if filename is not None:
             fig.savefig(filename, bbox_inches='tight')


### PR DESCRIPTION
The symmetric log scale on the logX vs logL could be misleading and hard to interpret. This MR removes it.

For example:

![image](https://user-images.githubusercontent.com/25609742/132028561-17209f27-9a72-479e-920f-d55e26571edb.png)

There appears to structure around logL=0 but this in fact just the symmetric log scale. Removing this produces:

![image](https://user-images.githubusercontent.com/25609742/132028841-6f6a5faa-2f05-46fc-a992-1c2812f6265c.png)

