### PR TITLE
Fix bilby requirement for python > 3.6

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,4 +6,5 @@ pytest-integration
 pre-commit
 lalsuite
 bilby<=1.1.3 ; python_version == '3.6'
+bilby ; python_version > '3.6'
 astropy


### PR DESCRIPTION
The integration tests that use `bilby` weren't running because `bilby` wasn't being installed for Python > 3.6. This PR adds bilby for python versions > 3.6