### PR TITLE
Fix initial live points bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed a bug where live points where added to the initial points with incorrect log-likelihood and log-prior.
 
 ## [0.5.0] - 2022-06-14
 ### Added

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -3,6 +3,7 @@
 Functions and objects related to the main nested sampling algorithm.
 """
 from collections import deque
+from copy import copy
 import datetime
 import logging
 import os
@@ -556,7 +557,7 @@ class NestedSampler:
             counter = 0
             while True:
                 counter += 1
-                newparam = self.proposal.draw(oldparam.copy())
+                newparam = self.proposal.draw(copy(oldparam))
 
                 # Prior is computed in the proposal
                 if newparam['logP'] != -np.inf:
@@ -652,8 +653,9 @@ class NestedSampler:
         with tqdm(total=self.nlive, desc='Drawing live points') as pbar:
             while i < self.nlive:
                 while i < self.nlive:
-                    count, live_point = next(
-                            self.yield_sample(self.model.new_point()))
+                    _, live_point = next(self.yield_sample(None))
+                    if live_point is None:
+                        break
                     if np.isnan(live_point['logL']):
                         logger.warning(
                             'Likelihood function returned NaN for '


### PR DESCRIPTION
Fix a bug where the point input to `yield_sample` would be returned and added to the live points.

These points have not had the likelihood or the prior evaluated, so the default to the current initial value of 0. This then biases the sampling since these points have incorrect prior and likelihood values.

**Fix**
Input `None` to `yield_sample` and add an if statement to handle `None` being returned.

**Future**
In the future, the changes proposed in https://github.com/mj-will/nessai/pull/170 will address this by changing the defaults for `logP` and `logL` to `np.nan`.