### PR TITLE
Add delta phase reparameterisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changes
+### Added
+
+- Add `DeltaPhaseReparameterisation` for GW analyses.
+- Add `nessai.utils.sorting`.
+
+### Changed
 
 - Refactor `nessai.reparameterisations` into a submodule.
 - Use `torch.inference_mode` instead of `torch.no_grad`.
+- Changed `CombinedReparameterisations` to sort and add reparameterisations based on their requirements.
 
 ## [0.7.0]
 

--- a/nessai/gw/reparameterisations.py
+++ b/nessai/gw/reparameterisations.py
@@ -5,8 +5,11 @@ Specific reparameterisations for gravitational-wave inference.
 
 import logging
 
+import numpy as np
+
 from ..reparameterisations import (
     default_reparameterisations,
+    Reparameterisation,
     RescaleToBounds,
     AnglePair,
     get_reparameterisation,
@@ -137,6 +140,80 @@ class DistanceReparameterisation(RescaleToBounds):
         ]
 
 
+class DeltaPhase(Reparameterisation):
+    """Reparameterisation that converts phase to delta phase.
+
+    The Jacobian determinant of this transformation is 1.
+
+    Requires "psi" and "theta_jn".
+
+    Parameters
+    ----------
+    parameters : Union[str, List[str]]
+        Name(s) of the parameter(s).
+    prior_bounds : Union[list, dict]
+        Prior bounds for the parameters
+    """
+
+    def __init__(self, parameters=None, prior_bounds=None):
+        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+        self.requires = ["psi", "theta_jn"]
+        self.prime_parameters = ["delta_phase"]
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        """
+        Apply the reparameterisation to convert from x-space to x'-space.
+
+        Parameters
+        ----------
+        x : structured array
+            Array of inputs
+        x_prime : structured array
+            Array to be update
+        log_j : array_like
+            Log jacobian to be updated
+
+        Returns
+        -------
+        x, x_prime : structured arrays
+            Update version of the x and x_prime arrays
+        log_j : array_like
+            Updated log Jacobian determinant
+        """
+        x_prime[self.prime_parameters[0]] = (
+            x[self.parameters[0]] - np.sign(np.cos(x["theta_jn"])) * x["psi"]
+        )
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        """
+        Apply the reparameterisation to convert from x-space
+        to x'-space
+
+        Parameters
+        ----------
+        x : structured array
+            Array
+        x_prime : structured array
+            Array to be update
+        log_j : array_like
+            Log jacobian to be updated
+
+        Returns
+        -------
+        x, x_prime : structured arrays
+            Update version of the x and x_prime arrays
+        log_j : array_like
+            Updated log Jacobian determinant
+        """
+        x[self.parameters[0]] = np.mod(
+            x_prime[self.prime_parameters[0]]
+            + np.sign(np.cos(x["theta_jn"])) * x["psi"],
+            2 * np.pi,
+        )
+        return x, x_prime, log_j
+
+
 default_gw = {
     "distance": (
         DistanceReparameterisation,
@@ -159,6 +236,8 @@ default_gw = {
         },
     ),
     "mass": (RescaleToBounds, {"update_bounds": True}),
+    "delta_phase": (DeltaPhase, {}),
+    "delta-phase": (DeltaPhase, {}),
 }
 
 

--- a/nessai/gw/reparameterisations.py
+++ b/nessai/gw/reparameterisations.py
@@ -140,7 +140,7 @@ class DistanceReparameterisation(RescaleToBounds):
         ]
 
 
