### PR TITLE
Patch LU CUDA bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `fallback_reparameterisation` to `FlowProposal`. This allows the user to specify which reparameterisation to use for parameters that are not included in the reparameterisations dictionary. Default behaviour remains unchanged (defaults to no reparameterisation).
 - Add `rolling_mean` to `nessai.utils.stats`.
 - Add `nessai.flows.utils.create_linear_transform` as a common function for creating linear transforms in the flows.
+- Add `nessai.flows.transforms.LULinear` to address a [bug in nflows](https://github.com/bayesiains/nflows/pull/38) that has not been patched and prevents the use of CUDA with `LULinear`.
 
 ### Changed
 

--- a/nessai/flows/transforms.py
+++ b/nessai/flows/transforms.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Transform for use in normalising flows."""
+from nflows.transforms import LULinear as BaseLULinear
+import torch
+
+
+class LULinear(BaseLULinear):
+    """Wrapper for LULinear from nflows that works with CUDA.
+
+    The original implementation has a bug that prevents use with CUDA. See
+    https://github.com/bayesiains/nflows/pull/38 for details.
+
+    This should be removed if the bug is fixed in nflows.
+    """
+
+    def weight_inverse(self):
+        """Cost:
+            inverse = O(D^3)
+        where:
+            D = num of features
+        """
+        lower, upper = self._create_lower_upper()
+        identity = torch.eye(
+            self.features, self.features, device=self.lower_entries.device)
+        lower_inverse, _ = torch.triangular_solve(
+            identity, lower, upper=False, unitriangular=True
+        )
+        weight_inverse, _ = torch.triangular_solve(
+            lower_inverse, upper, upper=True, unitriangular=False
+        )
+        return weight_inverse

--- a/nessai/flows/utils.py
+++ b/nessai/flows/utils.py
@@ -11,6 +11,7 @@ from nflows import transforms
 from nflows.nn.nets import MLP as NFlowsMLP
 
 from .distributions import MultivariateNormal
+from .transforms import LULinear
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ def reset_permutations(module):
     module : :obj:`torch.nn.Module`
         Module to reset
     """
-    if isinstance(module, transforms.LULinear):
+    if isinstance(module, (transforms.LULinear, LULinear)):
         module.cache.invalidate()
         module._initialize(identity_init=True)
     elif isinstance(module, transforms.RandomPermutation):
@@ -194,7 +195,7 @@ def create_linear_transform(linear_transform, features):
     elif linear_transform.lower() == 'lu':
         return transforms.CompositeTransform([
             transforms.RandomPermutation(features=features),
-            transforms.LULinear(features, identity_init=True, using_cache=True)
+            LULinear(features, identity_init=True, using_cache=True)
         ])
     elif linear_transform.lower() == 'svd':
         return transforms.CompositeTransform([

--- a/tests/test_flows/test_flow_transforms.py
+++ b/tests/test_flows/test_flow_transforms.py
@@ -21,7 +21,7 @@ def test_LULinear_weight_inverse():
     assert not torch.isnan(out).any()
     assert not torch.isinf(out).any()
     assert out.shape == torch.Size((2, 2))
-    torch.testing.assert_equal(out, weight_inverse)
+    assert torch.equal(out, weight_inverse)
 
 
 @pytest.mark.cuda

--- a/tests/test_flows/test_flow_transforms.py
+++ b/tests/test_flows/test_flow_transforms.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tests for the transforms included for the flows"""
+from nessai.flows.transforms import LULinear
+import pytest
+import torch
+
+
+def test_LULinear_weight_inverse():
+    """Test the patched weight inverse method.
+
+    Based on the test included in nflows:
+    https://github.com/bayesiains/nflows/blob/master/tests/transforms/lu_test.py#L12
+    """
+    transform = LULinear(2)
+    lower, upper = transform._create_lower_upper()
+    weight = lower @ upper
+    weight_inverse = torch.inverse(weight)
+
+    out = transform.weight_inverse()
+
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()
+    assert out.shape == torch.Size((2, 2))
+    torch.testing.assert_equal(out, weight_inverse)
+
+
+@pytest.mark.cuda
+def test_LUlinear_CUDA():
+    """Test to verify that CUDA works"""
+    transform = LULinear(2)
+    transform.to('cuda')
+    transform.weight_inverse()


### PR DESCRIPTION
Implement a wrapper for `nflows.transforms.lu.LULinear` that fixes the bug described in https://github.com/bayesiains/nflows/pull/38 and prevents the use of CUDA with `LULinear`. The wrapped version is used in `create_linear_transform` and is therefore applied to all of the flows.

These commits can be reverted if the bug is fixed in `nflows` and a new version is released.