### PR TITLE
Use GW reparameterisations by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RealNVP` and `NeuralSplineFlow` now raise an error if `features<=1`.
 - Add option in `nessai.reparameterisations.Angle` to set `scale=None`, the scale is then set as `2 * pi / angle_prior_range`.
 - Add `'periodic'` reparameterisation that uses `scale=None` in `nessai.reparameterisations.Angle`.
+- Add the `use_default_reparameterisations` option to `FlowProposal` to allow the use of the default reparameterisations in `GWFlowProposal` without specifying any reparameterisations.
 
 ### Changed
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework `AugmentedFlowProposal` to work with the new defaults.
 - `Model.names` and `Model.bounds` are now properties by default and their setters include checks to verify the values provided are valid and raise errors if not.
 - Logger now has propagation enabled by default.
+- `FlowProposal.configure_reparameterisations` can now handle an input of `None`. In this case only the default reparameterisations will be added.
 
 ### Fixed
 

--- a/nessai/gw/proposal.py
+++ b/nessai/gw/proposal.py
@@ -36,6 +36,15 @@ class GWFlowProposal(FlowProposal):
         'a_2': ('to-cartesian', None),
         'luminosity_distance': ('distance', None),
     }
+    """
+    Dictionary of aliases used to determine the default reparameterisations
+    for common gravitational-wave parameters.
+    """
+    use_default_reparameterisations = True
+    """
+    GW specific reparameterisations will be used by default. This is different
+    to the parent class where they are disabled by default.
+    """
 
     def get_reparameterisation(self, reparameterisation):
         """Function to get reparameterisations that checks GW defaults and

--- a/tests/test_gw/test_gw_proposal.py
+++ b/tests/test_gw/test_gw_proposal.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test the GW flow proposal method"""
+from math import pi
 import pytest
 from unittest.mock import create_autospec, MagicMock, patch
 
@@ -95,3 +96,29 @@ def test_augmented_reparameterisation_prime_prior(augmented_proposal):
 
     augmented_proposal.augmented_prior.assert_called_once_with(1)
     mock.assert_called_once_with(1)
+
+
+@pytest.mark.integration_test
+def test_default_reparameterisations(caplog):
+    """Assert that the GW defaults are used even in reparameterisations
+    is not given.
+    """
+    caplog.set_level("INFO")
+    model = MagicMock()
+    model.names = ['mass_ratio', 'theta_jn', 'phase']
+    model.bounds = {
+        'mass_ratio': [20.0, 40.0],
+        'theta_jn': [0.0, pi],
+        'phase': [0.0, 2 * pi]
+    }
+    model.reparameterisations = None
+    expected_params = model.names + ['phase_radial']
+    proposal = GWFlowProposal(model, poolsize=100)
+    # Mocked model so can't verify rescaling
+    proposal.verify_rescaling = MagicMock()
+    proposal.initialise()
+    assert proposal._reparameterisation is not None
+    assert all(
+        [p in expected_params for p in proposal._reparameterisation.parameters]
+    )
+    assert 'reparameterisations included in GWFlowProposal' in caplog.text

--- a/tests/test_gw/test_gw_proposal.py
+++ b/tests/test_gw/test_gw_proposal.py
@@ -99,7 +99,7 @@ def test_augmented_reparameterisation_prime_prior(augmented_proposal):
 
 
 @pytest.mark.integration_test
-def test_default_reparameterisations(caplog):
+def test_default_reparameterisations(caplog, tmpdir):
     """Assert that the GW defaults are used even in reparameterisations
     is not given.
     """
@@ -113,7 +113,9 @@ def test_default_reparameterisations(caplog):
     }
     model.reparameterisations = None
     expected_params = model.names + ['phase_radial']
-    proposal = GWFlowProposal(model, poolsize=100)
+    proposal = GWFlowProposal(
+        model, poolsize=100, output=str(tmpdir.mkdir('test'))
+    )
     # Mocked model so can't verify rescaling
     proposal.verify_rescaling = MagicMock()
     proposal.initialise()

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
@@ -80,14 +80,16 @@ def test_configure_reparameterisation_angle_pair(tmpdir, model):
 
 
 @pytest.mark.integration_test
-def test_default_reparameterisations(caplog):
+def test_default_reparameterisations(caplog, tmpdir):
     """Assert that by default reparameterisations are not used."""
     caplog.set_level('INFO')
     model = MagicMock()
     model.names = ['x', 'y']
     model.bounds = {p: [-1, 1] for p in model.names}
     model.reparameterisations = None
-    proposal = FlowProposal(model, poolsize=100)
+    proposal = FlowProposal(
+        model, poolsize=100, output=str(tmpdir.mkdir('test'))
+    )
     # Mocked model so can't verify rescaling
     proposal.verify_rescaling = MagicMock()
     proposal.initialise()

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
@@ -4,7 +4,7 @@ Integration tests for adding the default reparameterisations
 """
 import numpy as np
 import pytest
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 from nessai.model import Model
 from nessai.proposal import FlowProposal
@@ -77,3 +77,18 @@ def test_configure_reparameterisation_angle_pair(tmpdir, model):
         )
     proposal.set_rescaling()
     assert proposal._reparameterisation is not None
+
+
+@pytest.mark.integration_test
+def test_default_reparameterisations(caplog):
+    """Assert that by default reparameterisations are not used."""
+    caplog.set_level('INFO')
+    model = MagicMock()
+    model.names = ['x', 'y']
+    model.bounds = {p: [-1, 1] for p in model.names}
+    model.reparameterisations = None
+    proposal = FlowProposal(model, poolsize=100)
+    # Mocked model so can't verify rescaling
+    proposal.verify_rescaling = MagicMock()
+    proposal.initialise()
+    assert proposal._reparameterisation is None

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -20,6 +20,19 @@ def test_init(model, kwargs):
     assert getattr(fp, 'prior', None) is None
 
 
+@pytest.mark.parametrize(
+    'value, expected',
+    [(True, True), (False, False), (None, False)]
+)
+def test_init_use_default_reparams(model, proposal, value, expected):
+    """Assert use_default_reparameterisations is set correctly"""
+    proposal.use_default_reparameterisations = False
+    FlowProposal.__init__(
+        proposal, model, poolsize=10, use_default_reparameterisations=value
+    )
+    assert proposal.use_default_reparameterisations is expected
+
+
 @pytest.mark.parametrize('ef, fuzz', [(2.0, 3.0**0.5), (False, 2.0)])
 def test_initialise(tmpdir, proposal, ef, fuzz):
     """Test the initialise method"""

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -199,6 +199,8 @@ def test_reset(proposal):
     assert proposal._edges['x'] is None
 
 
+@pytest.mark.timeout(10)
+@pytest.mark.flaky(run=3)
 @pytest.mark.integration_test
 def test_reset_integration(tmpdir, model):
     """Test reset method iteration with other methods"""
@@ -208,8 +210,8 @@ def test_reset_integration(tmpdir, model):
         model,
         output=output,
         plot=False,
-        poolsize=100,
-        latent_prior='uniform_nball',
+        poolsize=10,
+        latent_prior='truncated_gaussian',
         constant_volume_mode=False
     )
 
@@ -217,8 +219,8 @@ def test_reset_integration(tmpdir, model):
         model,
         output=output,
         plot=False,
-        poolsize=100,
-        latent_prior='uniform_nball',
+        poolsize=10,
+        latent_prior='truncated_gaussian',
         constant_volume_mode=False
     )
     proposal.initialise()
@@ -239,6 +241,8 @@ def test_reset_integration(tmpdir, model):
 
 
 @pytest.mark.parametrize('rescale', [True, False])
+@pytest.mark.timeout(10)
+@pytest.mark.flaky(run=3)
 @pytest.mark.integration_test
 def test_test_draw(tmpdir, model, rescale):
     """Verify that the `test_draw` method works.

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -4,10 +4,18 @@ import numpy as np
 from nessai.livepoint import numpy_array_to_live_points
 from nessai.proposal import FlowProposal
 from nessai.reparameterisations import (
-    get_reparameterisation
+    NullReparameterisation,
+    get_reparameterisation,
 )
 import pytest
 from unittest.mock import MagicMock, Mock, call, patch
+
+
+@pytest.fixture
+def proposal(proposal):
+    """Specific mocked proposal for reparameterisation tests"""
+    proposal.use_default_reparameterisations = False
+    return proposal
 
 
 @pytest.fixture
@@ -210,6 +218,28 @@ def test_configure_reparameterisations_dict_reparam(mocked_class, proposal):
     assert proposal.rescale_parameters == ['x']
     assert proposal._reparameterisation.parameters == ['x', 'y']
     assert proposal._reparameterisation.prime_parameters == ['x_prime', 'y']
+    assert mocked_class.called_once
+
+
+@patch('nessai.reparameterisations.CombinedReparameterisation')
+def test_configure_reparameterisations_none(mocked_class, proposal):
+    """Test configuration when input is None"""
+    proposal.add_default_reparameterisations = MagicMock()
+    proposal.get_reparameterisation = get_reparameterisation
+    proposal.model = MagicMock()
+    proposal.model.bounds = {'x': [-1, 1], 'y': [-1, 1]}
+    proposal.names = ['x', 'y']
+    FlowProposal.configure_reparameterisations(proposal, None)
+    proposal.add_default_reparameterisations.assert_called_once()
+    assert proposal.rescaled_names == ['x', 'y']
+
+    assert proposal.rescale_parameters == []
+    assert proposal._reparameterisation.parameters == ['x', 'y']
+    assert proposal._reparameterisation.prime_parameters == ['x', 'y']
+    assert all(
+        [isinstance(r, NullReparameterisation)
+         for r in proposal._reparameterisation.reparameterisations.values()]
+    )
     assert mocked_class.called_once
 
 


### PR DESCRIPTION
Currently `GWFlowProposal` will not use the included reparameterisations if `reparameterisations=None`. This means that running the sampler with the correct proposal doesn't guarantee the correct reparameterisations.

 This PR adds an option to force FlowProposal or any class that inherits from it to use the default reparameterisations even if `reparameterisations=None` and adds an attribute that defines the default behaviour.

**Changes**
- Add attribute `use_default_reparameterisations` to FlowProposal this defaults to `False` and can be overridden by child classes.
- Add `use_default_reparameterisations=None` to the inputs of `FlowProposal`. When set to `None` the default for the class is used. Setting it to `True` or `False` overrides the default behaviour.



