### PR TITLE
Fix slow integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,9 @@ jobs:
         pip install -r requirements.txt
         pip install -r dev_requirements.txt
         pip install -e .
-    - name: Run integration tests with pytest
+    - name: Run (quick) integration tests
       run: |
-        pytest tests/ -m "integration_test or slow_integration_test"
+        pytest tests/ -m "integration_test"
+    - name: Run slow integration tests
+      run: |
+        pytest tests/ -m "slow_integration_test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ vertical lines that can appear in the subplots.
 ### Fixed
 
 - Fixed a bug in `RescaleToBounds` when using `pre_rescaling` without boundary inversion.
+- Fixed slow integration tests not running if a quick integration test is reran after failing.
 
 ### Removed
 


### PR DESCRIPTION
Separate quick and slow integration tests into separate actions in the integration test workflow.

Closes https://github.com/mj-will/nessai/issues/152