### PR TITLE
Add fallback reparameterisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `dataframe_to_live_points` function to `nessai.livepoint` for converting from a `pandas.DataFrame` to live points.
+- Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters which are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
 
 ## [0.4.0] - 2021-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `dataframe_to_live_points` function to `nessai.livepoint` for converting from a `pandas.DataFrame` to live points.
-- Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters which are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
+- Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters that are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
 
 ## [0.4.0] - 2021-11-23
 

--- a/nessai/gw/proposal.py
+++ b/nessai/gw/proposal.py
@@ -62,7 +62,7 @@ class GWFlowProposal(FlowProposal):
         """
         parameters = list(set(self.names)
                           - set(self._reparameterisation.parameters))
-        logger.debug(f'Adding default reparameterisations for {parameters}')
+        logger.info(f'Adding default reparameterisations for {parameters}')
 
         for p in parameters:
             logger.debug(f'Trying to add reparameterisation for {p}')
@@ -79,8 +79,10 @@ class GWFlowProposal(FlowProposal):
                 p = [p]
             prior_bounds = {k: self.model.bounds[k] for k in p}
             reparam, kwargs = get_gw_reparameterisation(name)
-            logger.debug(
-                f'Add reparameterisation for {p} with config: {kwargs}')
+            logger.info(
+                f'Adding reparameterisation {reparam.__name__} for {p} '
+                f'with config: {kwargs}'
+            )
             self._reparameterisation.add_reparameterisation(
                 reparam(parameters=p, prior_bounds=prior_bounds, **kwargs))
 

--- a/nessai/gw/proposal.py
+++ b/nessai/gw/proposal.py
@@ -60,8 +60,9 @@ class GWFlowProposal(FlowProposal):
         Add default reparameterisations for parameters that have not been
         specified.
         """
-        parameters = list(set(self.names)
-                          - set(self._reparameterisation.parameters))
+        parameters = \
+            [n for n in self.names
+             if n not in self._reparameterisation.parameters]
         logger.info(f'Adding default reparameterisations for {parameters}')
 
         for p in parameters:

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -704,8 +704,8 @@ class FlowProposal(RejectionProposal):
         self.names = self._reparameterisation.parameters
         self.rescaled_names = self._reparameterisation.prime_parameters
         self.rescale_parameters = \
