### PR TITLE
Update GW defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option in `nessai.reparameterisations.Angle` to set `scale=None`, the scale is then set as `2 * pi / angle_prior_range`.
 - Add `'periodic'` reparameterisation that uses `scale=None` in `nessai.reparameterisations.Angle`.
 - Add the `use_default_reparameterisations` option to `FlowProposal` to allow the use of the default reparameterisations in `GWFlowProposal` without specifying any reparameterisations.
+- Add `chi_1`, `chi_2` and `time_jitter` to known parameters in `GWFlowProposal` with corresponding defaults.
 
 ### Changed
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Model.names` and `Model.bounds` are now properties by default and their setters include checks to verify the values provided are valid and raise errors if not.
 - Logger now has propagation enabled by default.
 - `FlowProposal.configure_reparameterisations` can now handle an input of `None`. In this case only the default reparameterisations will be added.
+- Changed default reparameterisation for gravitational-wave parameters `a_1` and `a_2` to `'default'`.
 
 ### Fixed
 

--- a/nessai/gw/proposal.py
+++ b/nessai/gw/proposal.py
@@ -32,8 +32,11 @@ class GWFlowProposal(FlowProposal):
         'phase': ('angle-2pi', None),
         'psi': ('angle-pi', None),
         'geocent_time': ('time', None),
-        'a_1': ('to-cartesian', None),
-        'a_2': ('to-cartesian', None),
+        'time_jitter': ('periodic', None),
+        'a_1': ('default', None),
+        'a_2': ('default', None),
+        'chi_1': ('default', None),
+        'chi_2': ('default', None),
         'luminosity_distance': ('distance', None),
     }
     """


### PR DESCRIPTION
Update the default reparameterisations for `a_1` and `a_2` and add reparameterisations for: `chi_1`, `chi_2`, and `time_jitter`.

**Reparameterisations**

* `a_1` and `a_2` now use `default` instead of `to-cartesian`
* `chi_1` and `chi_2` use `default`
* `time_jitter` uses the new `periodic` reparameterisation added in https://github.com/mj-will/nessai/pull/127

**Validation**

I've re-run the analysis from the paper with distance marginalisation enabled and seen roughly a 2x speed up whist still passing the P-P test:

![image](https://user-images.githubusercontent.com/25609742/143067769-cebdd3bb-89bf-4074-b421-f0ba45367fa6.png)
