### PR TITLE
Improve reparameterisation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `calibration_example.py` to the gravitational wave examples.
 - Add `defaults` keyword argument to `nessai.reparameterisations.get_reparameterisation` for overriding the dictionary of default reparameterisations.
 - Add explicit tests for `nessai.flowsampler`
+- Add more tests for `nessai.reparameterisations`
 
 ### Changed
 
@@ -28,6 +29,11 @@ vertical lines that can appear in the subplots.
 - Updated all of the examples to reflect the new defaults.
 - Rework `nessai.gw.reparameterisations.get_gw_reparameterisation` to use `get_reparameterisation` with the `defaults` keyword argument.
 - Switch to `os.path.join` for joining paths in `nessai.flowsampler`.
+
+
+### Fixed
+
+- Fixed a bug in `RescaleToBounds` when using `pre_rescaling` without boundary inversion.
 
 ### Removed
 

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -581,6 +581,16 @@ class RescaleToBounds(Reparameterisation):
         self.set_bounds(self.prior_bounds)
 
     def configure_pre_rescaling(self, pre_rescaling):
+        """Configure the rescaling applied before the standard rescaling.
+
+        Used in :code:`DistanceReparameterisation`.
+
+        Parameters
+        ----------
+        pre_rescaling : str or Tuple[Callable, Callable]
+            Name of the pre-rescaling of tuple contain the forward and inverse
+            functions that should return the rescaled value and the Jacobian.
+        """
         if pre_rescaling is not None:
             if isinstance(pre_rescaling, str):
                 logger.debug(f'Getting pre-rescaling function {pre_rescaling}')
@@ -589,22 +599,31 @@ class RescaleToBounds(Reparameterisation):
                         pre_rescaling.lower(), (None, None))
                 if self.pre_rescaling is None:
                     raise RuntimeError(
-                        f'Unknown rescaling function: {pre_rescaling}')
+                        f'Unknown rescaling function: {pre_rescaling}'
+                    )
             elif len(pre_rescaling) == 2:
                 self.pre_rescaling = pre_rescaling[0]
                 self.pre_rescaling_inv = pre_rescaling[1]
             else:
                 raise RuntimeError(
-                    'Pre-rescaling must be str or tuple of two functions')
-            logger.debug('Disabling prime prior with pre-rescaling')
-            self.has_prior_prior = False
+                    'Pre-rescaling must be a str or tuple of two functions'
+                )
             self.has_pre_rescaling = True
         else:
             logger.debug('No pre-rescaling to configure')
             self.has_pre_rescaling = False
 
     def configure_post_rescaling(self, post_rescaling):
+        """Configure the rescaling applied after the standard rescaling.
 
+        Used to apply the logit/sigmoid transforms after rescaling to [0, 1]
+
+        Parameters
+        ----------
+        post_rescaling : str or Tuple[Callable, Callable]
+            Name of the post-rescaling of tuple contain the forward and inverse
+            functions that should return the rescaled value and the Jacobian.
+        """
         if post_rescaling is not None:
             if isinstance(post_rescaling, str):
                 logger.debug(
@@ -614,15 +633,17 @@ class RescaleToBounds(Reparameterisation):
                         post_rescaling.lower(), (None, None))
                 if self.post_rescaling is None:
                     raise RuntimeError(
-                        f'Unknown rescaling function: {post_rescaling}')
+                        f'Unknown rescaling function: {post_rescaling}'
+                    )
             elif len(post_rescaling) == 2:
                 self.post_rescaling = post_rescaling[0]
                 self.post_rescaling_inv = post_rescaling[1]
             else:
                 raise RuntimeError(
-                    'Post-rescaling must be str or tuple of two functions')
+                    'Post-rescaling must be a str or tuple of two functions'
+                )
             logger.debug('Disabling prime prior with post-rescaling')
-            self.has_prior_prior = False
+            self.has_prime_prior = False
 
             if post_rescaling == 'logit':
                 if self._update_bounds:

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -518,7 +518,9 @@ class RescaleToBounds(Reparameterisation):
             elif isinstance(rescale_bounds, dict):
                 s = set(parameters) - set(rescale_bounds.keys())
                 if s:
-                    raise RuntimeError(f'Missing bounds for parameters {s}')
+                    raise RuntimeError(
+                        f'Missing rescale bounds for parameters: {s}'
+                    )
                 self.rescale_bounds = rescale_bounds
             else:
                 raise TypeError(
@@ -536,8 +538,9 @@ class RescaleToBounds(Reparameterisation):
                     {p: inversion_type for p in self.parameters}
             else:
                 raise TypeError(
-                    'boundary_inversion must be an instance of list or dict. '
-                    f'Got type: {type(boundary_inversion).__name__}')
+                    'boundary_inversion must be a list, dict or bool. '
+                    f'Got type: {type(boundary_inversion).__name__}'
+                )
         else:
             self.boundary_inversion = []
 
@@ -554,7 +557,8 @@ class RescaleToBounds(Reparameterisation):
 
         if self.detect_edges and not self.boundary_inversion:
             raise RuntimeError(
-                'Must enable boundary inversion to detect edges')
+                'Must enable boundary inversion to use detect edges'
+            )
 
         if prior == 'uniform':
             self.prior = 'uniform'

--- a/nessai/reparameterisations.py
+++ b/nessai/reparameterisations.py
@@ -784,7 +784,7 @@ class RescaleToBounds(Reparameterisation):
                         x, x_prime, log_j, p, pp, compute_radius, **kwargs)
             else:
                 x_prime[pp], lj = \
-                    self._rescale_to_bounds(x[p] - self.offsets[p], p)
+                    self._rescale_to_bounds(x_prime[pp] - self.offsets[p], p)
                 log_j += lj
             if self.has_post_rescaling:
                 x_prime[pp], lj = self.post_rescaling(x_prime[pp])

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -87,6 +87,12 @@ def test_incorrect_bounds_type():
     assert 'Prior bounds must be' in str(excinfo.value)
 
 
+def test_incorrect_bounds_length():
+    with pytest.raises(RuntimeError) as excinfo:
+        Reparameterisation(parameters=['x', 'y'], prior_bounds=[1, 2, 3])
+    assert 'Prior bounds got a list of len > 2' in str(excinfo.value)
+
+
 def test_methods_not_implemented():
     """Test to ensure class fails if user does not define the methods"""
     reparam = Reparameterisation(parameters='x', prior_bounds=[0, 1])