-class DeltaPhase(Reparameterisation):
+class DeltaPhaseReparameterisation(Reparameterisation):
     """Reparameterisation that converts phase to delta phase.
 
     The Jacobian determinant of this transformation is 1.
@@ -236,8 +236,8 @@ default_gw = {
         },
     ),
     "mass": (RescaleToBounds, {"update_bounds": True}),
-    "delta_phase": (DeltaPhase, {}),
-    "delta-phase": (DeltaPhase, {}),
+    "delta_phase": (DeltaPhaseReparameterisation, {}),
+    "delta-phase": (DeltaPhaseReparameterisation, {}),
 }
 
 

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -859,7 +859,7 @@ class FlowProposal(RejectionProposal):
         logger.info("Rescaling functions are invertible")
 
     def _rescale_w_reparameterisation(self, x, compute_radius=False, **kwargs):
-        x_prime = np.zeros([x.size], dtype=self.x_prime_dtype)
+        x_prime = empty_structured_array([x.size], dtype=self.x_prime_dtype)
         log_J = np.zeros(x_prime.size)
 
         if x.size == 1:
@@ -874,7 +874,7 @@ class FlowProposal(RejectionProposal):
         return x_prime, log_J
 
     def _inverse_rescale_w_reparameterisation(self, x_prime, **kwargs):
-        x = np.zeros([x_prime.size], dtype=self.x_dtype)
+        x = empty_structured_array([x_prime.size], dtype=self.x_dtype)
         log_J = np.zeros(x.size)
         x, x_prime, log_J = self._reparameterisation.inverse_reparameterise(
             x, x_prime, log_J, **kwargs

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -751,6 +751,8 @@ class FlowProposal(RejectionProposal):
                     "settings."
                 )
 
+        self._reparameterisation.check_order()
+
         self.rescale = self._rescale_w_reparameterisation
         self.inverse_rescale = self._inverse_rescale_w_reparameterisation
 

--- a/nessai/reparameterisations/combined.py
+++ b/nessai/reparameterisations/combined.py
@@ -102,7 +102,6 @@ class CombinedReparameterisation(dict):
         """
         parameters = []
         for key in self.from_prime_order:
