### PR TITLE
Tweak model reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ vertical lines that can appear in the subplots.
 - Rework `MaskedAutoregressiveFlow` to add `context_features`
 - Rework how likelihood parallelisation is handled. The model now contains the pool instead of the sampler and proposals.
 - Update `parallelisation_example.py` to show use of `n_pool` and `pool` for parallelisation.
+- Simplify how the normalising flow is reset in `FlowModel` and `NestedSampler`.
 
 
 ### Fixed

--- a/nessai/flowmodel.py
+++ b/nessai/flowmodel.py
@@ -138,6 +138,8 @@ class FlowModel:
     output : str, optional
         Path for output, this includes weights files and the loss plot.
     """
+    model_config = None
+
     def __init__(self, config=None, output='./'):
         self.model = None
         self.initialised = False
@@ -593,7 +595,10 @@ class FlowModel:
         if not any([weights, permutations]):
             logger.debug('Nothing to reset')
             return
-        if weights:
+        if weights and permutations:
+            logger.debug('Complete reset of model')
+            self.model, self.device = configure_model(self.model_config)
+        elif weights:
             self.model.apply(reset_weights)
             logger.debug('Reset weights')
         elif permutations:

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -807,13 +807,16 @@ class NestedSampler:
             self.proposal.reset_model_weights(weights=True, permutations=True)
             return
 
-        if (self.reset_weights and
-                not (self.proposal.training_count % self.reset_weights)):
-            self.proposal.reset_model_weights(weights=True)
-
-        if (self.reset_permutations and
-                not (self.proposal.training_count % self.reset_permutations)):
-            self.proposal.reset_model_weights(weights=False, permutations=True)
+        self.proposal.reset_model_weights(
+            weights=(
+                self.reset_weights and
+                not (self.proposal.training_count % self.reset_weights)
+            ),
+            permutations=(
+                self.reset_permutations and
+                not (self.proposal.training_count % self.reset_permutations)
+            ),
+        )
 
     def train_proposal(self, force=False):
         """

--- a/tests/test_flowmodel.py
+++ b/tests/test_flowmodel.py
@@ -191,10 +191,26 @@ def test_early_optimiser_init(flow_model):
 
 @pytest.mark.parametrize('weights', [False, True])
 @pytest.mark.parametrize('perms', [False, True])
-def test_reset_model(flow_model, weights, perms):
+def test_reset_model(model, weights, perms):
     """Test resetting the model"""
-    flow_model.initialise()
-    flow_model.reset_model(weights=weights, permutations=perms)
+    model.model = MagicMock()
+    model.apply = MagicMock()
+    model.get_optimiser = MagicMock()
+    model.optimiser = MagicMock()
+    model.optimiser_kwargs = {'lr': 0.01}
+
+    with patch(
+        'nessai.flowmodel.configure_model',
+        return_value=(MagicMock, 'cpu'),
+    ) as mock:
+        FlowModel.reset_model(model, weights=weights, permutations=perms)
+
+    if weights and perms:
+        mock.assert_called_once()
+    if any([weights, perms]):
+        model.get_optimiser.assert_called_once_with(model.optimiser, lr=0.01)
+    else:
+        model.get_optimiser.assert_not_called()
 
 
 def test_sample_and_log_prob_not_initialised(flow_model, data_dim):

--- a/tests/test_nested_sampler/test_flow_proposal.py
+++ b/tests/test_nested_sampler/test_flow_proposal.py
@@ -6,7 +6,7 @@ training itself.
 import datetime
 import numpy as np
 import pytest
-from unittest.mock import call, MagicMock
+from unittest.mock import MagicMock
 from nessai.nestedsampler import NestedSampler
 
 
@@ -148,7 +148,9 @@ def test_check_flow_model_reset_weights(sampler, training_count):
 
     NestedSampler.check_flow_model_reset(sampler)
 
-    sampler.proposal.reset_model_weights.assert_called_once_with(weights=True)
+    sampler.proposal.reset_model_weights.assert_called_once_with(
+        weights=True, permutations=False,
+    )
 
 
 @pytest.mark.parametrize('training_count', [10, 100])
@@ -164,7 +166,8 @@ def test_check_flow_model_reset_permutations(sampler, training_count):
     NestedSampler.check_flow_model_reset(sampler)
 
     sampler.proposal.reset_model_weights.assert_called_once_with(
-        weights=False, permutations=True)
+        weights=False, permutations=True
+    )
 
 
 @pytest.mark.parametrize('training_count', [10, 100])
@@ -179,8 +182,9 @@ def test_check_flow_model_reset_both(sampler, training_count):
 
     NestedSampler.check_flow_model_reset(sampler)
 
-    calls = [call(weights=True), call(weights=False, permutations=True)]
-    sampler.proposal.reset_model_weights.assert_has_calls(calls)
+    sampler.proposal.reset_model_weights.assert_called_once_with(
+        weights=True, permutations=True,
+    )
 
 
 def test_check_flow_model_reset_acceptance(sampler):


### PR DESCRIPTION
Simplify how the normalising flow is reset.

**Changes**

* If resetting both the weights and the permutations, simply create a new model instead of resetting both independently.
* Reset the flow in a single call to `FlowModel.reset_model` in `NestedSampler.check_flow_model_reset` instead of separate calls for weights and permutations.