### PR TITLE
Add constant volume mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- Add a constant volume mode to `FlowProposal`. In this mode the radius of the latent contour is fixed to the q'th quantile, which by default is `0.95`.
+
 ### Fixed
 
 - Fixed a bug in `nessai.livepoint.dict_to_live_points` when passing a dictionary where the entries contained floats instead of objects with a length raised an error.

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -439,7 +439,7 @@ class FlowProposal(RejectionProposal):
             if not self.latent_prior == 'truncated_gaussian':
                 raise RuntimeError(
                     "Constant volume requires "
-                    "`latent_prior='truncated_gaussian'"
+                    "`latent_prior='truncated_gaussian'`"
                 )
             self.fixed_radius = compute_radius(
                 self.rescaled_dims, self.volume_fraction

--- a/nessai/utils/__init__.py
+++ b/nessai/utils/__init__.py
@@ -28,6 +28,7 @@ from .rescaling import (
     sigmoid
 )
 from .sampling import (
+    compute_radius,
     draw_gaussian,
     draw_nsphere,
     draw_surface_nsphere,
@@ -47,6 +48,7 @@ __all__ = [
     'bonferroni_correction',
     'compute_indices_ks_test',
     'compute_minimum_distances',
+    'compute_radius',
     'configure_edge_detection',
     'configure_threads',
     'detect_edge',

--- a/nessai/utils/sampling.py
+++ b/nessai/utils/sampling.py
@@ -6,6 +6,27 @@ import numpy as np
 from scipy import stats
 
 
+def compute_radius(n, q=0.95):
+    """Compute the radius that contains a fraction of the total probability \
+         in an n-dimensional unit Gaussian.
+
+    Uses the inverse CDF of a chi-distribution with n degrees of freedom.
+
+    Parameters
+    ----------
+    n : int
+        Number of dimensions
+    q : float
+        Fraction of the total probability
+
+    Returns
+    -------
+    float
+        Radius
+    """
+    return stats.chi.ppf(q, n)
+
+
 def draw_surface_nsphere(dims, r=1, N=1000):
     """
     Draw N points uniformly from  n-1 sphere of radius r using Marsaglia's

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_configuration.py
@@ -143,6 +143,18 @@ def test_configure_constant_volume_disabled(proposal):
     mock.assert_not_called()
 
 
+def test_constant_volume_invalid_latent_prior(proposal):
+    """Assert an error is raised if the latent prior is not a truncated \
+        Gaussian
+    """
+    err = "Constant volume requires `latent_prior='truncated_gaussian'`"
+    proposal.constant_volume_mode = True
+    proposal.latent_prior = 'gaussian'
+    with pytest.raises(RuntimeError) as excinfo:
+        FlowProposal.configure_constant_volume(proposal)
+    assert str(excinfo.value) == err
+
+
 @pytest.mark.parametrize('inversion, parameters',
                          [(True, ['x', 'y']), (False, []), (['x'], ['x'])])
 def test_set_boundary_inversion(proposal, inversion, parameters):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
@@ -67,3 +67,28 @@ def test_training(tmpdir, model, plot):
 
     assert fp.training_count == 1
     assert fp.populated is False
+
+
+@pytest.mark.integration_test
+def test_constant_volume_mode(tmpdir, model):
+    """Integration test for constant volume mode.
+
+    With q=0.8647 should get a radius of ~2.
+    """
+    output = str(tmpdir.mkdir('flowproposal'))
+    expected_radius = 2.0
+    fp = FlowProposal(
+        model,
+        output=output,
+        plot=False,
+        poolsize=100,
+        constant_volume_mode=True,
+        volume_fraction=0.8647,
+    )
+    fp.initialise()
+    worst = numpy_array_to_live_points(0.5 * np.ones(fp.dims), fp.names)
+    fp.populate(worst, N=100)
+    assert fp.x.size == 100
+
+    np.testing.assert_approx_equal(fp.r, expected_radius, 4)
+    np.testing.assert_approx_equal(fp.fixed_radius, expected_radius, 4)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -206,3 +206,18 @@ def test_sampling_with_infinite_prior_bounds(tmpdir):
     )
     fs.run(plot=False)
     assert fs.ns.condition <= 0.1
+
+
+@pytest.mark.slow_integration_test
+def test_constant_volume_mode(model, tmpdir):
+    """Test sampling in constant volume mode"""
+    output = str(tmpdir.mkdir('test'))
+    fs = FlowSampler(
+        model,
+        output=output,
+        nlive=500,
+        plot=False,
+        proposal_plots=False,
+        constant_volume_mode=True
+    )
+    fs.run(plot=False)

--- a/tests/test_utils/test_sampling_utils.py
+++ b/tests/test_utils/test_sampling_utils.py
@@ -8,12 +8,43 @@ from scipy import stats
 from unittest.mock import patch
 
 from nessai.utils.sampling import (
+    compute_radius,
     draw_gaussian,
     draw_nsphere,
     draw_surface_nsphere,
     draw_truncated_gaussian,
     draw_uniform,
 )
+
+
+def test_compute_radius():
+    """Assert compute radius calls the correct function"""
+    with patch('scipy.stats.chi.ppf') as mock:
+        compute_radius(2, 0.95)
+    mock.assert_called_once_with(0.95, 2)
+
+
+@pytest.mark.parametrize(
+    "d, q, r",
+    [
+        [1, 0.6827, 1.0],
+        [1, 0.9545, 2.0],
+        [2, 0.3935, 1.0],
+        [5, 0.8909, 3.0],
+        [10, 0.9004, 4.0]
+    ]
+)
+def test_compute_radius_integration(d, q, r):
+    """Assert compute radius returns the expected value.
+
+    Checks that for a given confidence level the correct radius is returned,
+    values checked correspond to standard deviations.
+
+    Values for q taken from: \
+        https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4358977/
+    """
+    r_out = compute_radius(d, q)
+    np.testing.assert_almost_equal(r_out, r, decimal=4)
 
 
 @pytest.mark.parametrize("ndims, radius", [(2, 1), (10, 2), (10, 10), (1, 1)])


### PR DESCRIPTION
Add a constant volume mode to `FlowProposal`. In this mode the radius of the latent contour is fixed to the q'th quantile of an n-dimensional Gaussian, which by default is `0.95`.