### PR TITLE
Bump torch version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     matplotlib>=2.0
     seaborn
     scipy>=0.16
-    torch>=1.7.0
+    torch>=1.11.0
     tqdm
     glasflow
 


### PR DESCRIPTION
Increase the minimum pytorch version to 1.11.0 because glasflow requires torch>=1.11.0. 