### PR TITLE
Add log X to state plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `dataframe_to_live_points` function to `nessai.livepoint` for converting from a `pandas.DataFrame` to live points.
 - Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters that are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
+- Add `rolling_mean` to `nessai.utils.stats`.
+
+### Changed
+
+- `NestedSampler.plot_state` now includes the log-prior volume in one of the subplots and the rolling mean of the gradient (|dlogL/dLogX|) is plotted instead of the gradient directly.
+- The figure produced by `NestedSampler.plot_state` now includes a legend for the different vertical lines that can appear in the subplots.
 
 ## [0.4.0] - 2021-11-23
 

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -9,6 +9,7 @@ import os
 import pickle
 
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 import numpy as np
 import seaborn as sns
 import torch
@@ -893,7 +894,10 @@ class NestedSampler:
 
         for i in self.checkpoint_iterations:
             for a in ax:
-                a.axvline(i, ls='-', color='tab:pink')
+                a.axvline(i, ls=':', color='#66ccff')
+
+        for a in ax:
+            a.axvline(self.iteration, c='#ff9900', ls='-.')
 
         ax[0].plot(it, self.min_likelihood, label='Min logL',
                    c=colours[0], ls=ls[0])
@@ -968,6 +972,18 @@ class NestedSampler:
 
         fig.suptitle(f'Sampling time: {self.current_sampling_time}',
                      fontsize=16)
+
+        handles = [
+            Line2D([0], [0], color='#ff9900', linestyle='-.',
+                   label='Current iteration'),
+            Line2D([0], [0], color='lightgrey', linestyle='-',
+                   markersize=10, markeredgewidth=1.5, label='Training'),
+            Line2D([0], [0], color='#66ccff', linestyle=':',
+                   label='Checkpoint'),
+        ]
+        fig.legend(
+            handles=handles, frameon=False, ncol=3, loc=(0.6, 0.0)
+        )
 
         fig.tight_layout()
         fig.subplots_adjust(top=0.95)

--- a/nessai/utils/__init__.py
+++ b/nessai/utils/__init__.py
@@ -36,6 +36,7 @@ from .sampling import (
     draw_uniform
 )
 from .distance import compute_minimum_distances
+from .stats import rolling_mean
 from .structures import replace_in_list
 from .threading import configure_threads
 
@@ -67,6 +68,7 @@ __all__ = [
     'inverse_rescale_zero_to_one',
     'is_jsonable',
     'logit',
+    'rolling_mean',
     'replace_in_list',
     'rescale_minus_one_to_one',
     'rescale_zero_to_one',

--- a/nessai/utils/stats.py
+++ b/nessai/utils/stats.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities related to statistics.
+"""
+import numpy as np
+
+
+def rolling_mean(x, N=10):
+    """Compute the rolling mean with a given window size.
+
+    Based on this answer from StackOverflow: \
+        https://stackoverflow.com/a/47490020
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray`
+        Array of samples
+    N : int
+        Size of the window over which the rolling mean is computed.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Array containing the moving average.
+    """
+    # np.cumsum is faster but doesn't work with infs in the data.
+    return np.convolve(
+        np.pad(x, (N // 2, N - 1 - N // 2), mode='edge'),
+        np.ones(N) / N,
+        mode='valid'
+    )

--- a/tests/test_nested_sampler/test_ns_plotting.py
+++ b/tests/test_nested_sampler/test_ns_plotting.py
@@ -25,6 +25,7 @@ def test_plot_state(sampler, tmpdir, filename, track_gradients):
     sampler.checkpoint_iterations = [600]
     sampler.likelihood_evaluations = x
     sampler.state = MagicMock()
+    sampler.state.log_vols = np.linspace(0, -10, 1050)
     sampler.state.track_gradients = track_gradients
     sampler.state.gradients = np.arange(1050)
     sampler.logZ_history = x

--- a/tests/test_utils/test_stats_utils.py
+++ b/tests/test_utils/test_stats_utils.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the stats related utilities.
+"""
+import numpy as np
+
+from nessai.utils.stats import rolling_mean
+
+
+def test_rolling_mean():
+    """Test the rolling mean."""
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    expected = np.array([4.0 / 3.0, 2.0, 3.0, 4.0, 5.0, 17.0 / 3.0])
+    out = rolling_mean(x, N=3)
+    np.testing.assert_array_almost_equal(out, expected, decimal=15)


### PR DESCRIPTION
Add the log-prior volume to the state plot produced by nessai and tweak a few other aspects of the state plot.

**Tweaks**
- Use smoothed version of the gradient
- Add a vertical line showing the current iteration
- Add a legend for the vertical lines that can show up in subplots (training, checkpointing, current iteration)
- Plot now point after the final iteration when the sampler is finalised

**Added**
- `nessai.utils.stats.rolling_mean` for computing the rolling mean