### PR TITLE
Add `filehandler_kwargs` to `setup_logger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nessai.utils.testing` submodule which contains functions to use during testing.
 - Add `nessai.livepoint.unstructured_view` and `nessai.model.Model.unstructured_view` for constructing unstructured views of live points.
 - Add `nessai.plot.corner_plot` as an alternative to `plot_live_points` that uses `corner` instead of `seaborn`
+- Add `filehandler_kwargs` to `nessai.utils.logging.setup_logger` which allows the user to configure the `FileHandler` in the logger.
 
 ### Changed
 

--- a/nessai/utils/logging.py
+++ b/nessai/utils/logging.py
@@ -6,7 +6,9 @@ import logging
 import os
 
 
-def setup_logger(output=None, label="nessai", log_level="WARNING"):
+def setup_logger(
+    output=None, label="nessai", log_level="WARNING", filehandler_kwargs=None
+):
     """
     Setup the logger.
 
@@ -21,6 +23,9 @@ def setup_logger(output=None, label="nessai", log_level="WARNING"):
         Label for this instance of the logger.
     log_level : {'ERROR', 'WARNING', 'INFO', 'DEBUG'}, optional
         Level of logging passed to logger.
+    filehandler_kwargs : dict, optional
+        Keyword arguments for configuring the FileHandler. See logging
+        documentation for details.
 
     Returns
     -------
@@ -62,7 +67,9 @@ def setup_logger(output=None, label="nessai", log_level="WARNING"):
             else:
                 output = "."
             log_file = os.path.join(output, f"{label}.log")
-            file_handler = logging.FileHandler(log_file)
+            if filehandler_kwargs is None:
+                filehandler_kwargs = {}
+            file_handler = logging.FileHandler(log_file, **filehandler_kwargs)
             file_handler.setFormatter(
                 logging.Formatter(
                     "%(asctime)s %(levelname)-8s: %(message)s", datefmt="%H:%M"

--- a/tests/test_utils/test_logging_utils.py
+++ b/tests/test_utils/test_logging_utils.py
@@ -4,6 +4,7 @@ Test utilities related to logging.
 """
 import logging
 import os
+from unittest.mock import patch
 import pytest
 
 from nessai.utils.logging import setup_logger
@@ -67,3 +68,24 @@ def test_setup_logger_unknown_level():
     with pytest.raises(ValueError) as excinfo:
         setup_logger(log_level="test", label=None)
     assert "log_level test not understood" in str(excinfo.value)
+
+
+def test_filehandler_kwargs(tmp_path):
+    """Assert filehandler kwargs are passed to the handler."""
+    output = tmp_path / "logger_dir"
+    with patch("logging.FileHandler") as mock:
+        setup_logger(output=output, filehandler_kwargs={"mode": "w"})
+    mock.assert_called_once_with(
+        os.path.join(output, "nessai.log"),
+        mode="w",
+    )
+
+
+def test_filehandler_no_kwargs(tmp_path):
+    """Assert case of no kwargs for the file handler works as intended."""
+    output = tmp_path / "logger_dir"
+    with patch("logging.FileHandler") as mock:
+        setup_logger(output=output, filehandler_kwargs=None)
+    mock.assert_called_once_with(
+        os.path.join(output, "nessai.log"),
+    )


### PR DESCRIPTION
Add `filehandler_kwargs` to `setup_logger`. 

This allows the user to specify kwargs to `FileHandler` as specified in the [logging documentation](https://docs.python.org/3/library/logging.handlers.html#logging.FileHandler). The default behaviour is still the same but it allows the user, for example, to set the mode to `'w'` so existing logs are overwritten.

Closes https://github.com/mj-will/nessai/issues/197 