### PR TITLE
Tweak logging levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `CombinedReparameterisations` to sort and add reparameterisations based on their requirements.
 - Changed evidence calculation and posterior weights to use a better estimate of the shrinkage.
 - Refactor `nessai.evidence._NSIntegralState` to inherit from a base class.
+- Revert default logging level to `INFO`
+- Rework logging statements to reduce the amount of information printed by default.
 
 ### Removed
 

--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -209,7 +209,7 @@ class _NSIntegralState(_BaseNSIntegralState):
         if filename is not None:
             fig.savefig(filename, bbox_inches="tight")
             plt.close()
-            logger.info(f"Saved nested sampling plot as {filename}")
+            logger.debug(f"Saved nested sampling plot as {filename}")
         else:
             return fig
 

--- a/nessai/flowmodel/base.py
+++ b/nessai/flowmodel/base.py
@@ -510,7 +510,7 @@ class FlowModel:
             Dictionary that contains the training and validation losses.
         """
         if not self.initialised:
-            logger.info("Initialising")
+            logger.debug("Initialising")
             self.initialise()
 
         if not np.isfinite(samples).all():
@@ -568,11 +568,11 @@ class FlowModel:
         best_epoch = 0
         best_val_loss = np.inf
         best_model = copy.deepcopy(self.model.state_dict())
-        logger.info("Starting training")
-        logger.info("Training parameters:")
-        logger.info(f"Max. epochs: {max_epochs}")
-        logger.info(f"Patience: {patience}")
-        logger.info(f"Training with {samples.shape[0]} samples")
+        logger.debug("Starting training")
+        logger.debug("Training parameters:")
+        logger.debug(f"Max. epochs: {max_epochs}")
+        logger.debug(f"Patience: {patience}")
+        logger.debug(f"Training with {samples.shape[0]} samples")
 
         history = dict(loss=[], val_loss=[])
 
@@ -600,12 +600,12 @@ class FlowModel:
                 best_model = copy.deepcopy(self.model.state_dict())
 
             if not epoch % 50:
-                logger.info(
+                logger.debug(
                     f"Epoch {epoch}: loss: {loss:.3} val loss: {val_loss:.3}"
                 )
 
             if validate and (epoch - best_epoch > patience):
-                logger.info(f"Epoch {epoch}: Reached patience")
+                logger.debug(f"Epoch {epoch}: Reached patience")
                 break
 
         logger.debug("Finished training")

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -142,7 +142,7 @@ class FlowSampler:
                 signal.signal(signal.SIGINT, self.safe_exit)
                 signal.signal(signal.SIGALRM, self.safe_exit)
             except AttributeError:
-                logger.critical("Cannot set signal attributes on this system")
+                logger.error("Cannot set signal attributes on this system")
         else:
             logger.warning(
                 "Signal handling is disabled. nessai will not automatically "

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -613,7 +613,7 @@ class Model(ABC):
             )
 
         if self.log_prior(x).dtype == np.dtype("float16"):
-            logger.critical(
+            logger.warning(
                 "log_prior returned an array with float16 precision. "
                 "This not recommended and can lead to numerical errors."
                 " Consider casting to a higher precision."

--- a/nessai/proposal/base.py
+++ b/nessai/proposal/base.py
@@ -94,7 +94,7 @@ class Proposal(ABC):
         kwargs:
             Any of keyword arguments
         """
