### PR TITLE
Add logL and logP to trace plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dtype for tensors passed to the flow is now set using `torch.get_default_dtype()` rather than always using `float32`.
 - Incorrect values for `mask` in `nessai.flows.realnvp.RealNVP` now raise `ValueError` and improved the error messages returned by all the exceptions in the class.
 - Change scale of y-axis of the log-prior volume vs. log-likelihood plot from `symlog` to the default linear axis.
+`nessai.plot.plot_trace` now includes additional parameters such as `logL` and `logP` default, previously the last two parameters (assumed to be `logL` and `logP` were always excluded).
 
 
 ## [0.3.1] Minor improvements and bug fixes - 2021-08-23

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -294,8 +294,10 @@ def plot_loss(epoch, history, filename=None):
 
 
 def plot_trace(log_x, nested_samples, labels=None, filename=None):
-    """
-    Produce trace plot for all of the parameters.
+    """Produce trace plot for all of the parameters.
+
+    This includes all parameters in the sampler, not just those included in the
+    model being sampled.
 
     Parameters
     ----------
@@ -313,8 +315,7 @@ def plot_trace(log_x, nested_samples, labels=None, filename=None):
     if not nested_samples.dtype.names:
         raise TypeError('Nested samples must be a structured array')
 
-    names = nested_samples.dtype.names[:-2]
-
+    names = nested_samples.dtype.names
     if labels is None:
         labels = names
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -9,7 +9,6 @@ import pytest
 from unittest.mock import patch
 
 from nessai import plot
-from nessai.livepoint import numpy_array_to_live_points
 
 
 @pytest.fixture()
@@ -270,9 +269,7 @@ def test_trace_plot_save(nested_samples, save, tmpdir):
 def test_trace_plot_1d(nested_samples):
     """Test trace plot with only one parameter"""
     log_x = np.linspace(-10, 0, nested_samples.size)
-    nested_samples = numpy_array_to_live_points(
-        np.random.randn(log_x.size, 1), ['x'])
-    plot.plot_trace(log_x, nested_samples)
+    plot.plot_trace(log_x, nested_samples[['x']])
     plt.close()
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -289,8 +289,8 @@ def test_trace_plot_unstructured():
     assert 'structured array' in str(excinfo.value)
 
 
-@pytest.mark.parametrize('labels', [None, ['x', 'y']])
-def test_trace_plot_labels(nested_samples, labels, tmpdir):
+@pytest.mark.parametrize('labels', [None, ['x', 'y', 'logL', 'logP']])
+def test_trace_plot_labels(nested_samples, labels):
     """Test trace plot generation with labels."""
     log_x = np.linspace(-10, 0, nested_samples.size)
     plot.plot_trace(log_x, nested_samples, labels=labels)


### PR DESCRIPTION
The current trace plot excluded `logL` and `logP`,  these parameters can be useful when diagnosing issues during sampling.

This PR includes these parameters in the plot by default (and any other parameters that may be added in the future) and updates the corresponding unit tests.

The previous behaviour can be replicated by selecting fields in the samples prior to passing them to `plot_trace`, e.g. `plot_trace(x[['x', 'y']])` to only plot x and y.