### PR TITLE
Fix GW null reparam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nessai.flows.utils.create_linear_transform` as a common function for creating linear transforms in the flows.
 - Add `nessai.flows.transforms.LULinear` to address a [bug in nflows](https://github.com/bayesiains/nflows/pull/38) that has not been patched and prevents the use of CUDA with `LULinear`.
 - Add `calibration_example.py` to the gravitational wave examples.
+- Add `defaults` keyword argument to `nessai.reparameterisations.get_reparameterisation` for overriding the dictionary of default reparameterisations.
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The figure produced by `NestedSampler.plot_state` now includes a legend for the different
 vertical lines that can appear in the subplots.
 - Updated all of the examples to reflect the new defaults.
+- Rework `nessai.gw.reparameterisations.get_gw_reparameterisation` to use `get_reparameterisation` with the `defaults` keyword argument.
 
 ### Removed
 

--- a/nessai/gw/reparameterisations.py
+++ b/nessai/gw/reparameterisations.py
@@ -7,9 +7,9 @@ import logging
 
 from ..reparameterisations import (
     default_reparameterisations,
-    Reparameterisation,
     RescaleToBounds,
-    AnglePair
+    AnglePair,
+    get_reparameterisation,
 )
 
 from ..priors import log_uniform_prior
@@ -24,24 +24,22 @@ def get_gw_reparameterisation(reparameterisation):
     """
     Get a reparameterisation from the default list plus specific GW
     classes.
+
+    Parameters
+    ----------
+    reparameterisation : str, \
+            :obj:`nessai.reparameterisations.Reparameterisation`
+        Name of the reparameterisations to return or a class that inherits from
+        :obj:`~nessai.reparameterisations.Reparameterisation`
+
+    Returns
+    -------
+    :obj:`nessai.reparameteristaions.Reparameterisation`
+        Reparameterisation class.
+    dict
+        Keyword arguments for the specific reparameterisation.
     """
-    if isinstance(reparameterisation, str):
-        rc, kwargs = default_gw.get(reparameterisation, (None, None))
-        if rc is None:
-            raise ValueError(
-                f'Unknown GW reparameterisation: {reparameterisation}')
-        else:
-            if kwargs is None:
-                kwargs = {}
-            else:
-                kwargs = kwargs.copy()
-            return rc, kwargs
-    elif (isinstance(reparameterisation, type) and
-            issubclass(reparameterisation, Reparameterisation)):
-        return reparameterisation, {}
-    else:
-        raise RuntimeError('Reparmeterisation must a str or class that '
-                           'inherits from `Reparameterisation`')
+    return get_reparameterisation(reparameterisation, defaults=default_gw)
 
 
 class DistanceReparameterisation(RescaleToBounds):

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -32,7 +32,7 @@ from .priors import (
 logger = logging.getLogger(__name__)
 
 
-def get_reparameterisation(reparameterisation):
+def get_reparameterisation(reparameterisation, defaults=None):
     """Function to get a reparameterisation class from a name
 
     Parameters
@@ -41,17 +41,20 @@ def get_reparameterisation(reparameterisation):
             :obj:`nessai.reparameterisations.Reparameterisation`
         Name of the reparameterisations to return or a class that inherits from
         :obj:`~nessai.reparameterisations.Reparameterisation`
+    defaults : dict, optional
+        Dictionary of known reparameterisations that overrides the defaults.
 
     Returns
     -------
     :obj:`nessai.reparameteristaions.Reparameterisation`
-        T
+        Reparameterisation class.
     dict
-        Keyword arguments for the specific reparameterisations.
+        Keyword arguments for the specific reparameterisation.
     """
+    if defaults is None:
+        defaults = default_reparameterisations
     if isinstance(reparameterisation, str):
-        rc, kwargs = default_reparameterisations.get(
-            reparameterisation, (None, None))
+        rc, kwargs = defaults.get(reparameterisation, (None, None))
         if rc is None:
             raise ValueError(
                 f'Unknown reparameterisation: {reparameterisation}'

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tests for GW reparameterisations"""
+
+import pytest
+from nessai.gw.reparameterisations import (
+    DistanceReparameterisation,
+    default_gw,
+    get_gw_reparameterisation,
+)
+from unittest.mock import patch
+
+
+def test_get_gw_reparameterisation():
+    """Test getting the gw reparameterisations.
+
+    Assert the correct defaults are used.
+    """
+    expected = 'out'
+    with patch(
+        'nessai.gw.reparameterisations.get_reparameterisation',
+        return_value=expected,
+    ) as base_fn:
+        out = get_gw_reparameterisation('mass_ratio')
+    assert out == expected
+    base_fn.assert_called_once_with('mass_ratio', defaults=default_gw)
+
+
+@pytest.mark.integration_test
+def test_get_gw_reparameterisation_integration():
+    """Integration test for get_gw_reparameterisation"""
+    reparam, _ = get_gw_reparameterisation('distance')
+    assert reparam is DistanceReparameterisation

--- a/tests/test_reparameterisations/test_get_reparameterisation.py
+++ b/tests/test_reparameterisations/test_get_reparameterisation.py
@@ -97,3 +97,11 @@ def test_get_reparameterisation_invalid_input():
     with pytest.raises(TypeError) as excinfo:
         get_reparameterisation(2)
     assert 'Reparameterisation must be' in str(excinfo.value)
+
+
+def test_get_reparameterisation_defaults():
+    """Test using an updated defaults dictionary."""
+    defaults = {'default': ('Class', {'x': 2})}
+    cls, kwargs = get_reparameterisation('default', defaults=defaults)
+    assert cls == 'Class'
+    assert kwargs == {'x': 2}


### PR DESCRIPTION
In https://github.com/mj-will/nessai/pull/82 `get_reparameterisation` was changed so that `None` was a valid input and returned `NullReparameterisation`. `get_gw_reparameterisation` should have been updated as well but wasn't. As a result, an error is raised if a reparmeterisation is specified as `None`  when using `GWFlowProposal`. Previously this only occurred if a user-specified `None` but, with the changes in https://github.com/mj-will/nessai/pull/134, this error now occurs whenever a new parameter without a default is included in the model (if using `GWFlowProposal`). This PR fixes this.

**Changes**

Rework `get_gw_reparameterisation` so that it calls `get_reparameterisation`, removing the duplicate lines of code and hopefully making the function easier to maintain.

To do this, I've added a `defaults` keyword argument to `get_reparamterisation` which allows the dictionary of default reparameterisations to be overridden with another dictionary.