### PR TITLE
Add bilby utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add options `plot_{indices, posterior, logXlogL}` for disabling plots in `FlowSampler.run`.
 - Add `FlowSampler.terminate_run`.
 - Add `FlowSampler.log_evidence` and `FlowSampler.log_evidence_error`.
+- Add `nessai.utils.bilbyutils`.
 
 ### Changed
 

--- a/nessai/utils/bilbyutils.py
+++ b/nessai/utils/bilbyutils.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities to make interfacing with bilby easier.
+"""
+from inspect import signature
+from typing import List, Callable
+
+
+def _get_standard_methods() -> List[Callable]:
+    """Get a list of the methods used by the standard sampler"""
+    from ..flowsampler import FlowSampler
+    from ..proposal import AugmentedFlowProposal, FlowProposal
+    from ..samplers import NestedSampler
+
+    methods = [
+        FlowSampler.run,
+        AugmentedFlowProposal,
+        FlowProposal,
+        NestedSampler,
+        FlowSampler,
+    ]
+    return methods
+
+
+def get_all_kwargs() -> dict:
+    """Get a dictionary of all possible kwargs and their default values.
+
+    Returns
+    -------
+    Dictionary of kwargs and their default values.
+    """
+    methods = _get_standard_methods()
+    kwargs = {}
+    for m in methods:
+        kwargs.update(
+            {
+                k: v.default
+                for k, v in signature(m).parameters.items()
+                if v.default is not v.empty
+            }
+        )
+    return kwargs
+
+
+def get_run_kwargs_list() -> List[str]:
+    """Get a list of kwargs used in the run method"""
+    from ..flowsampler import FlowSampler
+
+    method = FlowSampler.run
+
+    run_kwargs_list = [
+        k
+        for k, v in signature(method).parameters.items()
+        if v.default is not v.empty
+    ]
+    return run_kwargs_list

--- a/tests/test_utils/test_bilbyutils.py
+++ b/tests/test_utils/test_bilbyutils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for bilbyutils
+"""
+from unittest.mock import patch
+from nessai.flowsampler import FlowSampler
+from nessai.utils.bilbyutils import (
+    get_all_kwargs,
+    get_run_kwargs_list,
+    _get_standard_methods,
+)
+
+
+def test_get_standard_methods():
+    """Assert a list of methods is returned"""
+    out = _get_standard_methods()
+    assert len(out) == 5
+
+
+def test_get_all_kwargs():
+    """Assert the correct dictionary is returned.
+
+    Positional arguments should be ignored.
+    """
+
+    def func0(a, b, c=2, d=None):
+        pass
+
+    def func1(e, f, g=3, h=True):
+        pass
+
+    expected = dict(c=2, d=None, g=3, h=True)
+
+    with patch(
+        "nessai.utils.bilbyutils._get_standard_methods",
+        return_value=[func0, func1],
+    ):
+        out = get_all_kwargs()
+
+    assert out == expected
+
+
+def test_get_run_kwargs_list():
+    """Assert the correct list is returned"""
+
+    def func(a, b=1, c=None):
+        pass
+
+    expected = ["b", "c"]
+
+    with patch.object(FlowSampler, "run", func):
+        out = get_run_kwargs_list()
+
+    assert out == expected


### PR DESCRIPTION
Introduce experimental functions that will be used in the bilby interface for `nessai`.

The aim is to have `nessai` "tell" bilby what the keyword arguments are rather than have bilby figure them out. This means it should be easier to update nessai without breaking bilby.