### PR TITLE
running-the-sampler.rst/Fix up a typo

### DIFF
--- a/docs/running-the-sampler.rst
+++ b/docs/running-the-sampler.rst
@@ -44,7 +44,7 @@ Once a modelled is defined, create an instance of :py:class:`nessai.flowsampler.
     from nessai.flowsampler import FlowSampler
 
     # Initialise sampler with the model
-    sampler = FlowSampler(Gaussian(), output='./', nlive=1000)
+    sampler = FlowSampler(GaussianModel(), output='./', nlive=1000)
     # Run the sampler
     sampler.run()
 


### PR DESCRIPTION
This block of code is not imported from an example, so probably it was missed and never checked again.