### PR TITLE
Fix typo in description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nessai
-description = Nessai: Nested Sampling with Aritificial Intelligence
+description = Nessai: Nested Sampling with Artificial Intelligence
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Michael J. Williams


### PR DESCRIPTION
Fix a long-standing typo in the description that I've missed up until now. This should update the description on `PyPI` once it's released.