### PR TITLE
Add periodic reparameterisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `angle-cosine` reparameterisation.
 - Added an explicit check for one-dimensional models that raises a custom exception `OneDimensionalModelError`.
 - `RealNVP` and `NeuralSplineFlow` now raise an error if `features<=1`.
+- Add option in `nessai.reparameterisations.Angle` to set `scale=None`, the scale is then set as `2 * pi / angle_prior_range`.
+- Add `'periodic'` reparameterisation that uses `scale=None` in `nessai.reparameterisations.Angle`.
 
 ### Changed
 
@@ -32,7 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework `AugmentedFlowProposal` to work with the new defaults.
 - `Model.names` and `Model.bounds` are now properties by default and their setters include checks to verify the values provided are valid and raise errors if not.
 
-## Deprecated
+### Fixed
+
+- Fixed a bug where the parameters list passed to `Reparameterisation` (or its child classes) wasn't being copied and changes made within the reparameterisation would change the original list.
+
+### Deprecated
 
 - `keep_samples` in `FlowProposal` will be removed in the next minor release.
 

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -866,7 +866,7 @@ class Angle(Reparameterisation):
         `reparameterisations`.
     scale : float, optional
         Value used to rescale the angle before converting to Cartesian
-        coordinates.
+        coordinates. If None the scale will be set to 2pi / prior_bounds.
     prior : {'uniform', 'sine', None}
         Type of prior being used for sampling this angle. If specified, the
         prime prior is enabled. If None then it is disabled.
@@ -886,7 +886,11 @@ class Angle(Reparameterisation):
         else:
             raise RuntimeError('Too many parameters for Angle')
 
-        self.scale = scale
+        if scale is None:
+            logger.debug('Scale is None, using 2pi / prior_range')
+            self.scale = 2.0 * np.pi / np.ptp(self.prior_bounds[self.angle])
+        else:
+            self.scale = scale
 
         if prior_bounds[self.angle][0] == 0:
             self._zero_bound = True

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -98,7 +98,7 @@ class Reparameterisation:
             raise TypeError('Parameters must be a str or list.')
 
         self.parameters = \
