### PR TITLE
Fix flaky mark

### DIFF
--- a/tests/test_flows/test_distributions.py
+++ b/tests/test_flows/test_distributions.py
@@ -50,7 +50,7 @@ def test_log_prob_invalid_shape(dist, dims):
     assert "Expected input of shape" in str(excinfo.value)
 
 
-@pytest.mark.flaky(run=5)
+@pytest.mark.flaky(reruns=5)
 def test_sample(dist, var):
     """
     Test the sample method and check if the resulting samples pass a

--- a/tests/test_flows/test_included_flows.py
+++ b/tests/test_flows/test_included_flows.py
@@ -118,7 +118,7 @@ def test_forward_and_log_prob(flow, x, n, data_dim):
     np.testing.assert_array_equal(log_prob.numpy(), log_prob_target.numpy())
 
 
-@pytest.mark.flaky(run=10)
+@pytest.mark.flaky(reruns=5)
 def test_sample_and_log_prob(flow, n, data_dim):
     """
     Assert that samples are drawn with correct shape and that the log
@@ -133,7 +133,7 @@ def test_sample_and_log_prob(flow, n, data_dim):
     )
 
 
-@pytest.mark.flaky(run=10)
+@pytest.mark.flaky(reruns=5)
 def test_invertibility(flow, x):
     """Test to ensure flows are invertible"""
     with torch.no_grad():
@@ -146,7 +146,7 @@ def test_invertibility(flow, x):
     )
 
 
-@pytest.mark.flaky(run=5)
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.integration_test
 def test_sample_and_log_prob_conditional(
     conditional_flow, n, data_dim, conditional_features

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -379,6 +379,7 @@ def test_safe_exit(flow_sampler):
 @pytest.mark.integration_test
 @pytest.mark.timeout(30)
 @pytest.mark.skip_on_windows
+@pytest.mark.flaky(reruns=3)
 def test_signal_handling(tmp_path, caplog, model, kwargs, mp_context):
     """Test the signal handling in nessai.
 

--- a/tests/test_gw/test_distance_converters.py
+++ b/tests/test_gw/test_distance_converters.py
@@ -277,7 +277,7 @@ def test_get_distance_converter(prior, cls):
 
 
 @pytest.mark.parametrize("power", [1, 2, 3, 4])
-@pytest.mark.flaky(run=5)
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.integration_test
 def test_power_law_converter_distribution(power):
     """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1072,6 +1072,7 @@ def test_pool(integration_model, mp_context):
 
 @pytest.mark.requires("ray")
 @pytest.mark.integration_test
+@pytest.mark.flaky(reruns=3)
 def test_pool_ray(integration_model):
     """Integration test for evaluating the likelihood with a pool from ray.
 

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_draw.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_draw.py
@@ -86,7 +86,7 @@ def test_test_draw(proposal):
 
 
 @pytest.mark.timeout(10)
-@pytest.mark.flaky(run=3)
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.integration_test
 def test_test_draw_integration(model, tmpdir):
     """Integration test for the test draw method"""

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -274,7 +274,7 @@ def test_reset_integration(tmpdir, model):
 
 @pytest.mark.parametrize("rescale", [True, False])
 @pytest.mark.timeout(10)
-@pytest.mark.flaky(run=3)
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.integration_test
 def test_test_draw(tmpdir, model, rescale):
     """Verify that the `test_draw` method works.

--- a/tests/test_utils/test_sampling_utils.py
+++ b/tests/test_utils/test_sampling_utils.py
@@ -101,7 +101,7 @@ def test_draw_gaussian():
         (7.0, 4.0, 2.0),
     ],
 )
-@pytest.mark.flaky(run=10)
+@pytest.mark.flaky(reruns=5)
 def test_draw_truncated_gaussian_1d(r, var, fuzz):
     """
     Test drawing from a truncated Gaussian in 1d


### PR DESCRIPTION
All of the tests with `pytest.mark.flaky` mark where only being rerun once because of a typo.

**Details**

The number of reruns should be specified with `reruns` not `runs`. This explains why some of the flaky tests would occasionally fail even after being rerun.

Also added the flaky mark to two tests that seem to intermittently fail.