--- a/tests/test_reparameterisations/test_combined.py
+++ b/tests/test_reparameterisations/test_combined.py
@@ -3,12 +3,21 @@
 Test the combined reparameterisation class.
 """
 import numpy as np
+import pytest
+from unittest.mock import MagicMock, call, create_autospec
 
 from nessai.reparameterisations import (
+    Angle,
     CombinedReparameterisation,
+    Reparameterisation,
     RescaleToBounds
     )
 from nessai.livepoint import get_dtype
+
+
+@pytest.fixture
+def reparam():
+    return create_autospec(CombinedReparameterisation)
 
 
 def test_init_none():
@@ -65,3 +74,153 @@ def test_add_multiple_reparameterisations(model):
     np.testing.assert_array_equal(x, x_inv)
     np.testing.assert_array_equal(x_prime_re, x_prime_inv)
     np.testing.assert_array_equal(log_j_re, -log_j_inv)
+
+
+def test_base_add_reparameterisation_missing_requirements(reparam):
+    """Assert an error is raised if a required parameter is missing"""
+    r = MagicMock(spec=Reparameterisation)
+    r.requires = ['x']
+
+    reparam.parameters = ['y']
+    reparam.prime_parameters = ['y_prime']
+
+    with pytest.raises(RuntimeError) as excinfo:
+        CombinedReparameterisation._add_reparameterisation(reparam, r)
+    assert 'missing requirement(s)' in str(excinfo.value)
+
+
+def test_add_reparameterisation(reparam):
+    """Assert add_reparameterisation calls the correct method.
+
+    Should just call CombinedReparameterisation.add_reparameteristions
+    """
+    new_reparam = MagicMock(spec=Reparameterisation)
+    CombinedReparameterisation.add_reparameterisation(reparam, new_reparam)
+    reparam.add_reparameterisations.assert_called_once_with(new_reparam)
+
+
+def test_add_reparameterisations_single(reparam):
+    """Assert add_reparameterisations works correctly for a single reparam.
+
+    Should convert to a list and then pass to `_add_reparameterisation`
+    """
+    new_reparam = MagicMock(spec=Reparameterisation)
+    CombinedReparameterisation.add_reparameterisations(reparam, new_reparam)
+    reparam._add_reparameterisation.assert_called_once_with(new_reparam)
+
+
+def test_add_reparameterisations_multiple(reparam):
+    """Assert add_reparameterisations works correctly with multiple reparams.
+
+    Should call `_add_reparmeterisation` with each reparam.
+    """
+    r1 = MagicMock(spec=Reparameterisation)
+    r2 = MagicMock(spec=Reparameterisation)
+    reparams = [r1, r2]
+    CombinedReparameterisation.add_reparameterisations(reparam, reparams)
+    reparam._add_reparameterisation.assert_has_calls([call(r1), call(r2)])
+
+
+@pytest.mark.parametrize('has', [False, True])
+def test_has_prime_prior(reparam, has):
+    """Assert correct value is returned for has_prime_prior.
+
+    If any of the reparam are missing the prime prior should be False. If all
+    of them have it, should be True.
+    """
+    r1 = MagicMock(spec=Reparameterisation)
+    r2 = MagicMock(spec=Reparameterisation)
+    r1.has_prime_prior = True
+    r2.has_prime_prior = has
+    reparam.values = MagicMock(return_value=[r1, r2])
+
+    out = CombinedReparameterisation.has_prime_prior.__get__(reparam)
+    assert out is has
+
+
+@pytest.mark.parametrize('require', [False, True])
+def test_requires_prime_prior(reparam, require):
+    """Assert correct value is returned for requires prime prior.
+
+    Should be True if any reparam requires the prime prior and False only if
+    none of them do.
+    """
+    r1 = MagicMock(spec=Reparameterisation)
+    r2 = MagicMock(spec=Reparameterisation)
+    r1.requires_prime_prior = False
+    r2.requires_prime_prior = require
+    reparam.values = MagicMock(return_value=[r1, r2])
+
+    out = CombinedReparameterisation.requires_prime_prior.__get__(reparam)
+    assert out is require
+
+
+def test_update_bounds(reparam):
+    """Assert update bounds calls the method for each reparam"""
+    x = [1, 2]
+    # Angle doesn't have update bounds
+    r1 = MagicMock(spec=Angle)
+    # RescaleToBounds does have update bounds
+    r2 = MagicMock(spec=RescaleToBounds)
+    reparam.values = MagicMock(return_value=[r1, r2])
+
+    assert not hasattr(r1, "update_bounds")
+
+    CombinedReparameterisation.update_bounds(reparam, x)
+
+    r2.update_bounds.assert_called_once_with(x)
+
+
+def test_reset_inversion(reparam):
+    """Assert reset inversion calls the method for each reparam"""
+    # Angle doesn't have reset inversion
+    r1 = MagicMock(spec=Angle)
+    # RescaleToBounds does have reset inversion
+    r2 = MagicMock(spec=RescaleToBounds)
+    reparam.values = MagicMock(return_value=[r1, r2])
+
+    assert not hasattr(r1, "reset_inversion")
+
+    CombinedReparameterisation.reset_inversion(reparam)
+
+    r2.reset_inversion.assert_called_once()
+
+
+def test_log_prior(reparam):
+    """Assert log_prior is only called for reparams with has_prior==True"""
+    r1 = MagicMock(spec=Reparameterisation)
+    r2 = MagicMock(spec=Reparameterisation)
+    r3 = MagicMock(spec=Reparameterisation)
+    r1.has_prior = False
+    r2.has_prior = True
+    r3.has_prior = True
+    r1.log_prior = MagicMock()
+    r2.log_prior = MagicMock(return_value=-5)
+    r3.log_prior = MagicMock(return_value=-6)
+    reparam.values = MagicMock(return_value=[r1, r2, r3])
+
+    x = [1, 2]
+
+    out = CombinedReparameterisation.log_prior(reparam, x)
+
+    assert out == -11
+    r1.log_prior.assert_not_called()
+    r2.log_prior.assert_called_once_with(x)
+    r3.log_prior.assert_called_once_with(x)
+
+
+def test_x_prime_log_prior(reparam):
+    """Assert x_prime_log_prior is called for all reparams"""
+    r1 = MagicMock(spec=Reparameterisation)
+    r2 = MagicMock(spec=Reparameterisation)
+    r1.x_prime_log_prior = MagicMock(return_value=-4)
+    r2.x_prime_log_prior = MagicMock(return_value=-5)
+    reparam.values = MagicMock(return_value=[r1, r2])
+
+    x = [1, 2]
+
+    out = CombinedReparameterisation. x_prime_log_prior(reparam, x)
+
+    assert out == -9
+    r1.x_prime_log_prior.assert_called_once_with(x)
+    r2.x_prime_log_prior.assert_called_once_with(x)

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -4,7 +4,7 @@ Test the RescaleToBound class.
 """
 import numpy as np
 import pytest
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, call, create_autospec
 
 from nessai.reparameterisations import RescaleToBounds
 from nessai.livepoint import get_dtype, numpy_array_to_live_points
