### PR TITLE
Fix linting CI

### DIFF
--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -602,7 +602,7 @@ class NestedSampler:
         self.block_iteration += 1
         count = 0
 
-        while(True):
+        while True:
             c, proposed = next(self.yield_sample(worst))
             count += c
 


### PR DESCRIPTION
Fix an issue with the whitespace in `nestedsampler.py` that was causing the CI to fail