### PR TITLE
Fix timing tests for Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from numpy.random import seed
 import numpy as np
 import pytest
 from scipy.stats import norm
+import time
 import torch
 
 from nessai.model import Model
@@ -46,6 +47,17 @@ def flow_config():
                               kwargs=dict(batch_norm_between_layers=False))
             )
     return d
+
+
+@pytest.fixture()
+def wait():
+    """Sleep for 0.01s for timing tests.
+
+    Time resolution on Windows is less than Linux and macOS
+    """
+    def func(*args, **kwargs):
+        time.sleep(0.01)
+    return func
 
 
 def pytest_configure(config):

--- a/tests/test_nested_sampler/test_flow_proposal.py
+++ b/tests/test_nested_sampler/test_flow_proposal.py
@@ -228,10 +228,10 @@ def test_train_proposal_not_training(sampler):
     sampler.proposal.train.assert_not_called()
 
 
-def test_train_proposal(sampler):
+def test_train_proposal(sampler, wait):
     """Verify the proposal is trained"""
     sampler.proposal = MagicMock()
-    sampler.proposal.train = MagicMock()
+    sampler.proposal.train = MagicMock(side_effect=wait)
     sampler.check_flow_model_reset = MagicMock()
     sampler.checkpoint = MagicMock()
     sampler.iteration = 100
@@ -258,10 +258,10 @@ def test_train_proposal(sampler):
     assert sampler.block_acceptance == 0
 
 
-def test_train_proposal_memory(sampler):
+def test_train_proposal_memory(sampler, wait):
     """Verify the proposal is trained with memory"""
     sampler.proposal = MagicMock()
-    sampler.proposal.train = MagicMock()
+    sampler.proposal.train = MagicMock(side_effect=wait)
     sampler.check_flow_model_reset = MagicMock()
     sampler.checkpoint = MagicMock()
     sampler.iteration = 100

--- a/tests/test_nested_sampler/test_resume.py
+++ b/tests/test_nested_sampler/test_resume.py
@@ -21,7 +21,7 @@ def complete_sampler(model, tmpdir):
 
 
 @pytest.mark.parametrize('periodic', [False, True])
-def test_checkpoint(sampler, periodic):
+def test_checkpoint(sampler, periodic, wait):
     """Test checkpointing method.
 
     Make sure a file is produced and that the sampling time is updated.
@@ -30,6 +30,7 @@ def test_checkpoint(sampler, periodic):
     sampler.checkpoint_iterations = [10]
     sampler.iteration = 20
     now = datetime.datetime.now()
+    wait()
     sampler.sampling_start_time = now
     sampler.sampling_time = datetime.timedelta()
     sampler.resume_file = 'test.pkl'

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -68,11 +68,11 @@ def test_populate(proposal, N):
 
 
 @pytest.mark.parametrize('populated', [True, False])
-def test_draw(proposal, populated):
+def test_draw(proposal, populated, wait):
     """Test the draw method"""
     N = 5
     proposal.populated = populated
-    proposal.populate = Mock()
+    proposal.populate = Mock(side_effect=wait)
     proposal.population_time = datetime.timedelta()
     proposal.indices = [0, 1, 2, 3, 4]
     proposal.samples = np.array([0, 1, 2, 3, 4])

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_draw.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_draw.py
@@ -31,7 +31,7 @@ def test_draw_populated_last_sample(proposal):
 
 
 @pytest.mark.parametrize('update', [False, True])
-def test_draw_not_popluated(proposal, update):
+def test_draw_not_populated(proposal, update, wait):
     """Test the draw method when the proposal is not populated"""
     import datetime
     proposal.populated = False
@@ -44,6 +44,7 @@ def test_draw_not_popluated(proposal, update):
     proposal.ns_acceptance = 0.5
 
     def mock_populate(*args, **kwargs):
+        wait()
         proposal.populated = True
         proposal.samples = np.arange(3)
         proposal.indices = list(range(3))


### PR DESCRIPTION
The time resolution on Windows is worse than on Linux and macOS so to make sure tests pass, wait 0.01s before checking the elapsed time.

**Changes**

Add a `wait` fixture that can be used to in any tests to wait a predefined amount of time. In principle, this could be set based on the system but for now, it's just 0.01 seconds.

**Testing**

Tested on Windows 10.