### PR TITLE
Fix tests broken by new numpy release

### DIFF
--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -499,7 +499,7 @@ def test_rescale_to_bounds(proposal, model, n, compute_radius):
         FlowProposal._rescale_to_bounds(
             proposal, x, compute_radius=compute_radius)
 
-    np.testing.assert_equal(log_j, -np.log(20))
+    np.testing.assert_allclose(log_j, -np.log(20), rtol=1e-14)
     assert_structured_arrays_equal(x_prime, x_prime_expected)
 
 
@@ -701,7 +701,7 @@ def test_inverse_rescale_to_bounds(proposal, model, n):
     x, log_j = \
         FlowProposal._inverse_rescale_to_bounds(proposal, x_prime)
 
-    np.testing.assert_equal(log_j, np.log(20))
+    np.testing.assert_allclose(log_j, np.log(20), rtol=1e-14)
     assert_structured_arrays_equal(x, x_expected)
 
 

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -436,7 +436,7 @@ def test_rescale_w_reparameterisation(proposal, n):
     np.testing.assert_array_equal(
         x_prime[['x_prime', 'y_prime']], x_prime_out[['x_prime', 'y_prime']])
     np.testing.assert_array_equal(
-        x[['logP', 'logL']], x_prime_out[['logL', 'logP']])
+        x[['logP', 'logL']], x_prime_out[['logP', 'logL']])
     proposal._reparameterisation.reparameterise.assert_called_once()
 
 
@@ -459,7 +459,7 @@ def test_inverse_rescale_w_reparameterisation(proposal, n):
 
     np.testing.assert_array_equal(x[['x', 'y']], x_out[['x', 'y']])
     np.testing.assert_array_equal(
-        x_prime[['logP', 'logL']], x_out[['logL', 'logP']])
+        x_prime[['logP', 'logL']], x_out[['logP', 'logL']])
     proposal._reparameterisation.inverse_reparameterise.assert_called_once()
 
 

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -903,22 +903,27 @@ def test_pre_rescaling_integration(is_invertible, model):
     x_out, x_prime_out, log_j_out = reparam.reparameterise(x, x_prime, log_j)
 
     assert_structured_arrays_equal(x_out, x)
-    np.testing.assert_array_equal(
-        x_prime_out['x_prime'], np.array([-1, 0.0, 2 * np.log(2) - 1, 1])
+    np.testing.assert_allclose(
+        x_prime_out['x_prime'], np.array([-1, 0.0, 2 * np.log(2) - 1, 1]),
+        rtol=1e-15,
 
     )
-    np.testing.assert_array_equal(log_j_out, -np.log(x['x']) + np.log(2))
+    np.testing.assert_allclose(
+        log_j_out, -np.log(x['x']) + np.log(2), rtol=1e-15,
+    )
 
     x_in = numpy_array_to_live_points(np.empty([x_prime_out.size, 1]), ['x'])
     log_j = np.zeros(x.size)
     x_out, x_prime_final, log_j_final = \
         reparam.inverse_reparameterise(x_in, x_prime_out, log_j)
 
-    np.testing.assert_array_equal(log_j_final, np.log(x_out['x']) - np.log(2))
+    np.testing.assert_allclose(
+        log_j_final, np.log(x_out['x']) - np.log(2), rtol=1e-15,
+    )
 
-    np.testing.assert_array_equal(x_out['x'], x['x'])
+    np.testing.assert_allclose(x_out['x'], x['x'], rtol=1e-15)
     assert_structured_arrays_equal(x_prime_final, x_prime_out)
-    np.testing.assert_array_equal(log_j_final, -log_j_out)
+    np.testing.assert_allclose(log_j_final, -log_j_out, rtol=1e-15)
 
     # Trick to get a 1d model to test only x
     model._names.remove('y')


### PR DESCRIPTION
The issue occurred because the order of the fields in the two arrays being compared was different and `numpy.testing.assert_array_equal` now raises a TypeError if the dtype of two structured arrays is not equal.

Closes https://github.com/mj-will/nessai/issues/180