### PR TITLE
Pin bilby-requirement for Python 3.6

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,5 +5,5 @@ pytest-cov
 pytest-integration
 pre-commit
 lalsuite
-bilby
+bilby<=1.1.3 ; python_version == '3.6'
 astropy


### PR DESCRIPTION
Try to fix the tests for Python 3.6 by setting the bilby version