### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,6 +33,10 @@ jobs:
         pip install -r requirements.txt
         pip install -r dev_requirements.txt
         pip install -e .
+    - name: Set MPL backend on Windows
+      if: runner.os == 'Windows'
+      run: |
+        echo "MPLBACKEND=agg" >> $env:GITHUB_ENV
     - name: Print environment variables
       run: |
         env

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -467,10 +467,9 @@ def test_safe_exit(flow_sampler):
 @pytest.mark.parametrize(
     "kwargs", [dict(n_pool=None), dict(max_threads=3, n_pool=2)]
 )
-@pytest.mark.integration_test
-@pytest.mark.timeout(30)
+@pytest.mark.slow_integration_test
+@pytest.mark.timeout(60)
 @pytest.mark.skip_on_windows
-@pytest.mark.flaky(reruns=3)
 def test_signal_handling(tmp_path, caplog, model, kwargs, mp_context):
     """Test the signal handling in nessai.
 
@@ -514,8 +513,8 @@ def test_signal_handling(tmp_path, caplog, model, kwargs, mp_context):
     )
 
 
-@pytest.mark.integration_test
-@pytest.mark.timeout(30)
+@pytest.mark.slow_integration_test
+@pytest.mark.timeout(60)
 @pytest.mark.skip_on_windows
 def test_signal_handling_disabled(tmp_path, caplog, model):
     """Assert signal handling is correctly disabled.

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -95,6 +95,9 @@ def test_nessai_style_integration(line_styles):
         assert line_styles is None
 
     # Assert rcParams are still set to the defaults
+    defaults = mpl.rcParamsDefault
+    # Set backend manually
+    defaults["backend"] = plt.rcParams["backend"]
     assert plt.rcParams == mpl.rcParamsDefault
 
 


### PR DESCRIPTION
Try and address the failing flaky CI on macOS and Windows.

It's not entirely clear to me what is causing the transient failures but they seem to be

* signal handling tests fail on macOS
* issue with plotting on Windows

**Changes**
* Set the matplotlib backend in the windows integration tests CI
* Increase the timeout on the signal handling tests and remove the flaky mark. I've also now marked these as slow tests since they take >4s

**Example failures**

macOS: https://github.com/mj-will/nessai/actions/runs/3191598908/jobs/5208101770

Windows: https://github.com/mj-will/nessai/actions/runs/3191598908/jobs/5208102403#step:7:238