### PR TITLE
Fix populate when not empty bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a warning in `Model.verify_model` when `Model.log_prior` returns an array that has `float16` precision.
 
+### Fixed
+
+- Fixed a bug in `FlowProposal.populate` which occurred when the pool of samples was not empty (closes [#176](https://github.com/mj-will/nessai/issues/176))
 
 ## [0.5.1] - 2022-06-20
 

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1411,11 +1411,15 @@ class FlowProposal(RejectionProposal):
 
         self.alt_dist = self.get_alt_distribution()
 
-        if not self.indices:
-            self.x = np.empty(N,  dtype=self.population_dtype)
-            self.x['logP'] = np.nan * np.ones(N)
-            self.indices = []
-            z_samples = np.empty([N, self.dims])
+        if self.indices:
+            logger.info(
+                "Existing pool of samples is not empty. "
+                "Discarding existing samples."
+            )
+        self.x = np.empty(N,  dtype=self.population_dtype)
+        self.x['logP'] = np.nan * np.ones(N)
+        self.indices = []
+        z_samples = np.empty([N, self.dims])
 
         proposed = 0
         accepted = 0

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_population.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_population.py
@@ -286,7 +286,8 @@ def test_check_prior_bounds(proposal):
 
 
 @pytest.mark.parametrize('check_acceptance', [False, True])
-def test_populate(proposal, check_acceptance):
+@pytest.mark.parametrize('indices', [[], [1]])
+def test_populate(proposal, check_acceptance, indices):
     """Test the main populate method"""
     n_dims = 2
     poolsize = 10
@@ -316,7 +317,7 @@ def test_populate(proposal, check_acceptance):
     proposal.drawsize = drawsize
     proposal.min_radius = 0.1
     proposal.fuzz = 1.0
-    proposal.indices = []
+    proposal.indices = indices
     proposal.approx_acceptance = [0.4]
     proposal.acceptance = [0.7]
     proposal.keep_samples = False


### PR DESCRIPTION
Fixes a bug that occurred when the sample pool in `FlowProposal` was not empty and `populate` was called.

Also added a logging statement to let the user know when this happens.

Closes https://github.com/mj-will/nessai/issues/176