-        logger.info("This proposal method cannot be trained")
+        logger.error("This proposal method cannot be trained")
 
     def resume(self, model):
         """

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -557,7 +557,7 @@ class FlowProposal(RejectionProposal):
         else:
             self._poolsize_scale = 1.0 / acceptance
             if self._poolsize_scale > self.max_poolsize_scale:
-                logger.info("Poolsize scaling is greater than maximum value")
+                logger.debug("Poolsize scaling is greater than maximum value")
                 self._poolsize_scale = self.max_poolsize_scale
             if self._poolsize_scale < 1.0:
                 self._poolsize_scale = 1.0
@@ -1476,7 +1476,7 @@ class FlowProposal(RejectionProposal):
                 "Try calling `initialise()` first."
             )
         if r is not None:
-            logger.info(f"Using user inputs for radius {r}")
+            logger.debug(f"Using user inputs for radius {r}")
             worst_q = None
         elif self.fixed_radius:
             r = self.fixed_radius
@@ -1495,13 +1495,13 @@ class FlowProposal(RejectionProposal):
             if self.min_radius and r < self.min_radius:
                 r = self.min_radius
 
-        logger.info(f"Populating proposal with lantent radius: {r:.5}")
+        logger.debug(f"Populating proposal with lantent radius: {r:.5}")
         self.r = r
 
         self.alt_dist = self.get_alt_distribution()
 
         if self.indices:
-            logger.info(
+            logger.debug(
                 "Existing pool of samples is not empty. "
                 "Discarding existing samples."
             )
@@ -1530,7 +1530,7 @@ class FlowProposal(RejectionProposal):
                 continue
 
             if warn and (x.size / self.drawsize < 0.01):
-                logger.info(
+                logger.debug(
                     "Rejection sampling accepted less than 1 percent of "
                     f"samples! ({x.size / self.drawsize})"
                 )
@@ -1541,7 +1541,7 @@ class FlowProposal(RejectionProposal):
             z_samples[accepted : (accepted + n), ...] = z[:n]
             accepted += n
             if accepted > percent * N:
-                logger.info(
+                logger.debug(
                     f"Accepted {accepted} / {N} points, "
                     f"acceptance: {accepted/proposed:.4}"
                 )
@@ -1573,8 +1573,8 @@ class FlowProposal(RejectionProposal):
         self.populated_count += 1
         self.populated = True
         self._checked_population = False
-        logger.info(f"Proposal populated with {len(self.indices)} samples")
-        logger.info(
+        logger.debug(f"Proposal populated with {len(self.indices)} samples")
+        logger.debug(
             f"Overall proposal acceptance: {self.x.size / proposed:.4}"
         )
 

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -79,6 +79,7 @@ class BaseNestedSampler(ABC):
         logger.info("Initialising nested sampler")
 
         self.info_enabled = logger.isEnabledFor(logging.INFO)
+        self.debug_enabled = logger.isEnabledFor(logging.DEBUG)
         model.verify_model()
         self.n_pool = n_pool
         self.model = model
@@ -252,7 +253,7 @@ class BaseNestedSampler(ABC):
                 else:
                     return
         self.sampling_time += now - self.sampling_start_time
-        logger.critical("Checkpointing nested sampling")
+        logger.info("Checkpointing nested sampling")
         safe_file_dump(self, self.resume_file, pickle, save_existing=True)
         self.sampling_start_time = datetime.datetime.now()
 
@@ -271,7 +272,7 @@ class BaseNestedSampler(ABC):
         obj
             Instance of BaseNestedSampler
         """
