### PR TITLE
Fix multiple new points returning too many points

### DIFF
--- a/nessai/model.py
+++ b/nessai/model.py
@@ -341,14 +341,17 @@ class Model(ABC):
             Numpy structured array with fields for each parameter
             and log-prior (logP) and log-likelihood (logL)
         """
-        new_points = empty_structured_array(0, names=self.names)
-        while new_points.size < N:
+        new_points = empty_structured_array(N, names=self.names)
+        n = 0
+        while n < N:
             p = numpy_array_to_live_points(
                     np.random.uniform(self.lower_bounds, self.upper_bounds,
                                       [N, self.dims]),
                     self.names)
-            logP = self.log_prior(p)
-            new_points = np.concatenate([new_points, p[np.isfinite(logP)]])
+            flag = np.isfinite(self.log_prior(p))
+            m = np.sum(flag)
+            new_points[n:(n + m)] = p[flag][:min(m, N - n)]
+            n += m
         return new_points
 
     def in_bounds(self, x):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -343,6 +343,23 @@ def test_multiple_new_points(model):
     assert ((x['y'] >= -2) & (x['y'] <= 2)).all()
 
 
+def test_multiple_new_points_reject(model):
+    """Assert the correct number of points are returned in some are rejected"""
+    n = 3
+    model.names = ['x', 'y']
+    model.bounds = {'x': [-1, 1], 'y': [-2, 2]}
+    model.lower_bounds = np.array([-1, -2])
+    model.upper_bounds = np.array([1, 2])
+    model.log_prior = MagicMock(
+        side_effect=2 * [np.array([-np.inf, 0.0, 0.0])]
+    )
+    model.dims = 2
+    x = Model._multiple_new_points(model, N=n)
+    assert x.size == n
+    assert ((x['x'] >= -1) & (x['x'] <= 1)).all()
+    assert ((x['y'] >= -2) & (x['y'] <= 2)).all()
+
+
 def test_new_point_log_prob(model):
     """Test the log prob for new points.
 


### PR DESCRIPTION
Fix a bug where `Model._multiple_new_points` would return more points than requested.

This occurred when the initial set of `N` points contain samples that had zero prior probability and are rejected. The next set of points would be concatenated and result in the overall array having `len > N`.

Also, add a test for this specific behaviour.