### PR TITLE
Tweak logit rescaling

### DIFF
--- a/nessai/utils/rescaling.py
+++ b/nessai/utils/rescaling.py
@@ -285,7 +285,7 @@ def determine_rescaled_bounds(
         raise ValueError(f"Invalid value for `invert`: {invert}")
 
 
-def logit(x, fuzz=1e-12):
+def logit(x, eps=None):
     """Logit function that also returns log Jacobian determinant.
 
     See :py:func:`nessai.utils.rescaling.sigmoid` for the inverse.
@@ -294,9 +294,9 @@ def logit(x, fuzz=1e-12):
     ----------
     x : float or ndarray
         Array of values
-    fuzz : float, optional
-        Fuzz used to avoid nans in logit. Values are rescaled from [0, 1]
-        to [0-fuzz, 1+fuzz].
+    eps : float, optional
+        Epsilon value used to clamp inputs to [eps, 1 - eps]. If None, then
+        inputs are not clamped.
 
     Returns
     -------
@@ -305,16 +305,13 @@ def logit(x, fuzz=1e-12):
     float or ndarray
         Log Jacobian determinant.
     """
-    if fuzz:
-        x += fuzz
-        x /= 1 + 2 * fuzz
+    if eps:
+        x = np.clip(x, eps, 1 - eps)
     log_j = -np.log(x) - np.log1p(-x)
-    if fuzz:
-        log_j -= np.log(1 + 2 * fuzz)
     return np.log(x) - np.log1p(-x), log_j
 
 
-def sigmoid(x, fuzz=1e-12):
+def sigmoid(x):
     """Sigmoid function that also returns log Jacobian determinant.
 
     See :py:func:`nessai.utils.rescaling.logit` for the inverse.
@@ -323,8 +320,6 @@ def sigmoid(x, fuzz=1e-12):
     ----------
     x : float or ndarray
         Array of values
-    fuzz : float, optional
-        Fuzz used to avoid nans in logit
 
     Returns
     -------
@@ -335,10 +330,6 @@ def sigmoid(x, fuzz=1e-12):
     """
     x = np.divide(1, 1 + np.exp(-x))
     log_j = np.log(x) + np.log1p(-x)
-    if fuzz:
-        x *= 1 + 2 * fuzz
-        x -= fuzz
-        log_j += np.log(1 + 2 * fuzz)
     return x, log_j
 
 

--- a/tests/test_utils/test_rescaling_utils.py
+++ b/tests/test_utils/test_rescaling_utils.py
@@ -169,7 +169,7 @@ def test_logit_bounds(x, y, log_J):
     Test logit at the bounds
     """
     with pytest.warns(RuntimeWarning):
-        assert logit(x, fuzz=0) == (y, log_J)
+        assert logit(x, eps=0) == (y, log_J)
 
 
 @pytest.mark.parametrize(
@@ -179,28 +179,28 @@ def test_sigmoid_bounds(x, y, log_J):
     """
     Test sigmoid for inf
     """
-    assert sigmoid(x, fuzz=0) == (y, log_J)
+    assert sigmoid(x) == (y, log_J)
 
 
 @pytest.mark.parametrize("p", [1e-5, 0.5, 1.0 - 1e-5])
-@pytest.mark.parametrize("fuzz", [False, 1e-12])
-def test_logit_sigmoid(p, fuzz):
+@pytest.mark.parametrize("eps", [False, 1e-12])
+def test_logit_sigmoid(p, eps):
     """
     Test invertibility of sigmoid(logit(x))
     """
-    x = logit(p, fuzz=fuzz)
-    y = sigmoid(x[0], fuzz=fuzz)
+    x = logit(p, eps=eps)
+    y = sigmoid(x[0])
     np.testing.assert_almost_equal(p, y[0], decimal=10)
     np.testing.assert_almost_equal(x[1] + y[1], 0.0, decimal=10)
 
 
 @pytest.mark.parametrize("p", [-10.0, -1.0, 0.0, 1.0, 10.0])
-@pytest.mark.parametrize("fuzz", [False, 1e-12])
-def test_sigmoid_logit(p, fuzz):
+@pytest.mark.parametrize("eps", [False, 1e-12])
+def test_sigmoid_logit(p, eps):
     """
     Test invertibility of logit(sigmoid(x))
     """
-    x = sigmoid(p, fuzz=fuzz)
-    y = logit(x[0], fuzz=fuzz)
+    x = sigmoid(p)
+    y = logit(x[0], eps=eps)
     np.testing.assert_almost_equal(p, y[0], decimal=10)
     np.testing.assert_almost_equal(x[1] + y[1], 0.0, decimal=10)


### PR DESCRIPTION
Tweak `logit` and `sigmoid` to match how they work in `torch` ([torch.logit](https://pytorch.org/docs/stable/special.html#torch.special.logit))

**Changes**
* Use `numpy.clip` instead of rescaling
* Remove `fuzz` from `sigmoid`
* Change `fuzz` to `eps` in `logit`