### PR TITLE
Common linear transforms func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `dataframe_to_live_points` function to `nessai.livepoint` for converting from a `pandas.DataFrame` to live points.
 - Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters that are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
 - Add `rolling_mean` to `nessai.utils.stats`.
+- Add `nessai.flows.utils.create_linear_transform` as a common function for creating linear transforms in the flows.
 
 ### Changed
 
 - `NestedSampler.plot_state` now includes the log-prior volume in one of the subplots and the rolling mean of the gradient (|dlogL/dLogX|) is plotted instead of the gradient directly.
 - The figure produced by `NestedSampler.plot_state` now includes a legend for the different vertical lines that can appear in the subplots.
+- `RealNVP` and `NeuralSplineFlow` now use `nessai.flows.utils.create_linear_transform`.
 
 ## [0.4.0] - 2021-11-23
 

--- a/nessai/flows/utils.py
+++ b/nessai/flows/utils.py
@@ -180,15 +180,23 @@ class MLP(NFlowsMLP):
 
 
 def create_linear_transform(linear_transform, features):
-    """Function for creating linear transforms."""
-    if linear_transform == 'permutation':
+    """Function for creating linear transforms.
+
+    Parameters
+    ----------
+    linear_transform : {'permutation', 'lu', 'svd'}
+        Linear transform to use.
+    featres : int
+        Number of features.
+    """
+    if linear_transform.lower() == 'permutation':
         return transforms.RandomPermutation(features=features)
-    elif linear_transform == 'lu':
+    elif linear_transform.lower() == 'lu':
         return transforms.CompositeTransform([
             transforms.RandomPermutation(features=features),
             transforms.LULinear(features, identity_init=True, using_cache=True)
         ])
-    elif linear_transform == 'svd':
+    elif linear_transform.lower() == 'svd':
         return transforms.CompositeTransform([
             transforms.RandomPermutation(features=features),
             transforms.SVDLinear(
@@ -198,5 +206,5 @@ def create_linear_transform(linear_transform, features):
     else:
         raise ValueError(
             f'Unknown linear transform: {linear_transform}. '
-            'Choose from: {permutation, lu, svd, None}.'
+            'Choose from: {permutation, lu, svd}.'
         )

--- a/tests/test_flows/test_flow_utils.py
+++ b/tests/test_flows/test_flow_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 from nessai.flows.utils import (
     configure_model,
+    create_linear_transform,
     silu,
     reset_weights,
     reset_permutations,
@@ -231,3 +232,17 @@ def test_configure_model_unknown_activation(config):
     with pytest.raises(RuntimeError) as excinfo:
         configure_model(config)
     assert "Unknown activation function: 'test'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize('linear_transform', ['lu', 'permutation', 'svd'])
+def test_create_linear_transform(linear_transform):
+    """Test creating a linear transform."""
+    lt = create_linear_transform(linear_transform, 2)
+    assert lt is not None
+
+
+def test_create_linear_transform_unknown():
+    """Assert an error is raised if an invalid input is given."""
+    with pytest.raises(ValueError) as excinfo:
+        create_linear_transform('not_a_transform', 2)
+    assert 'Unknown linear transform: not_a_transform' in str(excinfo.value)

--- a/tests/test_flows/test_flow_utils.py
+++ b/tests/test_flows/test_flow_utils.py
@@ -108,7 +108,7 @@ def test_mlp_forward_context():
 def test_configure_model_basic(config):
     """Test configure model with the most basic config."""
     config['kwargs'] = dict(num_bins=2)
-    with patch('nessai.flows.utils.RealNVP') as mock_flow:
+    with patch('nessai.flows.realnvp.RealNVP') as mock_flow:
         configure_model(config)
 
     mock_flow.assert_called_with(
@@ -123,17 +123,17 @@ def test_configure_model_basic(config):
 @pytest.mark.parametrize(
     'flow_inputs',
     [
-        {'ftype': 'realnvp', 'expected': 'RealNVP'},
-        {'ftype': 'frealnvp', 'expected': 'RealNVP'},
-        {'ftype': 'spline', 'expected': 'NeuralSplineFlow'},
-        {'ftype': 'nsf', 'expected': 'NeuralSplineFlow'},
-        {'ftype': 'maf', 'expected': 'MaskedAutoregressiveFlow'}
+        {'ftype': 'realnvp', 'expected': 'realnvp.RealNVP'},
+        {'ftype': 'frealnvp', 'expected': 'realnvp.RealNVP'},
+        {'ftype': 'spline', 'expected': 'nsf.NeuralSplineFlow'},
+        {'ftype': 'nsf', 'expected': 'nsf.NeuralSplineFlow'},
+        {'ftype': 'maf', 'expected': 'maf.MaskedAutoregressiveFlow'}
     ]
 )
 def test_configure_model_flows(config, flow_inputs):
     """Test the different flows."""
     config['ftype'] = flow_inputs['ftype']
-    with patch(f"nessai.flows.utils.{flow_inputs['expected']}") as mock_flow:
+    with patch(f"nessai.flows.{flow_inputs['expected']}") as mock_flow:
         model, _ = configure_model(config)
     mock_flow.assert_called_with(
         config['n_inputs'],
@@ -168,7 +168,7 @@ def test_configure_model_device_cuda(config):
     config['device_tag'] = 'cuda'
     expected_device = torch.device('cuda')
     mock_model = MagicMock()
-    with patch('nessai.flows.utils.RealNVP',
+    with patch('nessai.flows.realnvp.RealNVP',
                return_value=mock_model) as mock_flow:
         model, device = configure_model(config)
 
@@ -197,7 +197,7 @@ def test_configure_model_activation_functions(config, act):
     """Test the different activation functions."""
     config['kwargs'] = dict(activation=act['act'])
 
-    with patch('nessai.flows.utils.RealNVP') as mock_flow:
+    with patch('nessai.flows.realnvp.RealNVP') as mock_flow:
         configure_model(config)
 
     mock_flow.assert_called_with(


### PR DESCRIPTION
Add `create_linear_transforms` to `nessai.flows.utils` as a common function for creating linear transforms.

Currently, `RealNVP` and `NeuralSplineFlow` each have their own internal function for creating linear transforms. This is unnecessary and removing them means there's less code to maintain and test.

This does require moving some of the imports in `nessai.flows.utils` to prevent circular imports.