### PR TITLE
Rework max threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Change how threading is handled to no longer use `max_threads`.
+
+## Deprecated
+
+- Setting `max_threads` is deprecated and will be removed in a future release.
+
 ## [0.6.0] - 2022-08-24
 
 ### Added

--- a/docs/parallelisation.rst
+++ b/docs/parallelisation.rst
@@ -8,13 +8,10 @@ One benefit of the proposal method used in ``nessai`` is it allows for simple pa
 Enabling parallelisation
 ************************
 
-There are two keyword arguments that must be set to enable parallelisation:
-
-- :code:`n_pool`: The number of threads to use for evaluating the likelihood
-- :code:`max_threads`: The maximum number of threads to use, this should be at least 1 larger than :code:`n_pool`. Extra threads are allocated to PyTorch's CPU parallelisation.
+Likelihood parallelisation can be enabled in ``nessai`` by setting the keyword argument :code:`n_pool` when calling :code:`FlowSampler`. This determines the size of the multiprocessing pool to use for evaluating the likelihood.
 
 .. note::
-    If running ``nessai`` via a job scheduler such as HTCondor, remember to set the number of requested threads accordingly. This should match :code:`max_threads`.
+    If running ``nessai`` via a job scheduler such as HTCondor, remember to set the number of requested CPUs accordingly.
 
 
 *****************

--- a/examples/parallelisation_example.py
+++ b/examples/parallelisation_example.py
@@ -70,7 +70,7 @@ fs = FlowSampler(
     output=output,
     resume=False,
     seed=1234,
-    max_threads=3,  # Maximum number of threads
+    pytorch_threads=2,  # Allow pytorch to use 2 threads
     n_pool=2,  # Threads for evaluating the likelihood
 )
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -37,9 +37,9 @@ class FlowSampler:
     weights_files : str, optional
         Weights files used to resume sampler that replaces the weights file
         saved internally.
-    max_threads : int, optional
-        Maximum number of threads to use. If ``None`` torch uses all available
-        threads.
+    pytorch_threads : int
+        Maximum number of threads to use for torch. If ``None`` torch uses all
+        available threads.
     signal_handling : bool
         Enable or disable signal handling.
     exit_code : int, optional
@@ -57,14 +57,13 @@ class FlowSampler:
         weights_file=None,
         signal_handling=True,
         exit_code=130,
-        max_threads=1,
+        pytorch_threads=1,
         **kwargs,
     ):
 
         configure_threads(
-            max_threads=max_threads,
-            pytorch_threads=kwargs.get("pytorch_threads", None),
-            n_pool=kwargs.get("n_pool", None),
+            max_threads=kwargs.get("max_threads", None),
+            pytorch_threads=pytorch_threads,
         )
 
         self.exit_code = exit_code

--- a/nessai/utils/threading.py
+++ b/nessai/utils/threading.py
@@ -3,13 +3,14 @@
 Utilities related to managing threads used by nessai.
 """
 import logging
+import warnings
 
 import torch
 
 logger = logging.getLogger(__name__)
 
 
-def configure_threads(max_threads=None, pytorch_threads=None, n_pool=None):
+def configure_threads(pytorch_threads=None, max_threads=None):
     """Configure the number of threads available.
 
     This is necessary when using PyTorch on the CPU as by default it will use
@@ -22,43 +23,21 @@ def configure_threads(max_threads=None, pytorch_threads=None, n_pool=None):
 
     Parameters
     ----------
-    max_threads: int, optional
-        Maximum total number of threads to use between PyTorch and
-        multiprocessing.
     pytorch_threads: int, optional