-            [parameters] if isinstance(parameters, str) else parameters
+            [parameters] if isinstance(parameters, str) else parameters.copy()
 
         if isinstance(prior_bounds, (list, tuple, np.ndarray)):
             if len(prior_bounds) == 2:

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -1343,6 +1343,7 @@ default_reparameterisations = {
     'angle-sine': (RescaleToBounds, None),
     'angle-cosine': (RescaleToBounds, None),
     'angle-pair': (AnglePair, None),
+    'periodic': (Angle, {'scale': None}),
     'to-cartesian': (ToCartesian, None),
     'none': (NullReparameterisation, None),
     'null': (NullReparameterisation, None),

--- a/tests/test_reparameterisations/test_angle.py
+++ b/tests/test_reparameterisations/test_angle.py
@@ -7,7 +7,7 @@ import pytest
 from unittest.mock import MagicMock, create_autospec
 
 from nessai.reparameterisations import Angle
-from nessai.livepoint import get_dtype
+from nessai.livepoint import get_dtype, parameters_to_live_point
 
 scales = [1.0, 2.0]
 
@@ -63,15 +63,28 @@ def assert_invertibility(model, n=100):
     return test_invertibility
 
 
-def test_angle_parameter():
+@pytest.mark.parametrize(
+    'bounds, scale, expected_scale',
+    [
+        ([0, 2 * np.pi], None, 1.0),
+        ([-1, 1], None, np.pi),
+        ([0, np.pi], 1.0, 1.0),
+    ]
+)
+def test_angle_parameter(bounds, scale, expected_scale):
     """Test init with just an angle parameter"""
     parameter = 'theta'
-    prior_bounds = {parameter: np.array([0, 2 * np.pi])}
-    reparam = Angle(parameters=parameter, prior_bounds=prior_bounds)
+    prior_bounds = {parameter: bounds}
+    reparam = Angle(
+        parameters=parameter, prior_bounds=prior_bounds, scale=scale
+    )
 
     assert reparam.chi is not False
     assert hasattr(reparam.chi, 'rvs')
-    assert reparam._zero_bound is True
+    if bounds[0] == 0.0:
+        assert reparam._zero_bound is True
+    else:
+        assert reparam._zero_bound is False
     assert reparam.has_prime_prior is False
 
     assert reparam.angle == parameter
@@ -79,6 +92,19 @@ def test_angle_parameter():
     assert reparam.radius == (parameter + '_radial')
     assert reparam.x == (parameter + '_x')
     assert reparam.y == (parameter + '_y')
+    assert reparam.scale == expected_scale
+
+
+def test_angle_too_many_parameters(reparam):
+    """Assert an error is raised if too many parameters are given."""
+    parameters = ['x', 'y', 'z']
+    prior_bounds = {p: [-1, 1] for p in parameters}
+    with pytest.raises(RuntimeError) as excinfo:
+        Angle.__init__(
+            reparam, parameters=parameters, prior_bounds=prior_bounds
+        )
+    assert reparam.parameters == parameters
+    assert 'Too many parameters for Angle' in str(excinfo.value)
 
 
 def test_angle_prior_uniform():
@@ -175,3 +201,35 @@ def test_invertiblity_both_parameters(angle_prior,
     angle = np.random.uniform(*prior_bounds[parameters[0]], n)
     radial = np.random.uniform(*prior_bounds[parameters[1]], n)
     assert assert_invertibility(reparam, angle, radial=radial)
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize(
+    'value, output_x, output_y',
+    [
+        (-1.0, None, 0.0),
+        (1.0, None, 0.0),
+        (-0.5, 0.0, None),
+        (0.5, 0.0, None),
+    ]
+)
+def test_periodic_parameter(value, output_x, output_y):
+    """Test a generic periodic parameter"""
+    parameters = ['a']
+    prior_bounds = {'a': [-1.0, 1.0]}
+    reparam = Angle(
+        parameters=parameters, prior_bounds=prior_bounds, scale=None
+    )
+    x = parameters_to_live_point((value,), parameters)
+    x_prime = parameters_to_live_point(
+        (np.nan, np.nan), reparam.prime_parameters
+    )
+    log_j = np.zeros(x.size)
+    x_out, x_prime_out, log_j_out = reparam.reparameterise(x, x_prime, log_j)
+
+    np.testing.assert_array_equal(x_out, x)
+
+    if output_x:
+        assert x_prime_out[reparam.x] == output_x
+    if output_y:
+        assert x_prime_out[reparam.y] == output_y

--- a/tests/test_reparameterisations/test_get_reparameterisation.py
+++ b/tests/test_reparameterisations/test_get_reparameterisation.py
@@ -41,6 +41,7 @@ known_reparameteristions = [
     ('angle', Angle, {}),
     ('angle-pi', Angle, {'scale': 2.0, 'prior': 'uniform'}),
     ('angle-2pi', Angle, {'scale': 1.0, 'prior': 'uniform'}),
+    ('periodic', Angle, {'scale': None}),
     ('angle-sine', RescaleToBounds, {}),
     ('angle-cosine', RescaleToBounds, {}),
     ('angle-pair', AnglePair, {}),


### PR DESCRIPTION
I recently realised that the `time_jitter` used in the time marginalisation for CBC signals in `bilby` is actually a periodic parameter (see [here](https://git.ligo.org/lscsoft/bilby/-/blob/1.1.4/bilby/gw/likelihood.py#L164)). This prompted me to add a generic reparameterisation for parameters that aren't periodic on [0, pi] or [0, 2pi].

The scale for generic periodic parameters is set as 2pi / angle_prior_range, for example for a parameter that is periodic on [-1, 1] the scale should be pi. This behaviour is enabled by setting `scale=None`.

**Bug fix**
This PR also fixes a minor bug in all reparameterisations when `parameters=<some list>`: the list is not copied to changes to the parameters made in the reparameterisation will be reflect in the original list. This could lead to unexpected behaviour if that list is used in other parts of the code.

