### PR TITLE
Tweak `draw_truncated_gaussian`

### DIFF
--- a/nessai/utils/sampling.py
+++ b/nessai/utils/sampling.py
@@ -151,8 +151,7 @@ def draw_truncated_gaussian(dims, r, N=1000, fuzz=1.0, var=1):
         Array of samples with shape (N, dims)
     """
     sigma = np.sqrt(var)
-    r *= fuzz
-    u_max = stats.chi.cdf(r / sigma, df=dims)
+    u_max = stats.chi.cdf(r * fuzz / sigma, df=dims)
     u = np.random.uniform(0, u_max, N)
     p = sigma * stats.chi.ppf(u, df=dims)
     x = np.random.randn(p.size, dims)


### PR DESCRIPTION
Remove an in-place operation that changed the input and may have been causing the tests to break.