### PR TITLE
Fix infinite loop on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug in `nessai.flows.utils.configure_model` that only occurred when the specified `device_tag` is invalid.
+- Fixed an infinite loop when resuming a run that was interrupted when switching proposal.
 
 ### Deprecated
 

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -756,6 +756,7 @@ class NestedSampler(BaseNestedSampler):
         ):
             if self.proposal is self._flow_proposal:
                 logger.warning("Already using flowproposal")
+                self.uninformed_sampling = False
                 return True
             logger.warning("Switching to FlowProposal")
             self.proposal = self._flow_proposal


### PR DESCRIPTION
Fix a bug where `nessai` would get stuck re-training after resuming.

This occurred because the proposal was switch to `FlowProposal` but the flag `uninformed_sampling` was still `False` and was being updated after resuming.

The fix is to set `uninformed_sampling=False` if the proposal is `FlowProposal`