### PR TITLE
Tweak proposal logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ vertical lines that can appear in the subplots.
 - Rework how likelihood parallelisation is handled. The model now contains the pool instead of the sampler and proposals.
 - Update `parallelisation_example.py` to show use of `n_pool` and `pool` for parallelisation.
 - Simplify how the normalising flow is reset in `FlowModel` and `NestedSampler`.
+- Reduce logging level a some statements in `FlowProposal`.
 
 
 ### Fixed

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -531,8 +531,9 @@ class FlowProposal(RejectionProposal):
         else:
             self._poolsize_scale = 1.0 / acceptance
             if self._poolsize_scale > self.max_poolsize_scale:
-                logger.warning(
-                    'Poolsize scaling is greater than maximum value')
+                logger.info(
+                    'Poolsize scaling is greater than maximum value'
+                )
                 self._poolsize_scale = self.max_poolsize_scale
             if self._poolsize_scale < 1.:
                 self._poolsize_scale = 1.
@@ -1433,9 +1434,10 @@ class FlowProposal(RejectionProposal):
                 continue
 
             if warn and (x.size / self.drawsize < 0.01):
-                logger.warning(
+                logger.info(
                     'Rejection sampling accepted less than 1 percent of '
-                    f'samples! ({x.size / self.drawsize})')
+                    f'samples! ({x.size / self.drawsize})'
+                )
                 warn = False
 
             n = min(x.size, N - accepted)


### PR DESCRIPTION
Reduce the log levels for two warnings to info:
* `05-13 10:37 nessai.proposal.flowproposal WARNING : Poolsize scaling is greater than maximum value`
* `05-13 10:37 nessai.proposal.flowproposal WARNING : Rejection sampling accepted less than 1 percent of samples! (0.005)`

**Motivation**
These logging statements don't indicate issues in the sampling but rather that sampling will be slow, so they shouldn't be warnings.