### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug in `FlowProposal.populate` which occurred when the pool of samples was not empty (closes [#176](https://github.com/mj-will/nessai/issues/176))
 
+### Removed
+
+- Drop support for Python 3.6
+
+
 ## [0.5.1] - 2022-06-20
 
 ### Fixed

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,6 @@ pytest-cov
 pytest-integration
 pre-commit
 lalsuite ; sys_platform != 'win32'
-bilby<=1.1.3 ; python_version == '3.6'
-bilby ; python_version > '3.6'
+bilby
 astropy
 ray[default]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 The preferred installation method is via ``pip`` in the virtual environment of your choice.
 
 .. note::
-    ``nessai`` requires Python 3.6 or greater.
+    ``nessai`` requires Python 3.7 or greater.
 
 
 Installing nessai

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ url = https://github.com/mj-will/nessai
 project_urls =
     Documentation = https://nessai.readthedocs.io/
 classifiers =
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -19,7 +18,7 @@ keywords = nested sampling, normalising flows, machine learning
 
 [options]
 packages = find:
-python requires = >=3.6
+python requires = >=3.7
 install_requires =
     numpy>=1.9
     pandas
@@ -39,8 +38,7 @@ test =
     pytest-integration
 gw =
     lalsuite
-    bilby<=1.1.3 ; python_version == '3.6'
-    bilby ; python_version > '3.6'
+    bilby
     astropy
 dev =
     pre-commit


### PR DESCRIPTION
Python 3.6 reached its [end of life more than six months ago](https://endoflife.date/python) so it's about time we dropped support for it.

This will also help reduce the number of CI workflows that need to be run for every PR.