-            list(set(self._reparameterisation.parameters)
-                 - set(self._reparameterisation.prime_parameters))
+            [p for p in self._reparameterisation.parameters
+             if p not in self._reparameterisation.prime_parameters]
 
     def set_rescaling(self):
         """

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -22,7 +22,6 @@ from ..livepoint import (
     )
 from ..reparameterisations import (
     CombinedReparameterisation,
-    NullReparameterisation,
     get_reparameterisation
     )
 from ..plot import plot_live_points, plot_1d_comparison
@@ -133,6 +132,11 @@ class FlowProposal(RejectionProposal):
         Dictionary for configure more flexible reparameterisations. This
         ignores any of the other settings related to rescaling. For more
         details see the documentation.
+    fallback_reparameterisation : None or str
+        Name of the reparameterisation to be used for parameters that have not
+        been specified in the reparameterisations dictionary. If None, the
+        :py:class:`~nessai.reparameterisations.NullReparameterisation` is used.
+        Reparameterisation should support multiple parameters.
     use_default_reparameterisations : bool, optional
         If True then reparameterisations will be used even if
         ``reparameterisations`` is None. The exact reparameterisations used
@@ -194,6 +198,7 @@ class FlowProposal(RejectionProposal):
         detect_edges=False,
         detect_edges_kwargs=None,
         reparameterisations=None,
+        fallback_reparameterisation=None,
         use_default_reparameterisations=None,
         **kwargs
     ):
@@ -227,6 +232,7 @@ class FlowProposal(RejectionProposal):
         if use_default_reparameterisations is not None:
             self.use_default_reparameterisations = \
                 use_default_reparameterisations
+        self.fallback_reparameterisation = fallback_reparameterisation
 
         self.output = output
 
@@ -667,17 +673,26 @@ class FlowProposal(RejectionProposal):
                     {default_config['parameters']:
                      self.model.bounds[default_config['parameters']]}
 
-            logger.debug(f'Adding {rc.__name__} with config {default_config}')
+            logger.info(f'Adding {rc.__name__} with config: {default_config}')
             r = rc(prior_bounds=prior_bounds, **default_config)
             self._reparameterisation.add_reparameterisations(r)
 
         self.add_default_reparameterisations()
 
-        p = [n for n in self.names
-             if n not in self._reparameterisation.parameters]
-        if p:
-            logger.info(f'Assuming no rescaling for {p}')
-            r = NullReparameterisation(parameters=list(p))
+        other_params = [n for n in self.names
+                        if n not in self._reparameterisation.parameters]
+        if other_params:
+            logger.debug('Getting fallback reparameterisation')
+            FallbackClass, fallback_kwargs = \
+                self.get_reparameterisation(self.fallback_reparameterisation)
+            fallback_kwargs['prior_bounds'] = \
+                {p: self.model.bounds[p] for p in other_params}
+            logger.info(
+                f'Assuming fallback reparameterisation '
+                f'({FallbackClass.__name__}) for {other_params} with kwargs: '
+                f'{fallback_kwargs}.'
+            )
+            r = FallbackClass(parameters=other_params, **fallback_kwargs)
             self._reparameterisation.add_reparameterisations(r)
 
         if any(r._update_bounds for r in self._reparameterisation.values()):
@@ -688,14 +703,15 @@ class FlowProposal(RejectionProposal):
         if self._reparameterisation.has_prime_prior:
             self.use_x_prime_prior = True
             self.x_prime_log_prior = self._reparameterisation.x_prime_log_prior
-            logger.info('Using x prime prior')
+            logger.debug('Using x prime prior')
         else:
-            logger.info('Prime prior is disabled')
+            logger.debug('Prime prior is disabled')
             if self._reparameterisation.requires_prime_prior:
                 raise RuntimeError(
                     'One or more reparameterisations require use of the x '
                     'prime prior but it cannot be enabled with the current '
-                    'settings.')
+                    'settings.'
+                )
 
         self.rescale = self._rescale_w_reparameterisation
         self.inverse_rescale = \

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -557,10 +557,10 @@ class RescaleToBounds(Reparameterisation):
             self.prior = 'uniform'
             self.has_prime_prior = True
             self._prime_prior = log_uniform_prior
-            logger.info(f'Prime prior enabled for {self.name}')
+            logger.debug(f'Prime prior enabled for {self.name}')
         else:
             self.has_prime_prior = False
-            logger.info(f'Prime prior disabled for {self.name}')
+            logger.debug(f'Prime prior disabled for {self.name}')
 
         self.configure_pre_rescaling(pre_rescaling)
         self.configure_post_rescaling(post_rescaling)
@@ -909,10 +909,10 @@ class Angle(Reparameterisation):
             else:
                 self._prime_prior = log_2d_cartesian_prior_sine
                 self._k = np.pi
-            logger.info(f'Prime prior enabled for {self.name}')
+            logger.debug(f'Prime prior enabled for {self.name}')
         else:
             self.has_prime_prior = False
-            logger.info(f'Prime prior disabled for {self.name}')
+            logger.debug(f'Prime prior disabled for {self.name}')
 
     @property
     def angle(self):
@@ -1137,7 +1137,7 @@ class AnglePair(Reparameterisation):
             )
         else:
             self.has_prime_prior = False
-            logger.info(f'Prime prior disabled for {self.name}')
+            logger.debug(f'Prime prior disabled for {self.name}')
 
         if convention is None:
             logger.debug('Trying to determine convention')

--- a/tests/test_gw/test_gw_proposal.py
+++ b/tests/test_gw/test_gw_proposal.py
@@ -39,6 +39,7 @@ def test_add_default_reparameterisation(proposal):
         {'chirp_mass': [10.0, 20.0], 'theta_jn': [0.0, 3.0]}
 
     reparam = MagicMock()
+    reparam.__name__ = 'MockReparam'
     with patch('nessai.gw.proposal.get_gw_reparameterisation',
                return_value=(reparam, {})) as mock_get:
         GWFlowProposal.add_default_reparameterisations(proposal)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -5,6 +5,7 @@ from nessai.livepoint import numpy_array_to_live_points
 from nessai.proposal import FlowProposal
 from nessai.reparameterisations import (
     NullReparameterisation,
+    RescaleToBounds,
     get_reparameterisation,
 )
 import pytest
@@ -191,6 +192,7 @@ def test_configure_reparameterisations_str(mocked_class, proposal):
     proposal.model = MagicMock
     proposal.model.bounds = {'x': [-1, 1], 'y': [-1, 1]}
     proposal.names = ['x', 'y']
+    proposal.fallback_reparameterisation = None
     FlowProposal.configure_reparameterisations(
         proposal, {'x': 'default'})
 
@@ -210,6 +212,7 @@ def test_configure_reparameterisations_dict_reparam(mocked_class, proposal):
     proposal.model = MagicMock
     proposal.model.bounds = {'x': [-1, 1], 'y': [-1, 1]}
     proposal.names = ['x', 'y']
+    proposal.fallback_reparameterisation = None
     FlowProposal.configure_reparameterisations(
         proposal, {'default': {'parameters': ['x']}})
 
@@ -229,6 +232,7 @@ def test_configure_reparameterisations_none(mocked_class, proposal):
     proposal.model = MagicMock()
     proposal.model.bounds = {'x': [-1, 1], 'y': [-1, 1]}
     proposal.names = ['x', 'y']
+    proposal.fallback_reparameterisation = None
     FlowProposal.configure_reparameterisations(proposal, None)
     proposal.add_default_reparameterisations.assert_called_once()
     assert proposal.rescaled_names == ['x', 'y']
@@ -238,6 +242,30 @@ def test_configure_reparameterisations_none(mocked_class, proposal):
     assert proposal._reparameterisation.prime_parameters == ['x', 'y']
     assert all(
         [isinstance(r, NullReparameterisation)
+         for r in proposal._reparameterisation.reparameterisations.values()]
+    )
+    assert mocked_class.called_once
+
+
+@patch('nessai.reparameterisations.CombinedReparameterisation')
+def test_configure_reparameterisations_fallback(mocked_class, proposal):
+    """Test configuration when input is None"""
+    proposal.add_default_reparameterisations = MagicMock()
+    proposal.get_reparameterisation = get_reparameterisation
+    proposal.model = MagicMock()
+    proposal.model.bounds = {'x': [-1, 1], 'y': [-1, 1]}
+    proposal.names = ['x', 'y']
+    proposal.fallback_reparameterisation = 'default'
+    FlowProposal.configure_reparameterisations(proposal, None)
+    proposal.add_default_reparameterisations.assert_called_once()
+    assert proposal.rescaled_names == ['x_prime', 'y_prime']
+
+    assert proposal.rescale_parameters == ['x', 'y']
+    assert proposal._reparameterisation.parameters == ['x', 'y']
+    assert proposal._reparameterisation.prime_parameters == \
+        ['x_prime', 'y_prime']
+    assert all(
+        [isinstance(r, RescaleToBounds)
          for r in proposal._reparameterisation.reparameterisations.values()]
     )
     assert mocked_class.called_once


### PR DESCRIPTION
Adds the option `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters that are not included in the reparameterisations dictionary. The default behaviour remains unchanged (defaults to no reparameterisation).

**Other minor changes**

- Information about prime prior is now debugging level
- Add information about which reparameterisations are being added.
- Move to use list comprehension instead of sets to determine missing parameters since the former preserves the ordering of the parameters.


**Implementation**

The fallback reparameterisation expects the name of one of the known reparameterisations and passes this to `get_reparameterisation`. It currently doesn't allow the user to configure the fallback reparameterisation and is limited to reparameterisations that accept multiple parameters. This could be changed in the future.

**Other**

Closes https://github.com/mj-will/nessai/issues/132