### PR TITLE
Fix lu cache reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,11 @@ vertical lines that can appear in the subplots.
 - Fixed a bug that prevented the use of `prior_sampling=True` with `FlowSampler`.
 - Fix issue when creating multiple instances of `FlowSampler` with the same output directory when resuming is enabled as reported in [#155](https://github.com/mj-will/nessai/issues/155).
 - Fixed missing square-root in `nessai.flows.distributions.MultivariateGaussian._sample` and fix the corresponding unit test.
+<<<<<<< HEAD
 - Fix issue with cosmology in `ComovingDistanceConverter` caused by changes to `astropy.cosmology` in version 5.1.
+=======
+- Fixed bug with caching in `LULinear` transform when reloading a checkpointed flow.
+>>>>>>> Update changelog
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,8 @@ vertical lines that can appear in the subplots.
 - Fixed a bug that prevented the use of `prior_sampling=True` with `FlowSampler`.
 - Fix issue when creating multiple instances of `FlowSampler` with the same output directory when resuming is enabled as reported in [#155](https://github.com/mj-will/nessai/issues/155).
 - Fixed missing square-root in `nessai.flows.distributions.MultivariateGaussian._sample` and fix the corresponding unit test.
-<<<<<<< HEAD
 - Fix issue with cosmology in `ComovingDistanceConverter` caused by changes to `astropy.cosmology` in version 5.1.
-=======
 - Fixed bug with caching in `LULinear` transform when reloading a checkpointed flow.
->>>>>>> Update changelog
 
 
 ### Removed

--- a/nessai/flowmodel.py
+++ b/nessai/flowmodel.py
@@ -523,6 +523,9 @@ class FlowModel:
                 logger.info(f'Epoch {epoch}: Reached patience')
                 break
 
+        # Make sure caches are reset
+        self.model.train()
+        self.model.eval()
         self.model.load_state_dict(best_model)
         self.save_weights(current_weights_file)
         self.move_to(self.inference_device)


### PR DESCRIPTION
This PR fixes a bug with caching in the `LULinear` transform when reloading a checkpointed flow.

**Details**

The cache in `LULinear` is not saved as a part of the state dictionary when checkpointing a flow and when loading a flow from a state dictionary, the cache is not updated. Therefore, the incorrect cached weights and biases will be used unless the cache is reset. This will not bias the results but will most likely make sampling less efficient in cases with many iterations after the "best epoch".
