### PR TITLE
Add set torch dtype

### DIFF
--- a/nessai/utils/torchutils.py
+++ b/nessai/utils/torchutils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for configuring torch.
+"""
+import logging
+from typing import Literal, Union
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+dtype_mapping = {
+    "float32": torch.float32,
+    "float64": torch.float64,
+}
+
+
+def set_torch_default_dtype(
+    dtype: Union[Literal["float32", "float64"], torch.dtype, None],
+) -> torch.dtype:
+    """Set the default dtype for torch tenors.
+
+    If dtype is None, returns the default dtype.
+
+    Parameters
+    ----------
+    dtype
+        The new default dtype for torch.
+
+    Returns
+    -------
+    The torch dtype used to set the default.
+    """
+    if dtype is None:
+        return torch.get_default_dtype()
+    if isinstance(dtype, str):
+        if dtype not in dtype_mapping:
+            raise ValueError(
+                f"Unknown torch dtype: {dtype}. "
+                f"Choose from: {list(dtype_mapping.keys())}"
+            )
+        dtype = dtype_mapping.get(dtype)
+    logger.info(f"Setting torch dtype to {dtype}")
+    torch.set_default_dtype(dtype)
+    return dtype

--- a/nessai/utils/torchutils.py
+++ b/nessai/utils/torchutils.py
@@ -3,7 +3,6 @@
 Utilities for configuring torch.
 """
 import logging
-from typing import Literal, Union
 
 import torch
 
@@ -15,21 +14,20 @@ dtype_mapping = {
 }
 
 
-def set_torch_default_dtype(
-    dtype: Union[Literal["float32", "float64"], torch.dtype, None],
-) -> torch.dtype:
+def set_torch_default_dtype(dtype) -> torch.dtype:
     """Set the default dtype for torch tenors.
 
     If dtype is None, returns the default dtype.
 
     Parameters
     ----------
-    dtype
+    dtype : {"float32", "float64", torch.dtype}
         The new default dtype for torch.
 
     Returns
     -------
-    The torch dtype used to set the default.
+    torch.dtype
+        The torch dtype used to set the default.
     """
     if dtype is None:
         return torch.get_default_dtype()

--- a/tests/test_utils/test_torchtutils_utils.py
+++ b/tests/test_utils/test_torchtutils_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for torch utils.
+"""
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from nessai.utils.torchutils import set_torch_default_dtype
+
+
+@pytest.mark.parametrize(
+    "dtype, expected",
+    [
+        ("float32", torch.float32),
+        ("float64", torch.float64),
+        (torch.float32, torch.float32),
+        (torch.float64, torch.float64),
+    ],
+)
+def test_setting_default_dtype(dtype, expected):
+    """Assert `set_default_dtype` is called correctly"""
+    with patch("torch.set_default_dtype") as mock:
+        out = set_torch_default_dtype(dtype)
+    mock.assert_called_once_with(expected)
+    assert out is expected
+
+
+def test_setting_default_none():
+    """Assert the default dtype is used when dtype is None"""
+    with patch("torch.get_default_dtype", return_value=torch.float32) as mock:
+        out = set_torch_default_dtype(None)
+    mock.assert_called_once()
+    assert out is torch.float32
+
+
+def test_setting_default_dtype_invalid_input():
+    """Assert an error is raised if the input is invalid"""
+    with pytest.raises(ValueError) as excinfo:
+        set_torch_default_dtype("not_a_dtype")
+    assert "Unknown torch dtype: not_a_dtype" in str(excinfo.value)


### PR DESCRIPTION
Add a function to `nessai.utils` for setting the torch default dtype from a string.