### PR TITLE
Fix missing `nessai.samplers` API

### DIFF
--- a/nessai/samplers/__init__.py
+++ b/nessai/samplers/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""Different nested samplers available in nessai.
+
+All samplers inherit from :py:obj:`nessai.samplers.base.BaseNestedSampler`.
+"""
 from .nestedsampler import NestedSampler
 
 __all__ = [


### PR DESCRIPTION
The API documentation for `nessai.samplers` was missing from the documentation because there wasn't a doc-string in the `__init__.py`.