### PR TITLE
Fix astropy cosmology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ vertical lines that can appear in the subplots.
 - Fixed a bug that prevented the use of `prior_sampling=True` with `FlowSampler`.
 - Fix issue when creating multiple instances of `FlowSampler` with the same output directory when resuming is enabled as reported in [#155](https://github.com/mj-will/nessai/issues/155).
 - Fixed missing square-root in `nessai.flows.distributions.MultivariateGaussian._sample` and fix the corresponding unit test.
+- Fix issue with cosmology in `ComovingDistanceConverter` caused by changes to `astropy.cosmology` in version 5.1.
 
 
 ### Removed

--- a/nessai/gw/utils.py
+++ b/nessai/gw/utils.py
@@ -228,9 +228,7 @@ class ComovingDistanceConverter(DistanceConverter):
         except AttributeError:
             raise RuntimeError(
                 f'Could not get specified cosmology ({cosmology}) from '
-                '`astropy.cosmology`. Available cosmologies are: '
-                f'{cosmo.parameters.available}. See astropy documentation '
-                'for more details.'
+                '`astropy.cosmology`. See astropy documentation for details.'
             )
         self.scale = np.float64(scale)
         self.pad = pad


### PR DESCRIPTION
Changes to `astropy.cosmology` in version 5.1 are breaking the unit tests (e.g. https://github.com/mj-will/nessai/actions/runs/2474312085) this fixes this by removing the list of available cosmologies from one of the error messages.