-        logger.critical("Resuming NestedSampler from " + filename)
+        logger.info("Resuming NestedSampler from " + filename)
         with open(filename, "rb") as f:
             obj = pickle.load(f)
         model.likelihood_evaluations += obj._previous_likelihood_evaluations

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -341,7 +341,7 @@ class NestedSampler(BaseNestedSampler):
         If None, 'inf' or 'None' flow will only train when empty.
         """
         if training_frequency in [None, "inf", "None"]:
-            logger.warning("Proposal will only train when empty")
+            logger.debug("Proposal will only train when empty")
             self.training_frequency = np.inf
         else:
             self.training_frequency = training_frequency
@@ -530,7 +530,7 @@ class NestedSampler(BaseNestedSampler):
 
     def log_state(self):
         """Log the current state of the sampler"""
-        logger.warning(
+        logger.info(
             f"it: {self.iteration:5d}: "
             f"n eval: {self.likelihood_calls} "
             f"H: {self.state.info[-1]:.2f} "
@@ -554,18 +554,18 @@ class NestedSampler(BaseNestedSampler):
 
         if p is not None:
             if rolling:
-                logger.warning(
+                logger.info(
                     f"it: {self.iteration:5d}: "
                     f"Rolling KS test: D={D:.4}, p-value={p:.4}"
                 )
                 self.rolling_p.append(p)
             else:
-                logger.warning(f"Final KS test: D={D:.4}, p-value={p:.4}")
+                logger.info(f"Final KS test: D={D:.4}, p-value={p:.4}")
                 self.final_p_value = p
                 self.final_ks_statistic = D
                 pt = 0.05
                 if self.final_p_value < pt:
-                    logger.critical(
+                    logger.warning(
                         f"Final p-value for the insertion indices is less "
                         f"than {pt}, this could be an indication of problems "
                         "during sampling. Consider checking the diagnostic "
@@ -668,8 +668,8 @@ class NestedSampler(BaseNestedSampler):
             self.block_acceptance / self.block_iteration
         )
 
-        if self.info_enabled and self.log_on_iteration:
-            logger.info(
+        if self.debug_enabled and self.log_on_iteration:
+            logger.debug(
                 f"{self.iteration:5d}: n: {count:3d} "
                 f"b_acc: {self.mean_block_acceptance:.3f} "
                 f"H: {self.state.info[-1]:.2f} "
@@ -696,11 +696,11 @@ class NestedSampler(BaseNestedSampler):
                     if live_point is None:
                         break
                     if np.isnan(live_point["logL"]):
-                        logger.warning(
+                        logger.error(
                             "Likelihood function returned NaN for "
                             f"live_point {live_point}"
                         )
-                        logger.warning(
+                        logger.error(
                             "You may want to check your likelihood function"
                         )
                         break
@@ -776,10 +776,10 @@ class NestedSampler(BaseNestedSampler):
             or force
         ):
             if self.proposal is self._flow_proposal:
-                logger.warning("Already using flowproposal")
+                logger.info("Already using flowproposal")
                 self.uninformed_sampling = False
                 return True
-            logger.warning("Switching to FlowProposal")
+            logger.info("Switching to FlowProposal")
             self.proposal = self._flow_proposal
             self.proposal.ns_acceptance = self.mean_block_acceptance
             self.uninformed_sampling = False
@@ -1222,7 +1222,7 @@ class NestedSampler(BaseNestedSampler):
         if self.iteration:
             self.update_state()
 
-        logger.critical("Starting nested sampling loop")
+        logger.info("Starting nested sampling loop")
 
         while self.condition > self.tolerance:
 
@@ -1241,11 +1241,11 @@ class NestedSampler(BaseNestedSampler):
         if not self.finalised and (self.condition <= self.tolerance):
             self.finalise()
 
-        logger.critical(
+        logger.info(
             f"Final evidence: {self.state.logZ:.3f} +/- "
             f"{self.state.log_evidence_error:.3f}"
         )
-        logger.critical("Information: {0:.2f}".format(self.state.info[-1]))
+        logger.info("Information: {0:.2f}".format(self.state.info[-1]))
 
         self.check_insertion_indices(rolling=False)
 

--- a/nessai/utils/logging.py
+++ b/nessai/utils/logging.py
@@ -10,7 +10,7 @@ import sys
 def setup_logger(
     output=None,
     label="nessai",
-    log_level="WARNING",
+    log_level="INFO",
     filehandler_kwargs=None,
     stream=None,
 ):

--- a/tests/test_samplers/test_nested_sampler/test_core_sampling.py
+++ b/tests/test_samplers/test_nested_sampler/test_core_sampling.py
@@ -2,6 +2,7 @@
 """
 Test the main sampling functions
 """
+import logging
 import numpy as np
 import pytest
 from unittest.mock import call, MagicMock
@@ -39,6 +40,7 @@ def sampler(sampler):
     sampler.block_acceptance = 0.0
     sampler.acceptance_history = []
     sampler.info_enabled = True
+    sampler.debug_enabled = True
     sampler.log_on_iteration = True
     return sampler
 
@@ -97,6 +99,7 @@ def test_initialise_resume(sampler):
 
 def test_log_state(sampler, caplog):
     """Assert log state outputs to the logger"""
+    caplog.set_level(logging.INFO)
     NestedSampler.log_state(sampler)
     assert "logZ:" in str(caplog.text)
 


### PR DESCRIPTION
Adjust logging statements so that the `INFO` level provides a more reasonable amount of information.

Current the INFO level produces lots of output that isn't really useful in most cases. This reduces the number of statements that are printed with `logger.info`

Also tweak some statements that were `critical` or `warning` but can be safely ignored.