### PR TITLE
Clean up setup.cfg meta-data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,19 +29,20 @@ install_requires =
     torch>=1.7.0
     tqdm
     nflows
-test_suite = tests
-tests_require =
-    pytest
-    pytest-timeout
-    pytest-rerunfailures
-    pytest-integration
 
 [options.extras_require]
-dev =
+test =
     pytest
+    pytest-cov
     pytest-timeout
     pytest-rerunfailures
     pytest-integration
+gw =
+    lalsuite
+    bilby<=1.1.3 ; python_version == '3.6'
+    bilby ; python_version > '3.6'
+    astropy
+dev =
     pre-commit
     ray[default]
 docs =


### PR DESCRIPTION
Remove deprecated `test_suite` and `tests_require` and add `extras_require` test, gw and dev.

This will allow us to skip installing `bilby` when running the tests on Windows.