### PR TITLE
Update evidence calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `DeltaPhaseReparameterisation` for GW analyses.
 - Add `nessai.utils.sorting`.
+- Add `log_posterior_weights` and `effective_n_posterior_samples` to the integral state object.
 
 ### Changed
 
 - Refactor `nessai.reparameterisations` into a submodule.
 - Use `torch.inference_mode` instead of `torch.no_grad`.
 - Changed `CombinedReparameterisations` to sort and add reparameterisations based on their requirements.
+- Changed evidence calculation and posterior weights to use a better estimate of the shrinkage.
+- Refactor `nessai.evidence._NSIntegralState` to inherit from a base class.
+
+### Removed
+
+- Removed `nessai._NSIntegralState.reset`
 
 ## [0.7.0]
 

--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -53,7 +53,7 @@ def log_integrate_log_trap(log_func, log_support):
     log_func_sum = np.logaddexp(log_func[:-1], log_func[1:]) - np.log(2)
     log_dxs = logsubexp(log_support[:-1], log_support[1:])
 
-    return np.logaddexp.reduce(log_func_sum + log_dxs)
+    return logsumexp(log_func_sum + log_dxs)
 
 
 class _BaseNSIntegralState(ABC):

--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -2,10 +2,12 @@
 """
 Functions related to computing the evidence.
 """
+from abc import ABC, abstractmethod
 import logging
 
 import numpy as np
 import matplotlib.pyplot as plt
+from scipy.special import logsumexp
 
 from .plot import nessai_style
 
@@ -54,7 +56,46 @@ def log_integrate_log_trap(log_func, log_support):
     return np.logaddexp.reduce(log_func_sum + log_dxs)
 
 
-class _NSIntegralState:
+class _BaseNSIntegralState(ABC):
+    """Base class for the nested sampling integral."""
+
+    @property
+    @abstractmethod
+    def log_evidence(self):
+        """The current log-evidence."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def log_evidence_error(self):
+        """The current error on the log-evidence."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def log_posterior_weights(self):
+        """The log-posterior weights."""
+        raise NotImplementedError()
+
+    @property
+    def effective_n_posterior_samples(self):
+        """Kish's effective sample size for the posterior weights.
+
+        Returns
+        -------
+        float
+            The effective sample size. Returns zero if the posterior weights
+            are empty.
+        """
+        log_p = self.log_posterior_weights
+        if not len(log_p):
+            return 0
+        log_p -= logsumexp(log_p)
+        n = np.exp(-logsumexp(2 * log_p))
+        return n
+
+
+class _NSIntegralState(_BaseNSIntegralState):
     """
     Stores the state of the nested sampling integrator
 
@@ -68,9 +109,19 @@ class _NSIntegralState:
     """
 
     def __init__(self, nlive, track_gradients=True):
-        self.nlive = nlive
-        self.reset()
+        self.base_nlive = nlive
         self.track_gradients = track_gradients
+
+        # Initial state of the integral
+        self.logZ = -np.inf
+        self.oldZ = -np.inf
+        self.logw = 0
+        self.info = [0.0]
+        # Initially contain all the prior volume
+        self.logLs = [-np.inf]  # Likelihoods sampled
+        self.log_vols = [0.0]  # Volumes enclosed by contours
+        self.nlive = []
+        self.gradients = [0]
 
     @property
     def log_evidence(self):
@@ -80,20 +131,7 @@ class _NSIntegralState:
     @property
     def log_evidence_error(self):
         """The current error on the log-evidence."""
