### PR TITLE
Fix bilby backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Setting `max_threads` is deprecated and will be removed in a future release.
+- `nessai.nestedsampler` is deprecated and will be removed in a future release. Use `nessai.samplers.nestedsampler` instead.
 
 ### Removed
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -37,6 +37,8 @@ class FlowSampler:
     pytorch_threads : int
         Maximum number of threads to use for torch. If ``None`` torch uses all
         available threads.
+    max_threads : int
+        Deprecated and will be removed in a future release.
     signal_handling : bool
         Enable or disable signal handling.
     exit_code : int, optional
@@ -56,11 +58,12 @@ class FlowSampler:
         signal_handling=True,
         exit_code=130,
         pytorch_threads=1,
+        max_threads=None,
         **kwargs,
     ):
 
         configure_threads(
-            max_threads=kwargs.get("max_threads", None),
+            max_threads=max_threads,
             pytorch_threads=pytorch_threads,
         )
 

--- a/nessai/nestedsampler.py
+++ b/nessai/nestedsampler.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Deprecated submodule that will be removed in a future release.
+Use `nessai.samplers.nestedsampler` instead.
+"""
+from warnings import warn
+
+from .samplers.nestedsampler import NestedSampler  # noqa
+
+msg = (
+    "`nessai.nestedsampler` is deprecated and will be removed in a future "
+    "release. Use `nessai.samplers.nestedsampler` instead."
+)
+warn(msg, FutureWarning)

--- a/nessai/utils/threading.py
+++ b/nessai/utils/threading.py
@@ -36,7 +36,7 @@ def configure_threads(pytorch_threads=None, max_threads=None):
             "pytorch and `n_pool` to set the number of cores for "
             "paralellisation."
         )
-        warnings.warn(msg, DeprecationWarning)
+        warnings.warn(msg, FutureWarning)
     if pytorch_threads:
         logger.debug(
             f"Setting maximum number of PyTorch threads to {pytorch_threads}"

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for modules/functions that are soon to be deprecated.
+"""
+from nessai.utils import configure_threads
+import pytest
+
+
+def test_max_threads_warning():
+    """Assert a future warning is raised if max threads is specified"""
+    with pytest.warns(FutureWarning) as record:
+        configure_threads(max_threads=1)
+    assert "`max_threads` is deprecated" in str(record[0].message)
+
+
+def test_nested_sampler_deprecation():
+    """Assert a warning is raised with nessai.nestedsampler is imported."""
+    with pytest.warns(FutureWarning) as record:
+        from nessai import nestedsampler  # noqa
+    assert "`nessai.nestedsampler` is deprecated" in str(record[0].message)

--- a/tests/test_utils/test_threading_utils.py
+++ b/tests/test_utils/test_threading_utils.py
@@ -2,7 +2,6 @@
 """
 Tests for threading related utilities.
 """
-import pytest
 from unittest.mock import patch
 
 from nessai.utils.threading import configure_threads
@@ -23,10 +22,3 @@ def test_configure_threads_none():
     with patch("torch.set_num_threads") as mock:
         configure_threads(pytorch_threads=None)
     mock.assert_not_called()
-
-
-def test_max_threads_warning():
-    """Assert a deprecation warning is raised if max threads is specified"""
-    with pytest.warns(DeprecationWarning) as record:
-        configure_threads(max_threads=1)
-    assert "`max_threads` is deprecated" in str(record[0].message)


### PR DESCRIPTION
Recent (unreleased) changes broke backwards compatibility with `bilby`, this PR fixes this.

**Changes**
* Add `nessai.nestedsampler` and have it only import `NestedSampler`.
* Add `max_threads` to `FlowSampler` rather than check the kwargs.
* Test deprecation warnings in a single test file.