### PR TITLE
Add bilby compatibility CI

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,0 +1,32 @@
+name: Compatibility tests
+
+on:
+  push:
+    branches: [ main, release* ]
+  pull_request:
+    branches: [ main, release* ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bilby-test:
+    name: Bilby compatibility test
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'  # Based on bilby
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -e .
+        pip install bilby
+    - name: Run bilby compatibility tests
+      run: |
+        python -m pytest --bilby-compatibility

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, release* ]
   pull_request:
     branches: [ main, release* ]
+  schedule:
+    # Run tests at 7:00 UTC everyday
+    - cron: '0 7 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -31,4 +31,4 @@ jobs:
         pip install bilby
     - name: Run bilby compatibility tests
       run: |
-        python -m pytest --bilby-compatibility
+        python -m pytest --bilby-compatibility -m "bilby_compatibility"

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
+        pip install -e .[test]
         pip install bilby
     - name: Run bilby compatibility tests
       run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+"""General configuration for the test suite"""
 import sys
 
 from numpy.random import seed
@@ -80,6 +81,15 @@ def mp_context(request):
     return multiprocessing.get_context(request.param)
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--bilby-compatibility",
+        action="store_true",
+        default=False,
+        help="Run bilby compatibility tests",
+    )
+
+
 def pytest_configure(config):
     # register an additional marker
     config.addinivalue_line(
@@ -95,6 +105,22 @@ def pytest_configure(config):
         "skip_on_windows: mark test to indicated it should be skipped on "
         "Windows",
     )
+    config.addinivalue_line(
+        "markers",
+        "bilby_compatibility: mark test as a bilby compatibility test, these "
+        "tests will be skipped unless the command line option is specified.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--bilby-compatibility"):
+        return
+    skip_bilby_compat = pytest.mark.skip(
+        reason="Need --bilby-compatibility to run"
+    )
+    for item in items:
+        if "bilby_compatibility" in item.keywords:
+            item.add_marker(skip_bilby_compat)
 
 
 def pytest_runtest_setup(item):

--- a/tests/test_bilby_compatibility.py
+++ b/tests/test_bilby_compatibility.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Test compatibility with bilby"""
+import numpy as np
+import pytest
+
+
+@pytest.mark.requires("bilby")
+@pytest.mark.bilby_compatibility
+@pytest.mark.slow_integration_test
+def test_bilby_compatiblity(tmp_path):
+    """Test compatibility with bilby"""
+    import bilby
+
+    outdir = tmp_path / "bilby_test"
+
+    class GaussianLikelihood(bilby.Likelihood):
+        def __init__(self):
+            super().__init__(parameters={"x": None, "y": None})
+
+        def log_likelihood(self):
+            """Log-likelihood."""
+            return -0.5 * (
+                self.parameters["x"] ** 2.0 + self.parameters["y"] ** 2.0
+            ) - np.log(2.0 * np.pi)
+
+    priors = dict(
+        x=bilby.core.prior.Uniform(-5, 5, "x"),
+        y=bilby.core.prior.Uniform(-5, 5, "y"),
+    )
+
+    bilby.run_sampler(
+        outdir=outdir,
+        resume=False,
+        plot=False,
+        likelihood=GaussianLikelihood(),
+        priors=priors,
+        sampler="nessai",
+        injection_parameters={"x": 0.0, "y": 0.0},
+        analytic_priors=True,
+        nlive=500,
+        seed=1234,
+        logging_interval=10,
+        log_on_iteration=False,
+    )


### PR DESCRIPTION
Add new tests and CI that run a simple `bilby` sampling run to make sure `nessai` is compatible.

These tests will also run on a schedule to help identify issues.

The tests will no run by default, but instead require the user to add `--bilby-compatibility` when running `pytest`.