-        return np.sqrt(self.info[-1] / self.nlive)
-
-    def reset(self):
-        """
-        Reset the sampler to its initial state at logZ = -infinity
-        """
-        self.logZ = -np.inf
-        self.oldZ = -np.inf
-        self.logw = 0
-        self.info = [0.0]
-        # Start with a dummy sample enclosing the whole prior
-        self.logLs = [-np.inf]  # Likelihoods sampled
-        self.log_vols = [0.0]  # Volumes enclosed by contours
-        self.gradients = [0]
+        return np.sqrt(self.info[-1] / self.base_nlive)
 
     def increment(self, logL, nlive=None):
         """
@@ -106,9 +144,12 @@ class _NSIntegralState:
                 f"{self.logLs[-1]:.5f} -> {logL:.5f}"
             )
         if nlive is None:
-            nlive = self.nlive
+            nlive = self.base_nlive
+
+        self.nlive.append(nlive)
         oldZ = self.logZ
-        logt = -1.0 / nlive
+        # <t> = N / (N + 1)
+        logt = -np.log1p(1 / nlive)
         Wt = self.logw + logL + np.log1p(-np.exp(logt))
         self.logZ = np.logaddexp(self.logZ, Wt)
         # Update information estimate
@@ -118,8 +159,6 @@ class _NSIntegralState:
                 + np.exp(oldZ - self.logZ) * (self.info[-1] + oldZ)
                 - self.logZ
             )
-            if np.isnan(info):
-                info = 0
             self.info.append(info)
 
         # Update history
@@ -138,8 +177,10 @@ class _NSIntegralState:
         Call at end of sampling run to refine estimate
         """
         # Trapezoidal rule
+        # Extra point represents X=0 and assume max(L) = L[-1]
         self.logZ = log_integrate_log_trap(
-            np.array(self.logLs), np.array(self.log_vols)
+            np.array(self.logLs + [self.logLs[-1]]),
+            np.array(self.log_vols + [np.NINF]),
         )
         return self.logZ
 
@@ -171,3 +212,13 @@ class _NSIntegralState:
             logger.info(f"Saved nested sampling plot as {filename}")
         else:
             return fig
