### PR TITLE
Fix multivariate normal variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ vertical lines that can appear in the subplots.
 - Fixed slow integration tests not running if a quick integration test is reran after failing.
 - Fixed a bug that prevented the use of `prior_sampling=True` with `FlowSampler`.
 - Fix issue when creating multiple instances of `FlowSampler` with the same output directory when resuming is enabled as reported in [#155](https://github.com/mj-will/nessai/issues/155).
+- Fixed missing square-root in `nessai.flows.distributions.MultivariateGaussian._sample` and fix the corresponding unit test.
 
 
 ### Removed

--- a/nessai/flows/distributions.py
+++ b/nessai/flows/distributions.py
@@ -2,6 +2,7 @@
 """
 Distributions to use as the 'base distribution' for normalising flows.
 """
+import math
 
 from nflows.distributions import Distribution
 from nflows.utils import torchutils
@@ -26,6 +27,7 @@ class MultivariateNormal(Distribution):
         super().__init__()
         self._shape = torch.Size(shape)
         self._var = var
+        self._std = math.sqrt(var)
 
         self.register_buffer(
             "_log_z",
@@ -47,7 +49,7 @@ class MultivariateNormal(Distribution):
 
     def _sample(self, num_samples, context):
         if context is None:
-            return torch.normal(0, self._var,
+            return torch.normal(0, self._std,
                                 size=(num_samples, *self._shape),
                                 device=self._log_z.device)
         else:

--- a/tests/test_flows/test_distributions.py
+++ b/tests/test_flows/test_distributions.py
@@ -52,14 +52,15 @@ def test_log_prob_invalid_shape(dist, dims):
 
 
 @pytest.mark.flaky(run=5)
-def test_sample(dist, scipy_dist):
+def test_sample(dist, var):
     """
     Test the sample method and check if the resulting samples pass a
-    KS test using the scipy distribution
+    KS test using the scipy distribution. Tests each dimensions one at a time.
     """
     samples = dist._sample(1000, None).numpy()
-    p, _ = stats.kstest(samples, scipy_dist.cdf)
-    assert p > 0.05
+    for s in samples.T:
+        _, p = stats.kstest(s, stats.norm(scale=np.sqrt(var)).cdf)
+        assert p > 0.05
 
 
 def test_sample_context(dist):


### PR DESCRIPTION
Fix call to `torch.sample` that was using the variance instead of the standard deviation.

**Effect on existing results**

The distribution `MultivariateNorm` isn't used anywhere in the code, so this bug shouldn't affect existing results.

**Testing**

The unit test that was meant to check the distribution was incorrectly checking the KS statistic instead of the p-value. Also, the [KS test in scipy](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstest.html) doesn't support n-dimensional samples. After fixing the test, the existing implementation fails as expected.