@@ -52,7 +52,10 @@ def assert_invertibility(model, n=100):
     return test_invertibility
 
 
-@pytest.mark.parametrize('rescale_bounds', [None, [0, 1]])
+@pytest.mark.parametrize(
+    'rescale_bounds',
+    [None, [0, 1], {'x': [0, 1], 'y': [-1, 1]}]
+)
 def test_rescale_bounds(reparameterisation, assert_invertibility,
                         rescale_bounds):
     """Test the different options for rescale to bounds"""
@@ -66,15 +69,68 @@ def test_rescale_bounds(reparameterisation, assert_invertibility,
     assert assert_invertibility(reparam)
 
 
-@pytest.mark.parametrize('boundary_inversion', [False,
-                                                True,
-                                                ['x']])
+def test_rescale_bounds_dict_missing_params(reparam):
+    """Assert an error is raised if the rescale_bounds dict is missing a
+    parameter.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.__init__(
+            reparam,
+            parameters=['x', 'y'],
+            prior_bounds={'x': [-1, 1], 'y': [0, 1]},
+            rescale_bounds={'x': [0, 1]}
+        )
+    assert 'Missing rescale bounds for parameters' in str(excinfo.value)
+
+
+def test_rescale_bounds_incorrect_type(reparam):
+    """Assert an error is raised if the rescale_bounds is an invalid type."""
+    with pytest.raises(TypeError) as excinfo:
+        RescaleToBounds.__init__(
+            reparam,
+            parameters=['x', 'y'],
+            prior_bounds={'x': [-1, 1], 'y': [0, 1]},
+            rescale_bounds=1,
+        )
+    assert 'must be an instance of list or dict' in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    'boundary_inversion',
+    [False, True, ['x'], {'x': 'split'}, {'x': 'inversion'}]
+)
 def test_boundary_inversion(reparameterisation, assert_invertibility,
                             boundary_inversion):
     """Test the different options for rescale to bounds"""
     reparam = reparameterisation({'boundary_inversion': boundary_inversion})
 
     assert assert_invertibility(reparam)
+
+
+def test_boundary_inversion_invalid_type(reparam):
+    """Assert an error is raised in the type is invalid"""
+    with pytest.raises(TypeError) as excinfo:
+        RescaleToBounds.__init__(
+            reparam,
+            parameters='x',
+            prior_bounds=[0, 1],
+            boundary_inversion='Yes',
+        )
+    assert 'boundary_inversion must be a list, dict or bool' \
+        in str(excinfo.value)
+
+
+def test_detect_edges_without_inversion(reparam):
+    """Assert detect edges cannot be used with boundary inversion"""
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.__init__(
+            reparam,
+            parameters=['x', 'y'],
+            prior_bounds={'x': [-1, 1], 'y': [0, 1]},
+            detect_edges=True,
+        )
+    assert 'Must enable boundary inversion to use detect edges' \
+        in str(excinfo.value)
 
 
 def test_set_bounds(reparam):
@@ -86,6 +142,183 @@ def test_set_bounds(reparam):
     RescaleToBounds.set_bounds(reparam, {'x': np.array([-10, 10])})
     np.testing.assert_array_equal(reparam.pre_prior_bounds['x'], [-5, 5])
     np.testing.assert_array_equal(reparam.bounds['x'], [-6, 4])
+
+
+def test_set_offets(reparam):
+    """Assert the offset are set correctly"""
+    reparam.pre_rescaling = lambda x: (x / 2, 0.0)
+
+    RescaleToBounds.__init__(
+        reparam,
+        parameters=['x', 'y'],
+        prior_bounds={'x': [8, 32], 'y': [2, 4]},
+        offset=True,
+    )
+
+    assert reparam.offsets == {'x': 10.0, 'y': 1.5}
+
+
+def test_reset_inversion(reparam):
+    """Assert the edges are reset correctly"""
+    reparam.parameters = ['x', 'y']
+    reparam._edges = {'x': [-10, 10], 'y': [-5, 5]}
+    RescaleToBounds.reset_inversion(reparam)
+    assert reparam._edges == {'x': None, 'y': None}
+
+
+def test_x_prime_log_prior_error(reparam):
+    """Assert an error is raised if the prime prior is not defined."""
+    reparam.has_prime_prior = False
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.x_prime_log_prior(reparam, 0.1)
+    assert 'Prime prior is not configured' in str(excinfo.value)
+
+
+def test_default_pre_rescaling(reparam):
+    """Assert the default pre-rescaling is the identity"""
+    x = np.array([1, 2, 3])
+    expected_log_j = np.zeros(3)
+    x_out, log_j = RescaleToBounds.pre_rescaling(reparam, x)
+    x_out_inv, log_j_inv = RescaleToBounds.pre_rescaling_inv(reparam, x)
+
+    np.testing.assert_array_equal(x_out, x)
+    np.testing.assert_array_equal(x_out_inv, x)
+    np.testing.assert_array_equal(log_j, expected_log_j)
+    np.testing.assert_array_equal(log_j_inv, expected_log_j)
+
+
+def test_default_post_rescaling(reparam):
+    """Assert the default post-rescaling is the identity"""
+    x = np.array([1, 2, 3])
+    expected_log_j = np.zeros(3)
+    x_out, log_j = RescaleToBounds.post_rescaling(reparam, x)
+    x_out_inv, log_j_inv = RescaleToBounds.post_rescaling_inv(reparam, x)
+
+    np.testing.assert_array_equal(x_out, x)
+    np.testing.assert_array_equal(x_out_inv, x)
+    np.testing.assert_array_equal(log_j, expected_log_j)
+    np.testing.assert_array_equal(log_j_inv, expected_log_j)
+
+
+def test_configure_pre_rescaling_none(reparam):
+    """Test the configuration of the pre-rescaling if it is None"""
+    RescaleToBounds.configure_pre_rescaling(reparam, None)
+    assert reparam.has_pre_rescaling is False
+
+
+def test_configure_post_rescaling_none(reparam):
+    """Test the configuration of the post-rescaling if it is None"""
+    RescaleToBounds.configure_post_rescaling(reparam, None)
+    assert reparam.has_post_rescaling is False
+
+
+def test_pre_rescaling_with_functions(reparam):
+    """Assert that specifying functions works as intended"""
+    rescaling = (np.exp, np.log)
+    RescaleToBounds.configure_pre_rescaling(reparam, rescaling)
+    assert reparam.has_pre_rescaling is True
+    assert reparam.pre_rescaling is np.exp
+    assert reparam.pre_rescaling_inv is np.log
+
+
+def test_post_rescaling_with_functions(reparam):
+    """Assert that specifying functions works as intended"""
+    rescaling = (np.exp, np.log)
+    RescaleToBounds.configure_post_rescaling(reparam, rescaling)
+    assert reparam.has_post_rescaling is True
+    assert reparam.has_prime_prior is False
+    assert reparam.post_rescaling is np.exp
+    assert reparam.post_rescaling_inv is np.log
+
+
+def test_pre_rescaling_with_str(reparam):
+    """Assert that specifying a str works as intended"""
+    from nessai.utils.rescaling import rescaling_functions
+    rescaling = 'logit'
+    RescaleToBounds.configure_pre_rescaling(reparam, rescaling)
+    assert reparam.has_pre_rescaling is True
+    assert reparam.pre_rescaling is rescaling_functions['logit'][0]
+    assert reparam.pre_rescaling_inv is rescaling_functions['logit'][1]
+
+
+def test_pre_rescaling_with_invalid_str(reparam):
+    """Assert an error is raised if the rescaling is not recognised"""
+    rescaling = 'not_a_rescaling'
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.configure_pre_rescaling(reparam, rescaling)
+    assert 'Unknown rescaling function: not_a_rescaling' in str(excinfo.value)
+
+
+def test_post_rescaling_with_invalid_str(reparam):
+    """Assert an error is raised if the rescaling is not recognised"""
+    rescaling = 'not_a_rescaling'
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.configure_post_rescaling(reparam, rescaling)
+    assert 'Unknown rescaling function: not_a_rescaling' in str(excinfo.value)
+
+
+def test_post_rescaling_with_str(reparam):
+    """Assert that specifying a str works as intended.
+
+    Also test the config for the logit
+    """
+    reparam._update_bounds = False
+    reparam.parameters = ['x']
+    from nessai.utils.rescaling import rescaling_functions
+    rescaling = 'logit'
+    RescaleToBounds.configure_post_rescaling(reparam, rescaling)
+    assert reparam.has_post_rescaling is True
+    assert reparam.has_prime_prior is False
+    assert reparam.post_rescaling is rescaling_functions['logit'][0]
+    assert reparam.post_rescaling_inv is rescaling_functions['logit'][1]
+    assert reparam.rescale_bounds == {'x': [0, 1]}
+
+
+def test_post_rescaling_with_logit_update_bounds(reparam):
+    """Assert an error is raised if using logit and update bounds"""
+    reparam._update_bounds = True
+    rescaling = 'logit'
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.configure_post_rescaling(reparam, rescaling)
+    assert 'Cannot use logit with update bounds' in str(excinfo.value)
+
+
+def test_pre_rescaling_invalid_input(reparam):
+    """Assert an error is raised if the input isn't a str or tuple"""
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.configure_pre_rescaling(reparam, (np.exp, ))
+    assert 'Pre-rescaling must be a str or tuple' in str(excinfo.value)
+
+
+def test_post_rescaling_invalid_input(reparam):
+    """Assert an error is raised if the input isn't a str or tuple"""
+    with pytest.raises(RuntimeError) as excinfo:
+        RescaleToBounds.configure_post_rescaling(reparam, (np.exp, ))
+    assert 'Post-rescaling must be a str or tuple' in str(excinfo.value)
+
+
+def test_update_bounds_disabled(reparam, caplog):
+    """Assert nothing happens in _update_bounds is False"""
+    caplog.set_level('DEBUG')
+    reparam._update_bounds = False
+    RescaleToBounds.update_bounds(reparam, [0, 1])
+    assert 'Update bounds not enabled' in str(caplog.text)
+
+
+def test_update_bounds(reparam):
+    """Assert the correct values are returned"""
+    reparam.offsets = {'x': 0.0, 'y': 1.0}
+    reparam.pre_rescaling = MagicMock(
+        side_effect=lambda x: (x, np.zeros_like(x))
+    )
+    reparam.parameters = ['x', 'y']
+    x = {'x': [-1, 0, 1], 'y': [-2, 0, 2]}
+    RescaleToBounds.update_bounds(reparam, x)
+    reparam.update_prime_prior_bounds.assert_called_once()
+    reparam.pre_rescaling.assert_has_calls(
+        [call(-1), call(1), call(-2), call(2)]
+    )
+    assert reparam.bounds == {'x': [-1, 1], 'y': [-3, 1]}
 
 
 @pytest.mark.integration_test

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -918,13 +918,13 @@ def test_pre_rescaling_integration(is_invertible, model):
     # Trick to get a 1d model to test only x
     model._names.remove('y')
     model._bounds = {'x': [1.0, np.e]}
-    assert is_invertible(reparam, model=model)
+    assert is_invertible(reparam, model=model, decimal=12)
 
 
 @pytest.mark.parametrize(
     'kwargs, decimal',
     [
-        (dict(post_rescaling='logit', update_bounds=False), 13),
+        (dict(post_rescaling='logit', update_bounds=False), 10),
         (dict(update_bounds=False), None),
         (dict(update_bounds=False, boundary_inversion=True), None),
         (dict(boundary_inversion=['x']), None),


### PR DESCRIPTION
Improve the test coverage across all of the reparameterisations in `nessai.reparameterisations`.

As a result of adding these tests, I've fixed a minor bug in `RescaleToBounds` when using a pre-rescaling function without boundary inversion. This shouldn't affect most users. Pre-rescaling is only used in `DistanceReparameterisation` and that always has boundary inversion enabled.

I've also improved a few of the error messages and doc-strings

**To-do**

- [x] Add a couple more integration tests for `RescaleToBounds`
- [x] Update the changelog 