### PR TITLE
Fix verify rescaling

### DIFF
--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -782,8 +782,14 @@ class FlowProposal(RejectionProposal):
             else:
                 # ratio = x_out.size // x.size
                 for f in x.dtype.names:
-                    if not all([np.any(np.isclose(x[f], xo))
-                                for xo in x_out[f]]):
+                    if np.isnan(x[f]).all():
+                        if not np.isnan(x_out[f]).all():
+                            raise RuntimeError(
+                                f'Rescaling is not invertible for {f} (NaNs)'
+                            )
+                    elif not all([
+                        np.any(np.isclose(x[f], xo)) for xo in x_out[f]
+                    ]):
                         raise RuntimeError(
                             'Duplicate samples must map to same input values. '
                             'Check the rescaling and inverse rescaling '

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
@@ -150,3 +150,24 @@ def test_constant_volume_mode(
 
     np.testing.assert_approx_equal(fp.r, expected_radius, 4)
     np.testing.assert_approx_equal(fp.fixed_radius, expected_radius, 4)
+
+
+@pytest.mark.parametrize("boundary_inversion", [True, False])
+@pytest.mark.parametrize("inversion_type", ["split", "duplicate"])
+@pytest.mark.integration_test
+def test_verify_rescaling_integration(
+    tmp_path, model, boundary_inversion, inversion_type
+):
+    """Assert verify rescaling passes."""
+    output = tmp_path / "test"
+    output.mkdir()
+
+    fp = FlowProposal(
+        model,
+        output=output,
+        poolsize=10,
+        boundary_inversion=boundary_inversion,
+        inversion_type=inversion_type,
+    )
+    fp.set_rescaling()
+    fp.verify_rescaling()

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -830,6 +830,24 @@ def test_verify_rescaling_duplicate_error(proposal):
     assert 'Duplicate samples must map to same input' in str(excinfo.value)
 
 
+def test_verify_rescaling_duplicate_error_nans(proposal):
+    """Assert an error is raised if the duplication is missing samples"""
+    x = np.array([[np.nan], [np.nan]], dtype=[('x', 'f8')])
+    x_prime = np.array([1.0, 2.0])
+    log_j = np.array([-2, -2, -2, -2])
+    x_out = np.array([[np.nan], [np.nan], [4], [np.nan]], dtype=[('x', 'f8')])
+    log_j_inv = np.array([2, 2, 2, 2])
+
+    proposal.model = MagicMock()
+    proposal.model.new_point = MagicMock(return_value=x)
+    proposal.rescale = MagicMock(return_value=(x_prime, log_j))
+    proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        FlowProposal.verify_rescaling(proposal)
+    assert 'Rescaling is not invertible for x (NaNs)' in str(excinfo.value)
+
+
 @pytest.mark.parametrize('has_inversion', [False, True])
 def test_verify_rescaling_jacobian_error(proposal, has_inversion):
     """Assert an error is raised if the Jacobian is not invertible"""


### PR DESCRIPTION
Fix a bug introduced in https://github.com/mj-will/nessai/pull/170 where the default values for `logL` and `logP` weew changed to `np.nan` which broke `FlowProposal.verify_rescaling` when duplication is enabled.