### PR TITLE
Allow truths dictionary in corner plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Revert default logging level to `INFO`
 - Rework logging statements to reduce the amount of information printed by default.
 - Refactor `nessai.proposal.FlowProposal.verify_rescaling` to be stricter.
+- Truth input in `nessai.plot.corner_plot` can now be an iterable or a dictionary.
 
 ### Removed
 

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -536,7 +536,7 @@ def corner_plot(
         List of parameters to exclude.
     labels : Optional[Iterable]
         Labels for each parameter that is to be plotted.
-    truths : Optional[Iterable]
+    truths : Optional[Union[Iterable, Dict]]
         Truth values for each parameters, parameters can be skipped by setting
         the value to None.
     filename : Optional[str]
@@ -594,9 +594,21 @@ def corner_plot(
         labels = labels[has_range]
 
     if truths:
-        truths = np.asarray(truths)
+        if isinstance(truths, dict):
+            if include:
+                truths = np.array([truths[n] for n in include])
+            else:
+                truths = np.fromiter(truths.values(), float)
+        else:
+            truths = np.asarray(truths)
         if len(truths) != unstruct_array.shape[-1]:
-            truths = truths[has_range]
+            if not all(has_range):
+                truths = truths[has_range]
+            else:
+                raise ValueError(
+                    "Length of truths does not match number of "
+                    "parameters being plotted"
+                )
 
     fig = corner.corner(
         unstruct_array, truths=truths, labels=labels, **default_kwargs

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -431,7 +431,10 @@ def test_corner_plot_w_labels(live_points, labels):
     plot.corner_plot(live_points, labels=labels)
 
 
-@pytest.mark.parametrize("truths", [[0, 0], [0, 0, None, None, None]])
+@pytest.mark.parametrize(
+    "truths",
+    [[0, 0], [0, 0, None, None, None], {"x": 0, "y": 0}],
+)
 def test_corner_plot_w_truths(live_points, truths):
     """Test the corner plot with truths"""
     plot.corner_plot(live_points, truths=truths)
@@ -453,6 +456,21 @@ def test_corner_plot_w_include_and_labels(live_points):
     """Test the parameter is included and the labels do not raise an error"""
     fig = plot.corner_plot(live_points, include=["x"], labels=["x_0"])
     assert len(fig.axes) == 1
+
+
+@pytest.mark.parametrize("truths", [[1], {"x": 1, "y": 1}])
+def test_corner_plot_w_include_and_truths(live_points, truths):
+    """Test the parameter is included and the truths do not raise an error"""
+    fig = plot.corner_plot(live_points, include=["x"], truths=truths)
+    assert len(fig.axes) == 1
+
+
+def test_corner_plot_w_include_and_truths_error(live_points):
+    """Assert an error is raised when the number truths do not match the
+    number of parameters
+    """
+    with pytest.raises(ValueError, match=r"truths does not match .*"):
+        plot.corner_plot(live_points, include=["x"], truths=[1, 1])
 
 
 def test_corner_plot_all_nans(caplog, live_points):


### PR DESCRIPTION
Change `corner_plot` so that `truths` can either be an `Iterable` or a `Dict`.

Also raise an error if the length of `truths` does not match the number of parameters being plotted.