### PR TITLE
Avoid seaborn UserWarning

### DIFF
--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -122,6 +122,9 @@ def plot_live_points(
     else:
         hue = None
 
+    if hue is None:
+        pairplot_kwargs["plot_kws"].pop("palette")
+
     fig = sns.PairGrid(df, corner=True, diag_sharey=False)
     fig.map_diag(plt.hist, **pairplot_kwargs["diag_kws"])
     fig.map_offdiag(sns.scatterplot, hue=hue, **pairplot_kwargs["plot_kws"])


### PR DESCRIPTION
`seaborn` is raising the following warning because a `palette` is specified when `hue=None`: 

```console
 /home/michaelwilliams/.miniconda3/envs/nessai/lib/python3.9/site-packages/seaborn/axisgrid.py:1609: UserWarning: Ignoring `palette` because no `hue` variable has been assigned.
    func(x=x, y=y, **kwargs)
```

This MR removes the palette when `hue=None`.