### PR TITLE
Add option to disable vectorisation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `log_posterior_weights` and `effective_n_posterior_samples` to the integral state object.
 - Add a check for the multiprocessing start method when using `n_pool`.
 - Add option to reverse reparameterisations in `FlowProposal`.
+- Add `disable_vectorisation` to `FlowSampler`.
 
 ### Changed
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -47,6 +47,9 @@ class FlowSampler:
         If True, the multiprocessing pool will be closed once the run method
         has been called. Disables the option in :code:`NestedSampler` if
         enabled.
+    disable_vectorisation : bool
+        Disable likelihood vectorisation. Overrides the value of
+        :py:attr:`nessai.model.Model.allow_vectorised.
     kwargs :
         Keyword arguments passed to
         :obj:`~nessai.samplers.nestedsampler.NestedSampler`.
@@ -64,6 +67,7 @@ class FlowSampler:
         pytorch_threads=1,
         max_threads=None,
         close_pool=True,
+        disable_vectorisation=False,
         **kwargs,
     ):
 
@@ -74,6 +78,12 @@ class FlowSampler:
 
         self.exit_code = exit_code
         self.close_pool = close_pool
+
+        if disable_vectorisation:
+            logger.warning(
+                "Overriding value of `allow_vectorised` in the model"
+            )
+            model.allow_vectorised = False
 
         self.output = os.path.join(output, "")
         if resume:

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -86,6 +86,26 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume):
     flow_sampler.save_kwargs.assert_called_once_with(kwargs)
 
 
+def test_disable_vectorisation(flow_sampler, tmp_path):
+    """Assert vectorisation is disabled"""
+    output = tmp_path / "test"
+    output.mkdir()
+
+    model = MagicMock()
+    model.allow_vectorised = True
+
+    with patch("nessai.flowsampler.NestedSampler") as mock:
+        FlowSampler.__init__(
+            flow_sampler,
+            model,
+            output=output,
+            disable_vectorisation=True,
+        )
+    mock.assert_called_once()
+    input_model = mock.call_args[0][0]
+    assert input_model.allow_vectorised is False
+
+
 @pytest.mark.parametrize(
     "test_old, error",
     [(False, None), (True, RuntimeError), (True, FileNotFoundError)],


### PR DESCRIPTION
Add an option to disable vectorisation when calling `FlowSampler`. This may be useful when running via `bilby` since the user cannot set `Model.allow_vectorised`.

**To-Do**

- [x] Check coverage
- [x] Update changelog