### PR TITLE
Add multiprocessing start method error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `DeltaPhaseReparameterisation` for GW analyses.
 - Add `nessai.utils.sorting`.
 - Add `log_posterior_weights` and `effective_n_posterior_samples` to the integral state object.
+- Add a check for the multiprocessing start method when using `n_pool`.
 
 ### Changed
 

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -243,7 +243,12 @@ class Model(ABC):
                 f"Starting multiprocessing pool with {n_pool} processes"
             )
             import multiprocessing
-            from nessai.utils.multiprocessing import initialise_pool_variables
+            from nessai.utils.multiprocessing import (
+                check_multiprocessing_start_method,
+                initialise_pool_variables,
+            )
+
+            check_multiprocessing_start_method()
 
             self.pool = multiprocessing.Pool(
                 processes=self.n_pool,

--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -3,6 +3,7 @@
 Utilities related to multiprocessing.
 """
 import logging
+import multiprocessing
 
 _model = None
 logger = logging.getLogger(__name__)
@@ -33,6 +34,20 @@ def get_n_pool(pool):
                 f"{type(pool)}."
             )
     return n_pool
+
+
+def check_multiprocessing_start_method():
+    """Check the multiprocessing start method.
+
+    Raise an error if the start method is not `fork`.
+    """
+    start_method = multiprocessing.get_start_method()
+    if start_method != "fork":
+        raise RuntimeError(
+            "nessai only supports multiprocessing using the 'fork' start "
+            f"method. Actual start method is: {start_method}. See the "
+            "multiprocessing documentation for more details."
+        )
 
 
 def initialise_pool_variables(model):

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -469,9 +469,7 @@ def test_safe_exit(flow_sampler):
     flow_sampler.terminate_run.assert_called_once_with(code=2)
 
 
-@pytest.mark.parametrize(
-    "kwargs", [dict(n_pool=None), dict(max_threads=3, n_pool=2)]
-)
+@pytest.mark.parametrize("kwargs", [dict(n_pool=None), dict(n_pool=2)])
 @pytest.mark.slow_integration_test
 @pytest.mark.timeout(60)
 @pytest.mark.skip_on_windows
@@ -484,7 +482,10 @@ def test_signal_handling(tmp_path, caplog, model, kwargs, mp_context):
     output = tmp_path / "output"
     output.mkdir()
 
-    with patch("multiprocessing.Pool", mp_context.Pool):
+    with patch("multiprocessing.Pool", mp_context.Pool), patch(
+        "nessai.utils.multiprocessing.multiprocessing.get_start_method",
+        mp_context.get_start_method,
+    ):
         fs = FlowSampler(
             model,
             output=output,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1109,7 +1109,10 @@ def test_n_pool(integration_model, mp_context):
     """Integration test for evaluating the likelihood with n_pool"""
     # Cannot pickle lambda functions
     integration_model.fn = lambda x: x
-    with patch("multiprocessing.Pool", mp_context.Pool):
+    with patch("multiprocessing.Pool", mp_context.Pool), patch(
+        "nessai.utils.multiprocessing.multiprocessing.get_start_method",
+        mp_context.get_start_method,
+    ):
         integration_model.configure_pool(n_pool=1)
     assert integration_model.n_pool == 1
     x = integration_model.new_point(10)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -849,9 +849,13 @@ def test_configure_pool_n_pool(model):
     """Test configuring the pool when n_pool is specified"""
     n_pool = 1
     pool = MagicMock()
-    with patch("multiprocessing.Pool", return_value=pool) as mock_pool:
+    with patch("multiprocessing.Pool", return_value=pool) as mock_pool, patch(
+        "nessai.utils.multiprocessing.check_multiprocessing_start_method"
+    ) as mock_check:
         Model.configure_pool(model, n_pool=n_pool)
     assert model.pool is pool
+
+    mock_check.assert_called_once()
     mock_pool.assert_called_once_with(
         processes=n_pool,
         initializer=initialise_pool_variables,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -153,7 +153,10 @@ def test_sampling_with_n_pool(model, flow_config, tmpdir, mp_context):
     Test running the sampler with multiprocessing.
     """
     output = str(tmpdir.mkdir("pool"))
-    with patch("multiprocessing.Pool", mp_context.Pool):
+    with patch("multiprocessing.Pool", mp_context.Pool), patch(
+        "nessai.utils.multiprocessing.multiprocessing.get_start_method",
+        mp_context.get_start_method,
+    ):
         fp = FlowSampler(
             model,
             output=output,

--- a/tests/test_utils/test_multiprocessing_utils.py
+++ b/tests/test_utils/test_multiprocessing_utils.py
@@ -47,6 +47,7 @@ def test_check_multiprocessing_start_method_error(method):
 
 
 @pytest.mark.integration_test
+@pytest.mark.skip_on_windows
 def test_check_multiprocessing_start_method_integration():
     """Integration test for checking the start method."""
     mp = multiprocessing.get_context("fork")

--- a/tests/test_utils/test_multiprocessing_utils.py
+++ b/tests/test_utils/test_multiprocessing_utils.py
@@ -2,11 +2,13 @@
 """
 Tests for rescaling functions
 """
+import multiprocessing
 from multiprocessing.dummy import Pool
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from nessai.utils.multiprocessing import (
+    check_multiprocessing_start_method,
     initialise_pool_variables,
     get_n_pool,
     log_likelihood_wrapper,
@@ -26,6 +28,41 @@ def test_pool_variables():
 
     # Reset to the default value
     initialise_pool_variables(None)
+
+
+def test_check_multiprocessing_start_method():
+    """Test check multiprocessing start method passes for 'fork'"""
+    with patch("multiprocessing.get_start_method", return_value="fork"):
+        check_multiprocessing_start_method()
+
+
+@pytest.mark.parametrize("method", ["spawn", "forkserver"])
+def test_check_multiprocessing_start_method_error(method):
+    """Assert an error is raised if the start method is not fork."""
+    error_msg = r"nessai only supports multiprocessing using the 'fork' .*"
+    with patch(
+        "multiprocessing.get_start_method", return_value=method
+    ), pytest.raises(RuntimeError, match=error_msg):
+        check_multiprocessing_start_method()
+
+
+@pytest.mark.integration_test
+def test_check_multiprocessing_start_method_integration():
+    """Integration test for checking the start method."""
+    mp = multiprocessing.get_context("fork")
+    with patch("multiprocessing.get_start_method", mp.get_start_method):
+        check_multiprocessing_start_method()
+
+
+@pytest.mark.integration_test
+def test_check_multiprocessing_start_method_error_integration():
+    """Integration test for checking the start method raises an error."""
+    mp = multiprocessing.get_context("spawn")
+    error_msg = r"nessai only supports multiprocessing using the 'fork' .*"
+    with patch(
+        "multiprocessing.get_start_method", mp.get_start_method
+    ), pytest.raises(RuntimeError, match=error_msg):
+        check_multiprocessing_start_method()
 
 
 def test_model_error():


### PR DESCRIPTION
This PR adds a function to check that the multiprocessing start method is set to `fork` when using `n_pool` and calls this function in `nessai.model.Model` when creating the multiprocessing pool.

**Motivation**

When using `nessai` on macOS, multiprocessing will not work out-of-the-box because the default multiprocessing start method is not `fork` (see the [documentation for details](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)). This leads to a pickling error when `n_pool` is specified, which can be confusing for users to debug. 