### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -e .
     - name: Run (quick) integration tests
       run: |
-        pytest tests/ -m "integration_test"
+        pytest -v tests/ -m "integration_test"
     - name: Run slow integration tests
       run: |
-        pytest tests/ -m "slow_integration_test"
+        pytest -v tests/ -m "slow_integration_test"

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
@@ -10,9 +10,11 @@ from nessai.livepoint import numpy_array_to_live_points
 torch.set_num_threads(1)
 
 
-@pytest.mark.parametrize('latent_prior', ['gaussian', 'truncated_gaussian',
-                                          'uniform_nball', 'uniform_nsphere',
-                                          'uniform'])
+@pytest.mark.parametrize(
+    'latent_prior',
+    ['gaussian', 'truncated_gaussian', 'uniform_nball', 'uniform_nsphere',
+     'uniform']
+)
 @pytest.mark.parametrize('expansion_fraction', [0, 1, None])
 @pytest.mark.parametrize('check_acceptance', [False, True])
 @pytest.mark.parametrize('rescale_parameters', [False, True])
@@ -20,19 +22,26 @@ torch.set_num_threads(1)
 @pytest.mark.timeout(10)
 @pytest.mark.flaky(run=3)
 @pytest.mark.integration_test
-def test_flowproposal_populate(tmpdir, model, latent_prior, expansion_fraction,
-                               check_acceptance, rescale_parameters,
-                               max_radius):
+def test_flowproposal_populate(
+    tmp_path,
+    model,
+    latent_prior,
+    expansion_fraction,
+    check_acceptance,
+    rescale_parameters,
+    max_radius,
+):
     """
     Test the populate method in the FlowProposal class with a range of
     parameters
     """
-    output = str(tmpdir.mkdir('flowproposal'))
+    output = tmp_path / 'flowproposal'
+    output.mkdir()
     fp = FlowProposal(
         model,
         output=output,
         plot=False,
-        poolsize=100,
+        poolsize=10,
         latent_prior=latent_prior,
         expansion_fraction=expansion_fraction,
         check_acceptance=check_acceptance,
@@ -42,10 +51,10 @@ def test_flowproposal_populate(tmpdir, model, latent_prior, expansion_fraction,
     )
 
     fp.initialise()
-    worst = numpy_array_to_live_points(0.5 * np.ones(fp.dims), fp.names)
-    fp.populate(worst, N=100)
+    worst = numpy_array_to_live_points(0.1 * np.ones(fp.dims), fp.names)
+    fp.populate(worst, N=10)
 
-    assert fp.x.size == 100
+    assert fp.x.size == 10
 
 
 @pytest.mark.parametrize('plot', [False, True])


### PR DESCRIPTION
Fix broken quick integration tests, e.g. https://github.com/mj-will/nessai/actions/runs/2351289919.

Broken test tries to populate flowproposal using different latent priors, some of these can be very inefficient, so I've tried reducing the number of samples.

Also not clear why the `timeout` mark isn't stopping these tests.