### PR TITLE
Tweak reparameterisation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nessai.utils.sorting`.
 - Add `log_posterior_weights` and `effective_n_posterior_samples` to the integral state object.
 - Add a check for the multiprocessing start method when using `n_pool`.
+- Add option to reverse reparameterisations in `FlowProposal`.
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `nessai.evidence._NSIntegralState` to inherit from a base class.
 - Revert default logging level to `INFO`
 - Rework logging statements to reduce the amount of information printed by default.
+- Refactor `nessai.proposal.FlowProposal.verify_rescaling` to be stricter.
 
 ### Removed
 

--- a/nessai/gw/legacy.py
+++ b/nessai/gw/legacy.py
@@ -995,6 +995,7 @@ class LegacyGWFlowProposal(FlowProposal):
         logger.info(f"x space parameters: {self.names}")
         logger.info(f"parameters to rescale {self.rescale_parameters}")
         logger.info(f"x prime space parameters: {self.rescaled_names}")
+        self.rescaling_set = True
 
     def check_state(self, x):
         """

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -853,10 +853,13 @@ class FlowProposal(RejectionProposal):
             else:
                 # ratio = x_out.size // x.size
                 for f in x.dtype.names:
-                    if np.isnan(x[f]).all():
-                        if not np.isnan(x_out[f]).all():
+                    if f in config.NON_SAMPLING_PARAMETERS:
+                        if not np.allclose(
+                            x[f], x_out[f][: x.size], equal_nan=True
+                        ):
                             raise RuntimeError(
-                                f"Rescaling is not invertible for {f} (NaNs)"
+                                f"Non-sampling parameter {f} changed in "
+                                " the rescaling when using duplication."
                             )
                     elif not all(
                         [np.any(np.isclose(x[f], xo)) for xo in x_out[f]]

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -146,6 +146,10 @@ class FlowProposal(RejectionProposal):
         value of the attribute
         :py:attr:`~nessai.proposal.flowproposal.FlowProposal.use_default_reparameterisations`
         is used.
+    reverse_reparameterisations : bool
+        Passed to :code:`reverse_order` in
+        :py:obj:`~nessai.reparameterisations.combined.CombinedReparameterisation`.
+        Reverses the order of the reparameterisations.
     draw_latent_kwargs : dict, optional
         Dictionary of kwargs passed to the function for drawing samples
         in the latent space. See the functions in utils for the possible
@@ -192,6 +196,7 @@ class FlowProposal(RejectionProposal):
         reparameterisations=None,
         fallback_reparameterisation=None,
         use_default_reparameterisations=None,
+        reverse_reparameterisations=False,
         **kwargs,
     ):
 
@@ -227,6 +232,7 @@ class FlowProposal(RejectionProposal):
                 use_default_reparameterisations
             )
         self.fallback_reparameterisation = fallback_reparameterisation
+        self.reverse_reparameterisations = reverse_reparameterisations
 
         self.output = output
 
@@ -631,7 +637,9 @@ class FlowProposal(RejectionProposal):
         else:
             _reparameterisations = copy.deepcopy(reparameterisations)
         logger.info(f"Adding reparameterisations from: {_reparameterisations}")
-        self._reparameterisation = CombinedReparameterisation()
+        self._reparameterisation = CombinedReparameterisation(
+            reverse_order=self.reverse_reparameterisations
+        )
 
         if not isinstance(_reparameterisations, dict):
             raise TypeError(

--- a/nessai/reparameterisations/combined.py
+++ b/nessai/reparameterisations/combined.py
@@ -18,15 +18,19 @@ class CombinedReparameterisation(dict):
         List of reparameterisations to add to the combined reparameterisations.
         Further reparameterisations can be added using
         `add_reparameterisations`.
+    reverse_order : bool
+        If True the order of the reparameterisations will be reversed compared
+        to the default ordering.
     """
 
-    def __init__(self, reparameterisations=None):
+    def __init__(self, reparameterisations=None, reverse_order=False):
         super().__init__()
         self.reparameterisations = {}
         self.parameters = []
         self.prime_parameters = []
         self.requires = []
         self.order = []
+        self.reverse_order = reverse_order
         if reparameterisations is not None:
             self.add_reparameterisations(reparameterisations)
 
@@ -43,12 +47,18 @@ class CombinedReparameterisation(dict):
     @property
     def to_prime_order(self):
         """Order when converting to the prime space"""
-        return reversed(self.order)
+        if self.reverse_order:
+            return reversed(self.order)
+        else:
+            return self.order
 
     @property
     def from_prime_order(self):
         """Order when converting from the prime space"""
-        return self.order
+        if self.reverse_order:
+            return self.order
+        else:
+            return reversed(self.order)
 
     def _add_reparameterisation(self, reparameterisation):
         requires = reparameterisation.requires

--- a/tests/test_gw/conftest.py
+++ b/tests/test_gw/conftest.py
@@ -1,0 +1,145 @@
+"""Configuration for the GW tests"""
+from typing import Callable
+
+from nessai.livepoint import dict_to_live_points
+from nessai.model import Model as BaseModel
+import pytest
+
+
+@pytest.fixture()
+def injection_parameters():
+    injection_parameters = dict(
+        mass_ratio=0.9,
+        chirp_mass=25.0,
+        a_1=0.4,
+        a_2=0.3,
+        tilt_1=0.5,
+        tilt_2=1.0,
+        phi_12=1.7,
+        phi_jl=0.3,
+        luminosity_distance=2000.0,
+        theta_jn=0.4,
+        psi=2.659,
+        phase=1.3,
+        geocent_time=1126259642.413,
+        ra=1.375,
+        dec=-1.2108,
+    )
+    return injection_parameters
+
+
+@pytest.fixture()
+def get_bilby_gw_model() -> Callable:
+    """Return a function will provide a nessai model given parameters
+    and an injection.
+    """
+
+    def get_model(parameters, injection_parameters) -> BaseModel:
+
+        import bilby
+
+        priors = bilby.gw.prior.BBHPriorDict()
+        fixed_params = [
+            "chirp_mass",
+            "mass_ratio",
+            "phi_12",
+            "phi_jl",
+            "a_1",
+            "a_2",
+            "tilt_1",
+            "tilt_2",
+            "ra",
+            "dec",
+            "luminosity_distance",
+            "geocent_time",
+            "theta_jn",
+            "psi",
+            "phase",
+        ]
+        try:
+            fixed_params.remove(parameters)
+        except ValueError:
+            for p in parameters:
+                fixed_params.remove(p)
+        priors["geocent_time"] = bilby.core.prior.Uniform(
+            minimum=injection_parameters["geocent_time"] - 0.1,
+            maximum=injection_parameters["geocent_time"] + 0.1,
+            name="geocent_time",
+            latex_label="$t_c$",
+            unit="$s$",
+        )
+        for key in fixed_params:
+            if key in injection_parameters:
+                priors[key] = injection_parameters[key]
+
+        waveform_generator = bilby.gw.WaveformGenerator(
+            duration=1,
+            sampling_frequency=256,
+            frequency_domain_source_model=bilby.gw.source.lal_binary_black_hole,  # noqa
+        )
+
+        likelihood = bilby.gw.GravitationalWaveTransient(
+            interferometers=["H1"],
+            waveform_generator=waveform_generator,
+            priors=priors,
+            phase_marginalization="phase" not in fixed_params,
+            distance_marginalization=False,
+            time_marginalization=False,
+            reference_frame="sky",
+        )
+
+        likelihood = bilby.core.likelihood.ZeroLikelihood(likelihood)
+
+        def log_prior(theta):
+            return priors.ln_prob(theta, axis=0)
+
+        search_parameter_keys = []
+        for key in priors:
+            if (
+                isinstance(priors[key], bilby.core.prior.Prior)
+                and priors[key].is_fixed is False
+            ):
+                search_parameter_keys.append(key)
+
+        def log_likelihood(theta):
+            params = {key: t for key, t in zip(search_parameter_keys, theta)}
+
+            likelihood.parameters.update(params)
+            return likelihood.log_likelihood_ratio()
+
+        class Model(BaseModel):
+            def __init__(self, names, priors):
+                self.names = names
+                self.priors = priors
+                self._update_bounds()
+
+            @staticmethod
+            def log_likelihood(x, **kwargs):
+                theta = [x[n].item() for n in search_parameter_keys]
+                return log_likelihood(theta)
+
+            @staticmethod
+            def log_prior(x, names=None, **kwargs):
+                if names is None:
+                    names = search_parameter_keys
+                theta = {n: x[n] for n in names}
+                return log_prior(theta)
+
+            def _update_bounds(self):
+                self.bounds = {
+                    key: [self.priors[key].minimum, self.priors[key].maximum]
+                    for key in self.names
+                }
+
+            def new_point(self, N=1):
+                prior_samples = self.priors.sample(size=N)
+                samples = {n: prior_samples[n] for n in self.names}
+                self._update_bounds()
+                return dict_to_live_points(samples)
+
+            def new_point_log_prob(self, x):
+                return self.log_prior(x)
+
+        return Model(search_parameter_keys, priors)
+
+    return get_model

--- a/tests/test_gw/test_equivalent_proposal.py
+++ b/tests/test_gw/test_equivalent_proposal.py
@@ -10,17 +10,10 @@ import numpy as np
 import pytest
 
 from nessai import config
-from nessai.model import Model as BaseModel
 from nessai.gw.proposal import GWFlowProposal
 from nessai.gw.legacy import LegacyGWFlowProposal
 from nessai.flowsampler import FlowSampler
-from nessai.livepoint import dict_to_live_points
-
-try:
-    import bilby
-except ImportError:
-    print("Could not import bilby, some tests will not work")
-
+from nessai.utils.testing import assert_structured_arrays_equal
 
 logger = logging.getLogger(__name__)
 
@@ -42,28 +35,6 @@ def update_config():
     config.NON_SAMPLING_DEFAULTS = [0.0, 0.0, 0]
     yield
     config.NON_SAMPLING_DEFAULTS = original
-
-
-@pytest.fixture(scope="module")
-def injection_parameters():
-    injection_parameters = dict(
-        mass_1=36.0,
-        mass_2=29.0,
-        a_1=0.4,
-        a_2=0.3,
-        tilt_1=0.5,
-        tilt_2=1.0,
-        phi_12=1.7,
-        phi_jl=0.3,
-        luminosity_distance=2000.0,
-        theta_jn=0.4,
-        psi=2.659,
-        phase=1.3,
-        geocent_time=1126259642.413,
-        ra=1.375,
-        dec=-1.2108,
-    )
-    return injection_parameters
 
 
 @pytest.fixture(scope="function")
@@ -135,11 +106,15 @@ def kwargs(legacy_kwargs):
         ["chirp_mass", "geocent_time"],
         ["chirp_mass", "mass_ratio"],
         ["chirp_mass", "luminosity_distance"],
+        ["mass_ratio", "chirp_mass"],
+        ["mass_ratio", "ra", "dec"],
+        ["ra", "dec", "mass_ratio"],
     ],
 )
 @pytest.mark.parametrize("compute_radius", [False, True])
 @pytest.mark.integration_test
 def test_parameter(
+    get_bilby_gw_model,
     parameters,
     injection_parameters,
     kwargs,
@@ -154,118 +129,15 @@ def test_parameter(
     log-Jacobian determinants are also the same.
     """
     outdir = str(tmpdir.mkdir("test"))
-    priors = bilby.gw.prior.BBHPriorDict()
-    fixed_params = [
-        "chirp_mass",
-        "mass_ratio",
-        "phi_12",
-        "phi_jl",
-        "a_1",
-        "a_2",
-        "tilt_1",
-        "tilt_2",
-        "ra",
-        "dec",
-        "luminosity_distance",
-        "geocent_time",
-        "theta_jn",
-        "psi",
-    ]
-    try:
-        fixed_params.remove(parameters)
-    except ValueError:
-        for p in parameters:
-            fixed_params.remove(p)
-    priors["geocent_time"] = bilby.core.prior.Uniform(
-        minimum=injection_parameters["geocent_time"] - 0.1,
-        maximum=injection_parameters["geocent_time"] + 0.1,
-        name="geocent_time",
-        latex_label="$t_c$",
-        unit="$s$",
-    )
-    for key in fixed_params:
-        if key in injection_parameters:
-            priors[key] = injection_parameters[key]
-        else:
-            priors.pop(key)
 
-    priors["mass_1"] = injection_parameters["mass_1"]
-    priors["mass_2"] = injection_parameters["mass_2"]
-
-    waveform_generator = bilby.gw.WaveformGenerator(
-        duration=1,
-        sampling_frequency=256,
-        frequency_domain_source_model=bilby.gw.source.lal_binary_black_hole,
-    )
-
-    likelihood = bilby.gw.GravitationalWaveTransient(
-        interferometers=["H1"],
-        waveform_generator=waveform_generator,
-        priors=priors,
-        phase_marginalization=True,
-        distance_marginalization=False,
-        time_marginalization=False,
-        reference_frame="sky",
-    )
-
-    likelihood = bilby.core.likelihood.ZeroLikelihood(likelihood)
-
-    def log_prior(theta):
-        return priors.ln_prob(theta, axis=0)
-
-    search_parameter_keys = []
-    for key in priors:
-        if (
-            isinstance(priors[key], bilby.core.prior.Prior)
-            and priors[key].is_fixed is False
-        ):
-            search_parameter_keys.append(key)
-
-    def log_likelihood(theta):
-        params = {key: t for key, t in zip(search_parameter_keys, theta)}
-
-        likelihood.parameters.update(params)
-        return likelihood.log_likelihood_ratio()
-
-    class Model(BaseModel):
-        def __init__(self, names, priors):
-            self.names = names
-            self.priors = priors
-            self._update_bounds()
-
-        @staticmethod
-        def log_likelihood(x, **kwargs):
-            theta = [x[n].item() for n in search_parameter_keys]
-            return log_likelihood(theta)
-
-        @staticmethod
-        def log_prior(x, names=None, **kwargs):
-            if names is None:
-                names = search_parameter_keys
-            theta = {n: x[n] for n in names}
-            return log_prior(theta)
-
-        def _update_bounds(self):
-            self.bounds = {
-                key: [self.priors[key].minimum, self.priors[key].maximum]
-                for key in self.names
-            }
-
-        def new_point(self, N=1):
-            prior_samples = self.priors.sample(size=N)
-            samples = {n: prior_samples[n] for n in self.names}
-            self._update_bounds()
-            return dict_to_live_points(samples)
-
-        def new_point_log_prob(self, x):
-            return self.log_prior(x)
+    model = get_bilby_gw_model(parameters, injection_parameters)
 
     reparameterisations = kwargs.pop("reparameterisations")
     for k in list(reparameterisations.keys()):
         if k == "sky-ra-dec":
-            if any(p in fixed_params for p in ["ra", "dec"]):
+            if not all(p in model.names for p in ["ra", "dec"]):
                 del reparameterisations["sky-ra-dec"]
-        elif k not in search_parameter_keys:
+        elif k not in model.names:
             del reparameterisations[k]
 
     if "luminosity_distance" in parameters:
@@ -273,7 +145,6 @@ def test_parameter(
             "uniform_distance_parameter"
         ] = True
 
-    model = Model(search_parameter_keys, priors)
     sampler = FlowSampler(
         model, output=outdir, flow_class=LegacyGWFlowProposal, **legacy_kwargs
     )
@@ -323,7 +194,7 @@ def test_parameter(
         np.testing.assert_array_almost_equal_nulp(lj_re, lj_re_new)
         np.testing.assert_array_equal(log_p, log_p_new)
         try:
-            np.testing.assert_array_equal(x_prime, x_prime_new)
+            assert_structured_arrays_equal(x_prime, x_prime_new)
         except (AssertionError, TypeError):
             flag = {n: False for n in x_prime_new.dtype.names}
             for n in x_prime_new.dtype.names:
@@ -333,7 +204,6 @@ def test_parameter(
                 if np.allclose(x_prime[legacy_name], x_prime_new[n]):
                     logger.critical(f"{n} is equivalent to {legacy_name}")
                     flag[n] = True
-
             assert all(v for v in flag.values()), print(f"Flags: {flag}")
         test_results[test] = True
 

--- a/tests/test_gw/test_reparameterisation_integration.py
+++ b/tests/test_gw/test_reparameterisation_integration.py
@@ -1,0 +1,59 @@
+"""Integration test for the reparameterisation in GWFlowProposal"""
+from nessai.gw.proposal import GWFlowProposal
+import numpy as np
+import pytest
+
+
+@pytest.mark.requires("bilby")
+@pytest.mark.requires("lal")
+@pytest.mark.requires("astropy")
+@pytest.mark.integration_test
+@pytest.mark.parametrize("reverse", [False, True])
+def test_invertibility(
+    tmp_path, get_bilby_gw_model, injection_parameters, reverse
+):
+    """Make sure the default GW reparameterisation is invertible.
+
+    Uses the `verify_rescaling` method from `FlowProposal`.
+
+    Also checks if the number of unique samples is the same as the input. This
+    will depend on the order of the reparameterisations when using inversion.
+    """
+    model = get_bilby_gw_model(
+        list(injection_parameters.keys()), injection_parameters
+    )
+    output = tmp_path / "test"
+    output.mkdir()
+
+    proposal = GWFlowProposal(
+        model=model,
+        poolsize=1000,
+        output=output,
+        reverse_reparameterisations=reverse,
+    )
+
+    proposal.set_rescaling()
+    proposal.verify_rescaling()
+
+    reparam = proposal._reparameterisation
+    assert reparam.order == list(reparam.keys())
+
+    if not reverse:
+        pytest.xfail(
+            "Checking unique samples with reverse=False will always fail."
+        )
+    # Check the number of unique samples
+    n = 10
+    x = model.new_point(n)
+
+    x_prime, _ = proposal.rescale(x)
+    x_out, _ = proposal.inverse_rescale(x_prime)
+
+    flags = {n: False for n in proposal.names}
+    for name in proposal.names:
+        flags[name] = np.unique(x_out[name].round(decimals=10)).size == n
+    if not all(flags.values()):
+        msg = f"""Number of unique samples has changed.
+        Breakdown per parameter: {flags}
+        """
+        raise AssertionError(msg)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -788,6 +788,7 @@ def test_verify_rescaling(proposal, has_inversion):
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
     proposal.check_state = MagicMock()
+    proposal.rescaling_set = True
 
     FlowProposal.verify_rescaling(proposal)
 
@@ -822,6 +823,7 @@ def test_verify_rescaling_invertible_error(proposal, has_inversion):
     proposal.model.new_point = MagicMock(return_value=x)
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+    proposal.rescaling_set = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -840,6 +842,7 @@ def test_verify_rescaling_duplicate_error(proposal):
     proposal.model.new_point = MagicMock(return_value=x)
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+    proposal.rescaling_set = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -858,6 +861,7 @@ def test_verify_rescaling_duplicate_error_nans(proposal):
     proposal.model.new_point = MagicMock(return_value=x)
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+    proposal.rescaling_set = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -883,10 +887,18 @@ def test_verify_rescaling_jacobian_error(proposal, has_inversion):
     proposal.model.new_point = MagicMock(return_value=x)
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+    proposal.rescaling_set = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
     assert "Rescaling Jacobian is not invertible" in str(excinfo.value)
+
+
+def test_verify_rescaling_rescaling_not_set(proposal):
+    """Assert an error is raised if the rescaling is not set"""
+    proposal.rescaling_set = False
+    with pytest.raises(RuntimeError, match=r"Rescaling must be set .*"):
+        FlowProposal.verify_rescaling(proposal)
 
 
 def test_check_state_boundary_inversion_default(proposal):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 def proposal(proposal):
     """Specific mocked proposal for reparameterisation tests"""
     proposal.use_default_reparameterisations = False
+    proposal.reverse_reparameterisations = False
     return proposal
 
 
@@ -50,10 +51,14 @@ def test_get_reparamaterisation(mocked_fn, proposal):
     assert mocked_fn.called_once_with("angle")
 
 
-def test_configure_reparameterisations_dict(proposal, dummy_cmb_rc, dummy_rc):
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_configure_reparameterisations_dict(
+    proposal, dummy_cmb_rc, dummy_rc, reverse_order
+):
     """Test configuration for reparameterisations dictionary.
 
-    Also tests to make sure boundary inversion is set.
+    Also tests to make sure boundary inversion is set and if the
+    `reverse_reparameterisation` is correctly set.
     """
     dummy_rc.return_value = "r"
     # Need to add the parameters before hand to prevent a
@@ -66,6 +71,7 @@ def test_configure_reparameterisations_dict(proposal, dummy_cmb_rc, dummy_rc):
     proposal.model = MagicMock()
     proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
     proposal.names = ["x"]
+    proposal.reverse_reparameterisations = reverse_order
 
     with patch(
         "nessai.proposal.flowproposal.CombinedReparameterisation",
@@ -80,7 +86,7 @@ def test_configure_reparameterisations_dict(proposal, dummy_cmb_rc, dummy_rc):
     dummy_rc.assert_called_once_with(
         prior_bounds={"x": [-1, 1]}, parameters="x", boundary_inversion=True
     )
-    mocked_class.assert_called_once()
+    mocked_class.assert_called_once_with(reverse_order=reverse_order)
     # fmt: off
     proposal._reparameterisation.add_reparameterisations \
         .assert_called_once_with("r")

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -846,11 +846,10 @@ def test_verify_rescaling_invertible_error_non_sampling(
     proposal, has_inversion
 ):
     """Assert an error is raised a non-sampler parameter changes"""
-    x = np.array([(1, np.nan), (2, 3)], dtype=[("x", "f8"), ("logL", "f8")])
+    x = np.array([(1, 3), (2, np.nan)], dtype=[("x", "f8"), ("logL", "f8")])
     x_prime = x["x"] / 2
     log_j = np.array([-2, -2])
     x_out = x.copy()
-    x_out["logL"] = np.array([np.nan, np.nan])
     log_j_inv = np.array([2, 2])
 
     if has_inversion:
@@ -858,6 +857,8 @@ def test_verify_rescaling_invertible_error_non_sampling(
         log_j = np.concatenate([log_j, log_j])
         log_j_inv = np.concatenate([log_j_inv, log_j_inv])
         x_out = np.concatenate([x_out, x_out])
+    # Change the last element, this will test both cases
+    x_out["logL"][-1] = 4
 
     proposal.model = MagicMock()
     proposal.model.new_point = MagicMock(return_value=x)
@@ -868,25 +869,6 @@ def test_verify_rescaling_invertible_error_non_sampling(
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
     assert "Non-sampling parameter logL changed" in str(excinfo.value)
-
-
-def test_verify_rescaling_duplicate_error(proposal):
-    """Assert an error is raised if the duplication is missing samples"""
-    x = np.array([[1], [2]], dtype=[("x", "f8")])
-    x_prime = x["x"] / 2
-    log_j = np.array([-2, -2, -2, -2])
-    x_out = np.array([[1], [3], [4], [5]], dtype=[("x", "f8")])
-    log_j_inv = np.array([2, 2, 2, 2])
-
-    proposal.model = MagicMock()
-    proposal.model.new_point = MagicMock(return_value=x)
-    proposal.rescale = MagicMock(return_value=(x_prime, log_j))
-    proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
-    proposal.rescaling_set = True
-
-    with pytest.raises(RuntimeError) as excinfo:
-        FlowProposal.verify_rescaling(proposal)
-    assert "Duplicate samples must map to same input" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("has_inversion", [False, True])

--- a/tests/test_reparameterisations/test_combined.py
+++ b/tests/test_reparameterisations/test_combined.py
@@ -36,6 +36,36 @@ def test_init_w_reparam():
     assert c.prime_parameters == ["x_prime"]
 
 
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_to_prime_order(reverse_order, reparam):
+    """Assert order is correct depending on the value of the reversed flag"""
+    order = [1, 2, 3]
+    reparam.order = order
+    reparam.reverse_order = reverse_order
+
+    expected = [1, 2, 3]
+    if reverse_order:
+        expected = list(reversed(expected))
+
+    out = CombinedReparameterisation.to_prime_order.__get__(reparam)
+    assert list(out) == expected
+
+
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_from_prime_order(reverse_order, reparam):
+    """Assert order is correct depending on the value of the reversed flag"""
+    order = [1, 2, 3]
+    reparam.order = order
+    reparam.reverse_order = reverse_order
+
+    expected = [3, 2, 1]
+    if reverse_order:
+        expected = list(reversed(expected))
+
+    out = CombinedReparameterisation.from_prime_order.__get__(reparam)
+    assert list(out) == expected
+
+
 def test_add_single_reparameterisations():
     """Test the core functionality of adding reparameterisations"""
     r = RescaleToBounds(parameters="x", prior_bounds=[0, 1])


### PR DESCRIPTION
An unintended side effect of https://github.com/mj-will/nessai/pull/244 was that it changed the default order of the reparameterisations when rescaling parameters. This doesn't matter in most cases but is relevant when using the `inversion` option in `RescaleToBounds`.

**Changes**
The PR reverts the order back to the previous order but adds an option to reverse the order.

It also includes some other minor changes related to testing this:
* `verify_rescaling` now checks to make sure the rescaling has been set before calling it
* Refactor the tests that compare to the legacy GW proposal to use a fixture so the code can be reused
* Add a test to check the number of unique samples in the GW reparameterisation