### PR TITLE
Fix AnglePair prior bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added more checks to the init method for `nessai.reparameterisations.AnglePair` to catch invalid combinations of priors and/or angle conventions. Now supports RA or azimuth defined on [-pi, pi] in addition to [0, 2pi].
+
+
 ### Changed
 
 - The dtype for tensors passed to the flow is now set using `torch.get_default_dtype()` rather than always using `float32`.
 - Incorrect values for `mask` in `nessai.flows.realnvp.RealNVP` now raise `ValueError` and improved the error messages returned by all the exceptions in the class.
 - Change scale of y-axis of the log-prior volume vs. log-likelihood plot from `symlog` to the default linear axis.
 `nessai.plot.plot_trace` now includes additional parameters such as `logL` and `logP` default, previously the last two parameters (assumed to be `logL` and `logP` were always excluded).
+
+
+### Fixed
+
+- Fixed an issue where `nessai.reparameterisations.AnglePair` would silently break when the prior range for RA or azimuth was set to a range that wasn't [0, 2pi]. It now correctly handles both [0, 2pi] and [-pi, pi] and raises an error for any other ranges.
 
 
 ## [0.3.1] Minor improvements and bug fixes - 2021-08-23

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -1128,11 +1128,13 @@ class AnglePair(Reparameterisation):
 
         if convention is None:
             logger.debug('Trying to determine convention')
-            if (self.prior_bounds[self.parameters[1]][0] == 0 and
-                    self.prior_bounds[self.parameters[1]][1] == np.pi):
+            if np.array_equal(
+                self.prior_bounds[self.parameters[1]], [0, np.pi]
+            ):
                 self.convention = 'az-zen'
