### PR TITLE
Add prior dtype warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Add a warning in `Model.verify_model` when `Model.log_prior` returns an array that has `float16` precision.
+
+
 ## [0.5.1] - 2022-06-20
 
 ## Fixed

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -524,6 +524,13 @@ class Model(ABC):
             raise RuntimeError('Log-likelihood function did not return '
                                'a likelihood value')
 
+        if self.log_prior(x).dtype == np.dtype("float16"):
+            logger.critical(
+                "log_prior returned an array with float16 precision. "
+                "This not recommended and can lead to numerical errors."
+                " Consider casting to a higher precision."
+            )
+
     def __getstate__(self):
         state = self.__dict__.copy()
         state['pool'] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 
 from numpy.random import seed
+import numpy as np
 import pytest
 from scipy.stats import norm
 import torch
@@ -22,11 +23,9 @@ def model():
             self.names = ['x', 'y']
 
         def log_prior(self, x):
-            log_p = 0.
+            log_p = np.log(self.in_bounds(x), dtype='float')
             for n in self.names:
-                log_p += ((x[n] >= self.bounds[n][0])
-                          & (x[n] <= self.bounds[n][1])) \
-                        / (self.bounds[n][1] - self.bounds[n][0])
+                log_p -= (self.bounds[n][1] - self.bounds[n][0])
             return log_p
 
         def log_likelihood(self, x):


### PR DESCRIPTION
Add a warning in  `Model.verify_model` when `Model.log_prior` returns an array with dtype `float16`.

**Motivation**
Rounding because of using `float16` can cause discreteness in the log-prior space which may bias results. This does not affect cases where the prior is uniform.

This mostly occurs when calling:

```python
log_p = np.log(self.in_bounds(x))
```
Users should instead use

```python
log_p = np.log(self.in_bounds(x), dtype="float")
```
**Examples**
The examples will be updated in an accompanying pull request.