-        Maximum number of threads for PyTorch on CPU.
-    n_pool: int, optional
-        Number of pools to use if using multiprocessing.
+        Maximum number of threads for PyTorch on CPU. If None, pytorch will
+        use all available threads.
+    max_threads: int, optional
+        Ignored. Deprecated starting nessai 0.7.0.
     """
-    if max_threads is not None:
-        if pytorch_threads is not None and pytorch_threads > max_threads:
-            raise RuntimeError(
-                f"More threads assigned to PyTorch ({pytorch_threads}) "
-                f"than are available ({max_threads})"
-            )
-        if n_pool is not None and n_pool >= max_threads:
-            raise RuntimeError(
-                f"More threads assigned to pool ({n_pool}) than are "
-                f"available ({max_threads})"
-            )
-        if (
-            n_pool is not None
-            and pytorch_threads is not None
-            and (pytorch_threads + n_pool) > max_threads
-        ):
-            raise RuntimeError(
-                f"More threads assigned to PyTorch ({pytorch_threads}) "
-                f"and pool ({n_pool}) than are available ({max_threads})"
-            )
-
-    if pytorch_threads is None:
-        if max_threads is not None:
-            if n_pool is not None:
-                pytorch_threads = max_threads - n_pool
-            else:
-                pytorch_threads = max_threads
-
-    if pytorch_threads is not None:
+    if max_threads:
+        msg = (
+            "`max_threads` is deprecated and will be removed in a future "
+            "release. Use `pytorch_threads` to set the number of threads for "
+            "pytorch and `n_pool` to set the number of cores for "
+            "paralellisation."
+        )
+        warnings.warn(msg, DeprecationWarning)
+    if pytorch_threads:
         logger.debug(
             f"Setting maximum number of PyTorch threads to {pytorch_threads}"
         )

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -42,11 +42,10 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume):
     output = str(output)
     resume = resume
     exit_code = 131
-    max_threads = 2
+    pytorch_threads = 2
     resume_file = "test.pkl"
     kwargs = dict(
         nlive=1000,
-        pytorch_threads=1,
     )
 
     flow_sampler.save_kwargs = MagicMock()
@@ -60,15 +59,14 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume):
             output=output,
             resume=resume,
             exit_code=exit_code,
-            max_threads=max_threads,
+            pytorch_threads=pytorch_threads,
             resume_file=resume_file,
             **kwargs,
         )
 
     mock_threads.assert_called_once_with(
-        max_threads=max_threads,
-        pytorch_threads=1,
-        n_pool=None,
+        pytorch_threads=pytorch_threads,
+        max_threads=None,
     )
 
     mock.assert_called_once_with(
@@ -98,7 +96,7 @@ def test_init_resume(flow_sampler, tmp_path, test_old, error):
     output.mkdir()
     resume = True
     exit_code = 131
-    max_threads = 2
+    pytorch_threads = 2
     resume_file = "test.pkl"
     weights_file = "model.pt"
     flow_config = dict(lr=0.1)
@@ -116,7 +114,6 @@ def test_init_resume(flow_sampler, tmp_path, test_old, error):
 
     kwargs = dict(
         nlive=1000,
-        pytorch_threads=1,
         flow_config=flow_config,
     )
 
@@ -133,16 +130,15 @@ def test_init_resume(flow_sampler, tmp_path, test_old, error):
             output=output,
             resume=resume,
             exit_code=exit_code,
-            max_threads=max_threads,
+            pytorch_threads=pytorch_threads,
             resume_file=resume_file,
             weights_file=weights_file,
             **kwargs,
         )
 
     mock_threads.assert_called_once_with(
-        max_threads=max_threads,
-        pytorch_threads=1,
-        n_pool=None,
+        pytorch_threads=pytorch_threads,
+        max_threads=None,
     )
 
     mock_resume.assert_called_with(

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -36,7 +36,6 @@ def test_sampling_with_rescale(model, flow_config, tmpdir):
         seed=1234,
         max_iteration=11,
         poolsize=10,
-        max_threads=1,
     )
     fp.run()
     assert fp.ns.proposal.flow.weights_file is not None
@@ -62,7 +61,6 @@ def test_sampling_with_inversion(model, flow_config, tmpdir):
         seed=1234,
         max_iteration=11,
         poolsize=10,
-        max_threads=1,
         boundary_inversion=True,
         update_bounds=True,
     )
@@ -169,7 +167,7 @@ def test_sampling_with_n_pool(model, flow_config, tmpdir, mp_context):
             seed=1234,
             max_iteration=11,
             poolsize=10,
-            max_threads=3,
+            pytorch_threads=2,
             n_pool=2,
         )
     fp.run()

--- a/tests/test_utils/test_threading_utils.py
+++ b/tests/test_utils/test_threading_utils.py
@@ -8,42 +8,25 @@ from unittest.mock import patch
 from nessai.utils.threading import configure_threads
 
 
-@pytest.mark.parametrize(
-    "max_threads, pytorch_threads, n_pool, expected",
-    [(2, 1, 1, 1), (1, None, None, 1), (2, None, 1, 1), (None, None, 4, None)],
-)
-def test_configure_threads(max_threads, pytorch_threads, n_pool, expected):
+def test_configure_threads():
     """Test configuring the threads"""
     with patch("torch.set_num_threads") as mock:
-        configure_threads(
-            max_threads=max_threads,
-            pytorch_threads=pytorch_threads,
-            n_pool=n_pool,
-        )
-    if expected:
-        mock.assert_called_once_with(expected)
-    else:
-        mock.assert_not_called()
+        configure_threads(pytorch_threads=1)
+    mock.assert_called_once_with(1)
 
 
-def test_configure_threads_pytorch_error():
-    """Assert an error is raised if pytorch_threads > max_threads"""
-    with pytest.raises(RuntimeError) as excinfo:
-        configure_threads(max_threads=2, pytorch_threads=3)
-    assert "More threads assigned to PyTorch (3) than" in str(excinfo.value)
+def test_configure_threads_none():
+    """Test configuring the threads.
+
+    Assert `set_num_threads` it not called if pytorch_threads is None.
+    """
+    with patch("torch.set_num_threads") as mock:
+        configure_threads(pytorch_threads=None)
+    mock.assert_not_called()
 
 
-def test_configure_threads_n_pool_error():
-    """Assert an error is raised if n_pool >= max_threads"""
-    with pytest.raises(RuntimeError) as excinfo:
-        configure_threads(max_threads=2, n_pool=2)
-    assert "More threads assigned to pool (2) than" in str(excinfo.value)
-
-
-def test_configure_threads_both_error():
-    """Assert an error is raised if pytorch_threads + n_pool > max_threads"""
-    with pytest.raises(RuntimeError) as excinfo:
-        configure_threads(max_threads=3, pytorch_threads=2, n_pool=2)
-    assert "More threads assigned to PyTorch (2) and pool (2)" in str(
-        excinfo.value
-    )
+def test_max_threads_warning():
+    """Assert a deprecation warning is raised if max threads is specified"""
+    with pytest.warns(DeprecationWarning) as record:
+        configure_threads(max_threads=1)
+    assert "`max_threads` is deprecated" in str(record[0].message)


### PR DESCRIPTION
When running with `n_pool>1` one thread is always excluded from the pool. This is not necessary, since the pool is not used in parallel to the main thread. This PR simplifies how threading is handled.

**Changes**
- Deprecate `max_threads`: it is now ignored completely
- Use `pytorch_threads` directly and set the default to `1`.
- Update examples

**To-Do**
- [x] Update docs