### PR TITLE
Use torch inference mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Refactor `nessai.reparameterisations` into a submodule.
+- Use `torch.inference_mode` instead of `torch.no_grad`.
 
 ## [0.7.0]
 

--- a/nessai/flowmodel/base.py
+++ b/nessai/flowmodel/base.py
@@ -450,16 +450,16 @@ class FlowModel:
                     x = data[0].to(self.device)
                 if weighted:
                     weights = data[1].to(self.device)
-                    with torch.no_grad():
+                    with torch.inference_mode():
                         val_loss += loss_fn(x, weights).item()
                 else:
-                    with torch.no_grad():
+                    with torch.inference_mode():
                         val_loss += loss_fn(x).item()
                 n += 1
 
             return val_loss / n
         else:
-            with torch.no_grad():
+            with torch.inference_mode():
                 val_loss += loss_fn(val_data).item()
             return val_loss
 
@@ -729,7 +729,7 @@ class FlowModel:
             .to(self.model.device)
         )
         self.model.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             z, log_prob = self.model.forward_and_log_prob(x)
 
         z = z.detach().cpu().numpy().astype(np.float64)
@@ -755,7 +755,7 @@ class FlowModel:
             .to(self.model.device)
         )
         self.model.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             log_prob = self.model.log_prob(x)
         log_prob = log_prob.cpu().numpy().astype(np.float64)
         return log_prob
@@ -773,7 +773,7 @@ class FlowModel:
         numpy.ndarray
             Array of samples
         """
-        with torch.no_grad():
+        with torch.inference_mode():
             x = self.model.sample(int(n))
         return x.cpu().numpy().astype(np.float64)
 
@@ -808,7 +808,7 @@ class FlowModel:
         if self.model.training:
             self.model.eval()
         if z is None:
-            with torch.no_grad():
+            with torch.inference_mode():
                 x, log_prob = self.model.sample_and_log_prob(int(N))
         else:
             if alt_dist is not None:
@@ -816,7 +816,7 @@ class FlowModel:
             else:
                 log_prob_fn = self.model.base_distribution_log_prob
 
-            with torch.no_grad():
+            with torch.inference_mode():
                 if isinstance(z, np.ndarray):
                     z = (
                         torch.from_numpy(z)

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1676,7 +1676,7 @@ class FlowProposal(RejectionProposal):
             )
 
             z_tensor = torch.from_numpy(z).to(self.flow.device)
-            with torch.no_grad():
+            with torch.inference_mode():
                 if self.alt_dist is not None:
                     log_p = self.alt_dist.log_prob(z_tensor).cpu().numpy()
                 else:

--- a/tests/test_flowmodel/test_flowmodel_base.py
+++ b/tests/test_flowmodel/test_flowmodel_base.py
@@ -431,11 +431,11 @@ def test_lu_cache_reset(tmp_path):
 
     test_data = torch.from_numpy(data).type(torch.get_default_dtype())
 
-    with torch.no_grad():
+    with torch.inference_mode():
         z_out, log_j = flow.model.forward(test_data)
     flow.model.train()
     flow.model.eval()
-    with torch.no_grad():
+    with torch.inference_mode():
         z_out_reset, log_j_reset = flow.model.forward(test_data)
 
     np.testing.assert_array_equal(z_out_reset, z_out)

--- a/tests/test_flows/test_included_flows.py
+++ b/tests/test_flows/test_included_flows.py
@@ -71,14 +71,14 @@ def test_init(flow_class, kwargs):
 
 def test_forward(flow, x, n, data_dim):
     """Test the forward pass of the flow"""
-    with torch.no_grad():
+    with torch.inference_mode():
         z, _ = flow.forward(x)
     assert z.shape == (n, data_dim)
 
 
 def test_inverse(flow, z, n, data_dim):
     """Test the inverse method"""
-    with torch.no_grad():
+    with torch.inference_mode():
         x, _ = flow.inverse(z)
     assert x.shape == (n, data_dim)
 
@@ -91,14 +91,14 @@ def test_sample(flow, n, data_dim):
 
 def test_log_prob(flow, x, n):
     """Test the log prob method"""
-    with torch.no_grad():
+    with torch.inference_mode():
         log_prob = flow.log_prob(x)
     assert log_prob.shape == (n,)
 
 
 def test_base_distribution_log_prob(flow, z, n):
     """Test the bast distribution"""
-    with torch.no_grad():
+    with torch.inference_mode():
         log_prob = flow.base_distribution_log_prob(z)
     assert log_prob.shape == (n,)
 
@@ -110,7 +110,7 @@ def test_forward_and_log_prob(flow, x, n, data_dim):
     Tests to ensure method runs and that it agrees with using forward
     and log_prob separately
     """
-    with torch.no_grad():
+    with torch.inference_mode():
         z, log_prob = flow.forward_and_log_prob(x)
         z_target, _ = flow.forward(x)
         log_prob_target = flow.log_prob(x)
@@ -124,7 +124,7 @@ def test_sample_and_log_prob(flow, n, data_dim):
     Assert that samples are drawn with correct shape and that the log
     prob is correct.
     """
-    with torch.no_grad():
+    with torch.inference_mode():
         x, log_prob = flow.sample_and_log_prob(n)
         log_prob_target = flow.log_prob(x)
     assert x.shape == (n, data_dim)
@@ -136,7 +136,7 @@ def test_sample_and_log_prob(flow, n, data_dim):
 @pytest.mark.flaky(reruns=5)
 def test_invertibility(flow, x):
     """Test to ensure flows are invertible"""
-    with torch.no_grad():
+    with torch.inference_mode():
         z, log_J = flow.forward(x)
         x_out, log_J_out = flow.inverse(z)
 
@@ -153,7 +153,7 @@ def test_sample_and_log_prob_conditional(
 ):
     """Test method for conditional flows."""
     c = torch.randn(n, conditional_features)
-    with torch.no_grad():
+    with torch.inference_mode():
         x, log_prob = conditional_flow.sample_and_log_prob(n, context=c)
         log_prob_target = conditional_flow.log_prob(x, context=c)
     assert x.shape == (n, data_dim)


### PR DESCRIPTION
Switch calls to `torch.no_grad` to `torch.inference_mode`.

This should be faster in all cases as described here: https://pytorch.org/docs/master/notes/autograd.html#locally-disable-grad-doc

Since changing to `glasflow` the minimum required version of pytorch is 1.11.0, so this doesn't require any changes to the requirements.

Closes https://github.com/mj-will/nessai/issues/79

**To-Do**

- [x] Update changelog