-            elif (self.prior_bounds[self.parameters[1]][0] == -np.pi / 2 and
-                    self.prior_bounds[self.parameters[1]][1] == np.pi / 2):
+            elif np.array_equal(
+                self.prior_bounds[self.parameters[1]], [-np.pi / 2, np.pi / 2]
+            ):
                 self.convention = 'ra-dec'
             else:
                 raise RuntimeError(

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -1040,6 +1040,12 @@ class AnglePair(Reparameterisation):
     If the radial component is not specified, it is sampled from a chi-
     distribution with three degrees of freedom.
 
+    Notes
+    -----
+    The parameters will be reordered such that the first parameter is the angle
+    along the horizon, the second parameter is the vertical angle and the last
+    parameter is the radial parameter.
+
     Parameters
     -----------
     parameters : list
@@ -1164,22 +1170,30 @@ class AnglePair(Reparameterisation):
 
     @property
     def angles(self):
+        """Names of the two angles.
+
+        Order is: angle along the horizon, vertical angle.
+        """
         return self.parameters[:2]
 
     @property
     def radial(self):
+        """Name of the radial parameter"""
         return self.parameters[-1]
 
     @property
     def x(self):
+        """Name of the first Cartesian coordinate"""
         return self.prime_parameters[0]
 
     @property
     def y(self):
+        """Name of the second Cartesian coordinate"""
         return self.prime_parameters[1]
 
     @property
     def z(self):
+        """Name of the third Cartesian coordinate"""
         return self.prime_parameters[2]
 
     def _az_zen(self, x, x_prime, log_j, r):

--- a/tests/test_reparameterisations/test_angle_pair.py
+++ b/tests/test_reparameterisations/test_angle_pair.py
@@ -3,15 +3,19 @@
 Test the AnglePair reparmeterisation
 """
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
+from unittest.mock import MagicMock, create_autospec
 
 from nessai.reparameterisations import AnglePair
-from nessai.livepoint import get_dtype
+from nessai.livepoint import get_dtype, parameters_to_live_point
 
-angle_pairs = [(['ra', 'dec'], [[0, 2 * np.pi], [-np.pi / 2, np.pi / 2]]),
-               (['az', 'zen'], [[0, 2 * np.pi], [0, np.pi]]),
-               (['zen', 'az'], [[0, np.pi], [0, 2 * np.pi]])]
+angle_pairs = [
+    (['ra', 'dec'], [[0, 2 * np.pi], [-np.pi / 2, np.pi / 2]]),
+    (['dec', 'ra'], [[0, 2 * np.pi], [-np.pi / 2, np.pi / 2]]),
+    (['ra', 'dec'], [[-np.pi, np.pi], [-np.pi / 2, np.pi / 2]]),
+    (['az', 'zen'], [[0, 2 * np.pi], [0, np.pi]]),
+    (['zen', 'az'], [[0, np.pi], [0, 2 * np.pi]])
+]
 
 
 @pytest.fixture(params=angle_pairs, scope='function')
@@ -88,8 +92,7 @@ def test_two_angles(angles):
         assert reparam.convention == 'az-zen'
 
     # Make sure parameter[0] is always ra or azimuth
-    assert_equal(reparam.prior_bounds[reparam.angles[0]],
-                 np.array([0, 2 * np.pi]))
+    assert np.ptp(reparam.prior_bounds[reparam.angles[0]]) == 2 * np.pi
 
     assert reparam.chi is not False
     assert hasattr(reparam.chi, 'rvs')
@@ -154,3 +157,233 @@ def test_w_radial(assert_invertibility):
     radial = np.random.uniform(*prior_bounds['r'], n)
 
     assert assert_invertibility(reparam, angles, radial=radial)
+
+
+@pytest.mark.parametrize(
+    'convention, input, expected',
+    [
+        ['az-zen', (1, 0, 0), (0, np.pi / 2, 1)],
+        ['ra-dec', (1, 0, 0), (0, 0, 1)],
+        ['az-zen', (-1, 0, 0), (np.pi, np.pi / 2, 1)],
+        ['ra-dec', (-1, 0, 0), (np.pi, 0, 1)],
+        ['az-zen', (0, 1, 0), (np.pi / 2, np.pi / 2, 1)],
+        ['ra-dec', (0, 1, 0), (np.pi / 2, 0, 1)],
+        ['az-zen', (0, -1, 0), (3 * np.pi / 2, np.pi / 2, 1)],
+        ['ra-dec', (0, -1, 0), (3 * np.pi / 2, 0, 1)],
+        ['az-zen', (0, 0, 1), (0, 0, 1)],
+        ['ra-dec', (0, 0, 1), (0, np.pi / 2, 1)],
+        ['az-zen', (0, 0, -1), (0, np.pi, 1)],
+        ['ra-dec', (0, 0, -1), (0, -np.pi / 2, 1)],
+        ['az-zen', (0, 0, 0), (0, 0, 0)],
+        ['ra-dec', (0, 0, 0), (0, 0, 0)],
+        ['az-zen', (1, 1, np.sqrt(2)), (np.pi / 4, np.pi / 4, 2)],
+        ['ra-dec', (1, 1, np.sqrt(2)), (np.pi / 4, np.pi / 4, 2)],
+        ['az-zen', (-1, -1, -np.sqrt(2)), (5 * np.pi / 4, 3 * np.pi / 4, 2)],
+        ['ra-dec', (-1, -1, -np.sqrt(2)), (5 * np.pi / 4, -np.pi / 4, 2)],
+    ]
+)
+def test_specific_points_x_prime_to_x_0_2pi(convention, input, expected):
+    """Test specific points on a sphere.
+
+    Order is (x, y, z) to (ra/az, dec/zen, r) using [0, 2pi] for ra/az.
+
+    Test:
+    - (+/-1, 0, 0) and all permutations
+    - (0, 0, 0)
+    - (+/-1, +-1, sqrt(2)) a point exactly 2 away from the origin
+    """
+    parameters = ['a', 'b']
+    if convention == 'ra-dec':
+        prior_bounds = {'a': [0, 2 * np.pi], 'b': [-np.pi / 2, np.pi / 2]}
+    else:
+        prior_bounds = {'a': [0, 2 * np.pi], 'b': [0, np.pi]}
+    reparam = AnglePair(
+        parameters=parameters,
+        prior_bounds=prior_bounds,
+        convention=convention,
+    )
+
+    x_prime = parameters_to_live_point(input, reparam.prime_parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.parameters)
+    log_j = 0
+
+    out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)
+
+    np.testing.assert_equal(out[reparam.parameters[0]], expected[0])
+    np.testing.assert_equal(out[reparam.parameters[1]], expected[1])
+    np.testing.assert_equal(out[reparam.parameters[2]], expected[2])
+
+
+@pytest.mark.parametrize(
+    'convention, input, expected',
+    [
+        ['az-zen', (1, 0, 0), (0, np.pi / 2, 1)],
+        ['ra-dec', (1, 0, 0), (0, 0, 1)],
+        ['az-zen', (-1, 0, 0), (np.pi, np.pi / 2, 1)],
+        ['ra-dec', (-1, 0, 0), (np.pi, 0, 1)],
+        ['az-zen', (0, 1, 0), (np.pi / 2, np.pi / 2, 1)],
+        ['ra-dec', (0, 1, 0), (np.pi / 2, 0, 1)],
+        ['az-zen', (0, -1, 0), (- np.pi / 2, np.pi / 2, 1)],
+        ['ra-dec', (0, -1, 0), (- np.pi / 2, 0, 1)],
+        ['az-zen', (0, 0, 1), (0, 0, 1)],
+        ['ra-dec', (0, 0, 1), (0, np.pi / 2, 1)],
+        ['az-zen', (0, 0, -1), (0, np.pi, 1)],
+        ['ra-dec', (0, 0, -1), (0, -np.pi / 2, 1)],
+        ['az-zen', (0, 0, 0), (0, 0, 0)],
+        ['ra-dec', (0, 0, 0), (0, 0, 0)],
+        ['az-zen', (1, 1, np.sqrt(2)), (np.pi / 4, np.pi / 4, 2)],
+        ['ra-dec', (1, 1, np.sqrt(2)), (np.pi / 4, np.pi / 4, 2)],
+        ['az-zen', (-1, -1, -np.sqrt(2)), (-3 * np.pi / 4, 3 * np.pi / 4, 2)],
+        ['ra-dec', (-1, -1, -np.sqrt(2)), (-3 * np.pi / 4, -np.pi / 4, 2)],
+    ]
+)
+def test_specific_points_x_prime_to_x_pi_pi(convention, input, expected):
+    """Test specific points on a sphere.
+
+    Order is (x, y, z) to (ra/az, dec/zen, r) using [-pi, pi] for ra/az.
+
+    Test:
+    - (+/-1, 0, 0) and all permutations
+    - (0, 0, 0)
+    - (+/-1, +-1, sqrt(2)) a point exactly 2 away from the origin
+    """
+    parameters = ['a', 'b']
+    if convention == 'ra-dec':
+        prior_bounds = {'a': [-np.pi, np.pi], 'b': [-np.pi / 2, np.pi / 2]}
+    else:
+        prior_bounds = {'a': [-np.pi, np.pi], 'b': [0, np.pi]}
+    reparam = AnglePair(
+        parameters=parameters,
+        prior_bounds=prior_bounds,
+        convention=convention,
+    )
+
+    x_prime = parameters_to_live_point(input, reparam.prime_parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.parameters)
+    log_j = 0
+
+    out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)
+
+    np.testing.assert_equal(out[reparam.parameters[0]], expected[0])
+    np.testing.assert_equal(out[reparam.parameters[1]], expected[1])
+    np.testing.assert_equal(out[reparam.parameters[2]], expected[2])
+
+
+@pytest.mark.parametrize(
+    'prior_bounds',
+    [
+        {'ra': [0, np.pi], 'dec':  [-np.pi / 2, np.pi / 2]},
+        {'ra': [0, 2 * np.pi], 'dec':  [-np.pi, np.pi]},
+    ]
+)
+def test_invalid_prior_ranges(prior_bounds):
+    """Assert an error is raised the prior ranges are invalid"""
+    with pytest.raises(ValueError) as excinfo:
+        AnglePair(parameters=['ra', 'dec'], prior_bounds=prior_bounds)
+    assert 'Invalid prior ranges' in str(excinfo.value)
+
+
+def test_invalid_prior_bounds_az():
+    """Assert an error is raised the prior bounds are invalid"""
+    prior_bounds = {'az': [np.pi, 3 * np.pi], 'zen': [0, np.pi]}
+    with pytest.raises(ValueError) as excinfo:
+        AnglePair(parameters=['az', 'zen'], prior_bounds=prior_bounds)
+    assert 'Prior bounds for az must be' in str(excinfo.value)
+
+
+def test_invalid_prior_bounds_inc():
+    """Assert an error is raised the prior bounds are invalid for the \
+        inclination angle.
+    """
+    prior_bounds = {'ra': [0.0, 2 * np.pi], 'dec': [0, np.pi]}
+    with pytest.raises(ValueError) as excinfo:
+        AnglePair(
+            parameters=['ra', 'dec'], prior_bounds=prior_bounds,
+            convention='ra-dec'
+        )
+    assert 'Prior bounds for dec must be' in str(excinfo.value)
+
+
+def test_unknown_prior():
+    """Assert an unknown prior raises an error"""
+    with pytest.raises(ValueError) as excinfo:
+        AnglePair(
+            parameters=['az', 'zen'],
+            prior_bounds={'az': [0.0, 2 * np.pi], 'zen': [0.0, np.pi]},
+            convention='az-zen',
+            prior='uniform',
+        )
+    assert "Unknown prior: `uniform`. Choose from: ['isotropic', None]" \
+        in str(excinfo.value)
+
+
+def test_unknown_convention():
+    """Assert an unknown convetion raises an error"""
+    with pytest.raises(ValueError) as excinfo:
+        AnglePair(
+            parameters=['az', 'zen'],
+            prior_bounds={'az': [0.0, 2 * np.pi], 'zen': [0.0, np.pi]},
+            convention='sky',
+        )
+    assert "Unknown convention: `sky`. Choose from: ['az-zen', 'ra-dec']" \
+        in str(excinfo.value)
+
+
+def test_log_prior():
+    """Assert log_prior calls the log pdf of a chi distribution."""
+    reparam = create_autospec(AnglePair)
+    reparam.parameters = ['a', 'b', 'r']
+    reparam.has_prior = True
+    x = parameters_to_live_point([0, 0, 2.0], reparam.parameters)
+    reparam.chi = MagicMock()
+    reparam.chi.logpdf = MagicMock(return_value=1.0)
+    out = AnglePair.log_prior(reparam, x)
+    reparam.chi.assert_not_called()
+    reparam.chi.logpdf.assert_called_once_with(x['r'])
+    assert out == 1.0
+
+
+def test_log_prior_radial():
+    """Assert log_prior raises an error if chi is False"""
+    reparam = create_autospec(AnglePair)
+    reparam.chi = False
+    reparam.has_prior = True
+    with pytest.raises(RuntimeError) as excinfo:
+        AnglePair.log_prior(reparam, 1)
+    assert 'log_prior is not defined' in str(excinfo.value)
+
+
+def test_log_prior_has_prior():
+    """Assert log_prior raises an error if has_prior is False.
+
+    This shouldn't be possible unless the user defines `chi`.
+    """
+    reparam = create_autospec(AnglePair)
+    reparam.chi = True
+    reparam.has_prior = False
+    with pytest.raises(RuntimeError) as excinfo:
+        AnglePair.log_prior(reparam, 1)
+    assert 'log_prior is not defined' in str(excinfo.value)
+
+
+def test_x_prime_log_prior():
+    """Test the x prime prior"""
+    reparam = create_autospec(AnglePair)
+    reparam.prime_parameters = ['x', 'y', 'z']
+    reparam.has_prime_prior = True
+    x = parameters_to_live_point([1, 1, 1], reparam.prime_parameters)
+    # Should be -1.5 * log(2pi) - 1.5
+    expected = -1.5 * (1 + np.log(2 * np.pi))
+    out = AnglePair.x_prime_log_prior(reparam, x)
+    np.testing.assert_equal(out, expected)
+
+
+def test_prime_prior_error():
+    """Assert an error is raised if calling the prime prior and \
+        has prime prior is false.
+    """
+    reparam = create_autospec(AnglePair)
+    reparam.has_prime_prior = False
+    with pytest.raises(RuntimeError) as excinfo:
+        AnglePair.x_prime_log_prior(reparam, 1)
+    assert 'x prime prior is not defined' in str(excinfo.value)


### PR DESCRIPTION
Closes #113.

Opted to correctly handle the case of RA or azimuth defined on `[-pi, pi]` by adding a flag that includes the modulo 2 pi that was already present only when needed.

Also adds the following for `nessai.reparameterisations.AnglePair`:
- Explicit checks for invalid prior ranges for both angles and conventions
- Improved doc-string
- More tests for this class