-            print(parameters)
             if not all([r in parameters for r in self[key].requires]):
                 raise RuntimeError(
                     "Order of reparameterisations is invalid (x' -> x)"

--- a/nessai/reparameterisations/combined.py
+++ b/nessai/reparameterisations/combined.py
@@ -4,6 +4,8 @@ Combined reparameterisation.
 """
 import logging
 
+from ..utils.sorting import sort_reparameterisations
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +26,7 @@ class CombinedReparameterisation(dict):
         self.parameters = []
         self.prime_parameters = []
         self.requires = []
+        self.order = []
         if reparameterisations is not None:
             self.add_reparameterisations(reparameterisations)
 
@@ -37,18 +40,29 @@ class CombinedReparameterisation(dict):
         """Boolean to check if any of the priors require the prime space"""
         return any(r.requires_prime_prior for r in self.values())
 
+    @property
+    def to_prime_order(self):
+        """Order when converting to the prime space"""
+        return reversed(self.order)
+
+    @property
+    def from_prime_order(self):
+        """Order when converting from the prime space"""
+        return self.order
+
     def _add_reparameterisation(self, reparameterisation):
         requires = reparameterisation.requires
         if requires and (
-            requires not in self.parameters
-            or requires not in self.prime_parameters
+            any([req not in self.parameters for req in requires])
+            and any([req not in self.prime_parameters for req in requires])
         ):
             raise RuntimeError(
                 f"Could not add {reparameterisation}, missing requirement(s): "
-                f"{reparameterisation.requires}."
+                f"{reparameterisation.requires}. Current: {self.parameters}."
             )
 
         self[reparameterisation.name] = reparameterisation
+        self.order = list(self.keys())
         self.parameters += reparameterisation.parameters
         self.prime_parameters += reparameterisation.prime_parameters
         self.requires += reparameterisation.requires
@@ -67,8 +81,36 @@ class CombinedReparameterisation(dict):
         """
         if not isinstance(reparameterisations, list):
             reparameterisations = [reparameterisations]
+
+        logger.debug("Sorting reparameterisations")
+        logger.debug(f"Existing parameters: {self.parameters}")
+        reparameterisations = sort_reparameterisations(
+            reparameterisations,
+            existing_parameters=self.parameters,
+        )
+
         for r in reparameterisations:
             self._add_reparameterisation(r)
+
+    def check_order(self):
+        """Check the order of the reparameterisations is valid.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the order is invalid.
+        """
+        parameters = []
+        for key in self.from_prime_order:
+            print(parameters)
+            if not all([r in parameters for r in self[key].requires]):
+                raise RuntimeError(
+                    "Order of reparameterisations is invalid (x' -> x)"
+                    f"{self[key].name} requires {self[key].requires} but with "
+                    f"the current order only the parameters {parameters} "
+                    "would be available."
+                )
+            parameters += self[key].parameters
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
         """
@@ -84,8 +126,10 @@ class CombinedReparameterisation(dict):
         log_j : array_like
             Log jacobian to be updated
         """
-        for r in self.values():
-            x, x_prime, log_j = r.reparameterise(x, x_prime, log_j, **kwargs)
+        for key in self.to_prime_order:
+            x, x_prime, log_j = self[key].reparameterise(
+                x, x_prime, log_j, **kwargs
+            )
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -102,8 +146,8 @@ class CombinedReparameterisation(dict):
         log_j : array_like
             Log jacobian to be updated
         """
-        for r in reversed(list(self.values())):
-            x, x_prime, log_j = r.inverse_reparameterise(
+        for key in self.from_prime_order:
+            x, x_prime, log_j = self[key].inverse_reparameterise(
                 x, x_prime, log_j, **kwargs
             )
         return x, x_prime, log_j

--- a/nessai/utils/sorting.py
+++ b/nessai/utils/sorting.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for sorting.
+"""
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..reparameterisations import Reparameterisation
+
+
+def sort_reparameterisations(
+    reparameterisations: List["Reparameterisation"],
+    existing_parameters: Optional[List[str]] = None,
+    known_parameters: Optional[List[str]] = None,
+    initial_sort: bool = True,
+) -> List["Reparameterisation"]:
+    """Sort reparameterisations based on their parameters and requirements.
+
+    Parameters
+    ----------
+    reparameterisations : List[Reparameterisation]
+        List of reparameterisations.
+    existing_parameters : Optional[List[str]]
+        List of parameters that are all included.
+    known_parameters : Optional[List[str]]
+        List of all known parameters. If not specified it is inferred from the
+        list of reparameterisations.
+    initial_sort : bool
+        Toggle initial sorting by the number of requirements.
+
+    Returns
+    -------
+    List[Reparameterisation]
+        Sorted list of reparameterisations.
+
+    Raises
+    ------
+    ValueError
+        If a required parameter is missing from the known parameters.
+    """
+    ordered = []
+    skipped = []
+    parameters = existing_parameters.copy() if existing_parameters else []
+
+    if known_parameters is None:
+        known_parameters = parameters.copy()
+        for r in reparameterisations:
+            known_parameters += r.parameters
+
+    if initial_sort:
+        reparameterisations = sorted(
+            reparameterisations, key=lambda r: len(r.requires)
+        )
+
+    for r in reparameterisations:
+        if not r.requires or all([req in parameters for req in r.requires]):
+            ordered.append(r)
+            parameters += r.parameters
+            print(r.name)
+        elif any([req not in known_parameters for req in r.requires]):
+            raise ValueError(
+                f"{r.name} requires {r.requires} which contains parameters "
+                f"that are not known ({known_parameters})"
+            )
+        else:
+            skipped.append(r)
+
+    if skipped:
+        ordered += skipped
+        return sort_reparameterisations(
+            ordered,
+            existing_parameters=existing_parameters,
+            known_parameters=known_parameters,
+            initial_sort=False,
+        )
+    return ordered

--- a/nessai/utils/sorting.py
+++ b/nessai/utils/sorting.py
@@ -56,7 +56,6 @@ def sort_reparameterisations(
         if not r.requires or all([req in parameters for req in r.requires]):
             ordered.append(r)
             parameters += r.parameters
-            print(r.name)
         elif any([req not in known_parameters for req in r.requires]):
             raise ValueError(
                 f"{r.name} requires {r.requires} which contains parameters "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ source = [
 omit = [
     "nessai/gw/legacy.py"
 ]
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
 
 [tool.black]
 line-length = 79

--- a/tests/test_gw/test_equivalent_proposal.py
+++ b/tests/test_gw/test_equivalent_proposal.py
@@ -319,8 +319,8 @@ def test_parameter(
         for n in model.names:
             np.testing.assert_array_almost_equal(x_re[n], x_re_new[n])
 
-        np.testing.assert_array_equal(lj, lj_new)
-        np.testing.assert_array_equal(lj_re, lj_re_new)
+        np.testing.assert_array_almost_equal_nulp(lj, lj_new)
+        np.testing.assert_array_almost_equal_nulp(lj_re, lj_re_new)
         np.testing.assert_array_equal(log_p, log_p_new)
         try:
             np.testing.assert_array_equal(x_prime, x_prime_new)

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -3,16 +3,29 @@
 
 import pytest
 from nessai.gw.reparameterisations import (
+    DeltaPhaseReparameterisation,
     DistanceReparameterisation,
     default_gw,
     get_gw_reparameterisation,
 )
+from nessai.utils.testing import assert_structured_arrays_equal
+import numpy as np
 from unittest.mock import MagicMock, patch, create_autospec
+
+from nessai.livepoint import (
+    dict_to_live_points,
+    empty_structured_array,
+)
 
 
 @pytest.fixture
 def distance_reparam():
     return create_autospec(DistanceReparameterisation)
+
+
+@pytest.fixture
+def delta_phase_reparam():
+    return create_autospec(DeltaPhaseReparameterisation)
 
 
 def test_get_gw_reparameterisation():
@@ -104,3 +117,95 @@ def test_distance_reparameterisation_n_parameters_error(distance_reparam):
     assert "DistanceReparameterisation only supports one parameter" in str(
         excinfo.value
     )
+
+
+def test_delta_phase_init(delta_phase_reparam):
+    """Assert the parent method is called and the parameters are set."""
+    parameters = "phase"
+    prior_bounds = {"phase": [0, 6.28]}
+    with patch(
+        "nessai.gw.reparameterisations.Reparameterisation.__init__"
+    ) as mock:
+        DeltaPhaseReparameterisation.__init__(
+            delta_phase_reparam,
+            parameters=parameters,
+            prior_bounds=prior_bounds,
+        )
+    mock.assert_called_once_with(
+        parameters=parameters, prior_bounds=prior_bounds
+    )
+    assert delta_phase_reparam.requires == ["psi", "theta_jn"]
+    assert delta_phase_reparam.prime_parameters == ["delta_phase"]
+
+
+def test_delta_phase_reparameterise(delta_phase_reparam):
+    """Assert the correct value is returned"""
+    delta_phase_reparam.parameters = ["phase"]
+    delta_phase_reparam.prime_parameters = ["delta_phase"]
+
+    x = dict(phase=1.0, theta_jn=0.0, psi=0.5)
+    x_prime = dict(delta_phase=np.nan, theta_jn=0.0, psi=0.5)
+    log_j = 0
+
+    (
+        x_out,
+        x_prime_out,
+        log_j_out,
+    ) = DeltaPhaseReparameterisation.reparameterise(
+        delta_phase_reparam, x, x_prime, log_j
+    )
+    assert x_out == x
+    assert x_prime_out["delta_phase"] == 0.5
+    assert log_j_out == 0
+
+
+def test_delta_phase_inverse_reparameterise(delta_phase_reparam):
+    """Assert the correct value is returned"""
+    delta_phase_reparam.parameters = ["phase"]
+    delta_phase_reparam.prime_parameters = ["delta_phase"]
+
+    x = dict(phase=np.nan, theta_jn=0.0, psi=0.5)
+    x_prime = dict(delta_phase=0.5, theta_jn=0.0, psi=0.5)
+    log_j = 0
+
+    (
+        x_out,
+        x_prime_out,
+        log_j_out,
+    ) = DeltaPhaseReparameterisation.inverse_reparameterise(
+        delta_phase_reparam, x, x_prime, log_j
+    )
+    assert x_prime_out == x_prime
+    assert x["phase"] == 1.0
+    assert log_j_out == 0
+
+
+@pytest.mark.itegration_test
+def test_delta_phase_inverse_invertible():
+    """Assert the reparameterisation is invertible"""
+    n = 10
+    parameters = ["phase"]
+    prior_bounds = {"phase": [0.0, 2 * np.pi]}
+    reparam = DeltaPhaseReparameterisation(
+        parameters=parameters, prior_bounds=prior_bounds
+    )
+    x = dict_to_live_points(
+        {
+            "phase": np.random.uniform(0, 2 * np.pi, n),
+            "psi": np.random.uniform(0, np.pi, n),
+            "theta_jn": np.random.uniform(0, np.pi, n),
+        }
+    )
+    x_prime = empty_structured_array(
+        n, names=["delta_phase", "theta_jn", "psi"]
+    )
+    x_prime["psi"] = x["psi"]
+    x_prime["theta_jn"] = x["theta_jn"]
+    log_j = np.zeros(n)
+    x_f, x_prime_f, log_j_f = reparam.reparameterise(x, x_prime, log_j)
+    assert_structured_arrays_equal(x_f, x)
+    np.testing.assert_array_equal(log_j_f, log_j)
+    x_i, x_prime_i, log_j_i = reparam.reparameterise(x_f, x_prime_f, log_j_f)
+    assert_structured_arrays_equal(x_prime_i, x_prime_f)
+    assert_structured_arrays_equal(x_i, x)
+    np.testing.assert_array_equal(log_j_i, log_j_f)

--- a/tests/test_reparameterisations/conftest.py
+++ b/tests/test_reparameterisations/conftest.py
@@ -1,0 +1,19 @@
+"""Configuration for the reparameterisation tests"""
+from dataclasses import dataclass
+from typing import List
+
+import pytest
+
+
+@dataclass
+class _LightReparam:
+    """Reparameterisation-like object"""
+
+    name: str
+    parameters: List[str]
+    requires: List[str]
+
+
+@pytest.fixture
+def LightReparam() -> _LightReparam:
+    return _LightReparam

--- a/tests/test_utils/test_sorting_utils.py
+++ b/tests/test_utils/test_sorting_utils.py
@@ -1,0 +1,45 @@
+"""Tests for the sorting utilities"""
+from dataclasses import dataclass
+from typing import List
+
+from nessai.utils.sorting import sort_reparameterisations
+import pytest
+
+
+@dataclass
+class Reparameterisation:
+    """A dataclass that mocks the Reparameterisation class"""
+
+    name: str
+    parameters: List[str]
+    requires: List[str]
+
+
+def test_sorting():
+    """Test a basic sorting example"""
+    r0 = Reparameterisation("1", ["a"], requires=["b", "c"])
+    r1 = Reparameterisation("2", ["b"], requires=["c"])
+    r2 = Reparameterisation("3", ["c"], requires=[])
+
+    out = sort_reparameterisations([r0, r1, r2])
+    print([o.name for o in out])
+    assert out == [r2, r1, r0]
+
+
+def test_sorting_existing():
+    """Test sorting when there are existing parameters"""
+    r0 = Reparameterisation("1", ["a"], requires=["c"])
+    r1 = Reparameterisation("2", ["b"], requires=[])
+    r2 = Reparameterisation("3", ["c"], requires=["d"])
+
+    out = sort_reparameterisations([r0, r1, r2], existing_parameters=["d"])
+    print([o.name for o in out])
+    assert out == [r1, r2, r0]
+
+
+def test_sorting_error():
+    """Assert an errors is raised if there is an invalid requirement"""
+    r0 = Reparameterisation("1", ["a"], requires=[])
+    r1 = Reparameterisation("2", ["b"], requires=["c"])
+    with pytest.raises(ValueError, match=r".* are not known \(\['a', 'b'\]\)"):
+        sort_reparameterisations([r0, r1])


### PR DESCRIPTION
Add a reparameterisation that converts from phase to delta-phase as described in this [bilby MR](https://git.ligo.org/lscsoft/bilby/-/merge_requests/850).

As a result of trying to add this reparameterisation, I've added some basic logic to try and resolve dependencies between different reparameterisations and sort them accordingly.

**To-Do**
- [x] Add tests for changes
- [x] Update changelog