+
+    @property
+    def log_posterior_weights(self):
+        """Compute the log-posterior weights."""
+        log_L = np.array(self.logLs + [self.logLs[-1]])
+        log_vols = np.array(self.log_vols + [np.NINF])
+        log_Z = log_integrate_log_trap(log_L, log_vols)
+        log_w = logsubexp(log_vols[:-1], log_vols[1:])
+        log_post_w = log_L[1:-1] + log_w[:-1] - log_Z
+        return log_post_w

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -206,7 +206,7 @@ class FlowSampler:
         logger.info("Computing posterior samples")
         self.posterior_samples = draw_posterior_samples(
             self.nested_samples,
-            nlive=self.ns.nlive,
+            log_w=self.ns.state.log_posterior_weights,
             method=posterior_sampling_method,
         )
         logger.info(

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -2,11 +2,12 @@
 """
 Test the object that handles the nested sampling evidence and prior volumes.
 """
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, patch
 import numpy as np
 import pytest
 
 from nessai.evidence import (
+    _BaseNSIntegralState,
     _NSIntegralState,
     logsubexp,
 )
@@ -15,6 +16,11 @@ from nessai.evidence import (
 @pytest.fixture()
 def nlive():
     return 100
+
+
+@pytest.fixture()
+def base_state():
+    return create_autospec(_BaseNSIntegralState)
 
 
 @pytest.fixture()
@@ -30,12 +36,38 @@ def test_logsubexp_negative():
         logsubexp(1, 2)
 
 
+@pytest.mark.parametrize(
+    "method", ["log_evidence", "log_evidence_error", "log_posterior_weights"]
+)
+def test_base_state_not_implemented_error_properties(base_state, method):
+    """Assert all of the abstract properties raised not implemented errors"""
+    with pytest.raises(NotImplementedError):
+        getattr(_BaseNSIntegralState, method).__get__(base_state)
+
+
+@pytest.mark.parametrize(
+    "weights, expected", [([], 0), ([0.1, 0.2, 0.3, 0.4], (1 / 0.3))]
+)
+def test_base_state_effective_n_posterior_samples(
+    base_state, weights, expected
+):
+    """Assert the correct effective sample size is returned.
+
+    Should be zero if weights are empty.
+    """
+    base_state.log_posterior_weights = np.log(weights)
+    ess = _BaseNSIntegralState.effective_n_posterior_samples.__get__(
+        base_state
+    )
+    np.testing.assert_almost_equal(ess, expected, decimal=10)
+
+
 def test_increment(nlive):
     """Test the basic functionality of incrementing the evidence estimate"""
     state = _NSIntegralState(nlive)
     state.increment(-10)
 
-    assert state.logw == (-1 / nlive)
+    assert state.logw == -np.log1p(1 / nlive)
     assert state.logZ != -np.inf
     np.testing.assert_equal(state.logLs, [-np.inf, -10])
 
@@ -43,7 +75,8 @@ def test_increment(nlive):
 def test_increment_monotonic_warning(ns_state, caplog):
     """Assert a warning is raised if the likelihood is non-monotonic"""
     ns_state.logLs = [1, 2, 3]
-    ns_state.nlive = 10
+    ns_state.base_nlive = 10
+    ns_state.nlive = 3 * [10]
     ns_state.logZ = -2.0
     ns_state.logw = 1.0
     ns_state.info = [0]
@@ -65,7 +98,7 @@ def test_log_evidence_error(ns_state, nlive):
     """Assert the log-evidence error property returns the correct value"""
     expected = np.sqrt(10 / nlive)
     ns_state.info = [1, 5, 10]
-    ns_state.nlive = nlive
+    ns_state.base_nlive = nlive
     out = _NSIntegralState.log_evidence_error.__get__(ns_state)
     assert out == expected
 
@@ -106,7 +139,7 @@ def test_variable_nlive(nlive):
     """
     state = _NSIntegralState(nlive)
     state.increment(-10, nlive=50)
-    assert state.logw == (-1 / 50)
+    assert state.logw == -np.log1p(1 / 50)
 
 
 def test_plot(nlive):
@@ -126,3 +159,23 @@ def test_plot_w_filename(nlive, tmpdir):
     state.increment(-5)
     fig = state.plot(filename=filename)
     assert fig is None
+
+
+def test_log_posterior_weights(ns_state):
+    """Test the log-posterior weights property"""
+    log_vols = [0.0, -0.1, -0.2, -0.3]
+    logL = [np.NINF, -10.0, -5.0, -0.0]
+    ns_state.log_vols = log_vols
+    ns_state.logLs = logL
+    log_z = -1.0
+    with patch(
+        "nessai.evidence.log_integrate_log_trap", return_value=log_z
+    ) as mock_int:
+        out = _NSIntegralState.log_posterior_weights.__get__(ns_state)
+
+    trap_inputs = mock_int.call_args[0]
+    np.testing.assert_array_equal(trap_inputs[0], logL + [-0.0])
+    np.testing.assert_array_equal(trap_inputs[1], log_vols + [np.NINF])
+    # Output should one shorted than logL since the initial point is not a
+    # nested sample.
+    assert len(out) == (len(logL) - 1)


### PR DESCRIPTION
Update the evidence calculation to use a better estimate of the shrinkage $t$.

**Explanation**

The shrinkage is distributed according to $\beta(N, 1)$ where $N$ is the number of live points. The estimator for $t$ is then

$$
\< t \> = \frac{N}{N+1}.
$$

This replaces the usual $\< t \> = \exp(-1 / N)$. The difference in most cases should be negligible since $N >> 1$. In practice this means that `logt = -np.log1p(1 / N)`.

Also, update the logic used to determine the prior volume when finalising the sampler and computing the posterior weights such that:

* Should always start with $X_0=1$, $L_0=0$
* Should always end with $X_{K+1}=0$, $L_i=\textrm{max}(L)$
* The final nested sample $X_K$ should NOT have $X=0$

Based on this `nessai.posterior.compute_weights`, now uses an array of the number of live points to avoid any confusion at the transition from constant `nlive` to decreasing `nlive` when finalising the sampler.


**Other changes**

* Remove `reset` method and move its contents to the init.
* Use the posterior weights from sampling when computing the posterior instead of recomputing them
* Replace `numpy.logaddexp.reduce` with `scipy.special.logsumexp` which should be more stable (see scipy [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.logsumexp.html))
* Add `_BaseNSIntegralState` which also integral states should inherit from
* Add `log_posterior_weights` and `effective_n_posterior_samples` to the integral state
* Track `nlive` in the integral state.
