### PR TITLE
Propagate logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default optimiser is now `adamw`.
 - Rework `AugmentedFlowProposal` to work with the new defaults.
 - `Model.names` and `Model.bounds` are now properties by default and their setters include checks to verify the values provided are valid and raise errors if not.
+- Logger now has propagation enabled by default.
 
 ### Fixed
 

--- a/nessai/utils/logging.py
+++ b/nessai/utils/logging.py
@@ -55,7 +55,7 @@ def setup_logger(output=None, label='nessai', log_level='WARNING'):
                     os.makedirs(output, exist_ok=True)
             else:
                 output = '.'
-            log_file = '{}/{}.log'.format(output, label)
+            log_file = os.path.join(output, f'{label}.log')
             file_handler = logging.FileHandler(log_file)
             file_handler.setFormatter(logging.Formatter(
                 '%(asctime)s %(levelname)-8s: %(message)s', datefmt='%H:%M'))

--- a/nessai/utils/logging.py
+++ b/nessai/utils/logging.py
@@ -11,7 +11,7 @@ def setup_logger(output=None, label='nessai', log_level='WARNING'):
     Setup the logger.
 
     Based on the implementation in Bilby:
-    https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/core/utils.py#L448
+    https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/core/utils/log.py
 
     Parameters
     ----------

--- a/nessai/utils/logging.py
+++ b/nessai/utils/logging.py
@@ -37,7 +37,6 @@ def setup_logger(output=None, label='nessai', log_level='WARNING'):
         level = int(log_level)
 
     logger = logging.getLogger('nessai')
-    logger.propagate = False
     logger.setLevel(level)
 
     if any([type(h) == logging.StreamHandler for h in logger.handlers]) \


### PR DESCRIPTION
The logger in `nessai` currently has `propagate=False`. The standard logging library has this set to `True` by default and we only use `False` as a carry-over from the `bilby` function it's based on. Given that we only ever create a single logger, I don't think we need this to set explicitly and we're better leaving it to the default value.

This also makes it easier to check the logging output in the unit tests using pytest's `caplog` .

From some quick tests this doesn't seem to change any with the logging in either standard `nessai` or `bilby` + `nessai`.