### PR TITLE
Add likelihood chunksize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a check for the multiprocessing start method when using `n_pool`.
 - Add option to reverse reparameterisations in `FlowProposal`.
 - Add `disable_vectorisation` to `FlowSampler`.
+- Add `likelihood_chunksize` which allows the user to limit how many points are passed to a vectorised likelihood function at once.
 
 ### Changed
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -49,7 +49,11 @@ class FlowSampler:
         enabled.
     disable_vectorisation : bool
         Disable likelihood vectorisation. Overrides the value of
-        :py:attr:`nessai.model.Model.allow_vectorised.
+        :py:attr:`nessai.model.Model.allow_vectorised`.
+    likelihood_chunksize : Optional[int]
+        Chunksize used when evaluating a vectorised likelihood. Overrides the
+        of :py:attr:`nessai.model.Model.likelihood_chunksize`. Set to None to
+        evaluate the likelihood with all available points.
     kwargs :
         Keyword arguments passed to
         :obj:`~nessai.samplers.nestedsampler.NestedSampler`.
@@ -68,6 +72,7 @@ class FlowSampler:
         max_threads=None,
         close_pool=True,
         disable_vectorisation=False,
+        likelihood_chunksize=None,
         **kwargs,
     ):
 
@@ -84,6 +89,9 @@ class FlowSampler:
                 "Overriding value of `allow_vectorised` in the model"
             )
             model.allow_vectorised = False
+
+        if likelihood_chunksize:
+            model.likelihood_chunksize = likelihood_chunksize
 
         self.output = os.path.join(output, "")
         if resume:

--- a/nessai/utils/structures.py
+++ b/nessai/utils/structures.py
@@ -77,3 +77,23 @@ def isfinite_struct(x, names=None):
     if names is None:
         names = x.dtype.names
     return np.all([np.isfinite(x[n]) for n in names], axis=0)
+
+
+def array_split_chunksize(x, chunksize):
+    """Split an array into multiple sub-arrays of a specified chunksize.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Input array.
+    chunksize : int
+        Chunksize into which to split the array.
+
+    Returns
+    -------
+    list
+        List of numpy arrays each with a maximum length given by the chunksize.
+    """
+    if chunksize < 1:
+        raise ValueError("chunksize must be greater than 1")
+    return np.array_split(x, range(chunksize, len(x), chunksize))

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -106,6 +106,26 @@ def test_disable_vectorisation(flow_sampler, tmp_path):
     assert input_model.allow_vectorised is False
 
 
+def test_likelihood_chunksize(flow_sampler, tmp_path):
+    """Assert the likelihood chunksize is set."""
+    output = tmp_path / "test"
+    output.mkdir()
+
+    model = MagicMock()
+    model.likelihood_chunksize = None
+
+    with patch("nessai.flowsampler.NestedSampler") as mock:
+        FlowSampler.__init__(
+            flow_sampler,
+            model,
+            output=output,
+            likelihood_chunksize=100,
+        )
+    mock.assert_called_once()
+    input_model = mock.call_args[0][0]
+    assert input_model.likelihood_chunksize == 100
+
+
 @pytest.mark.parametrize(
     "test_old, error",
     [(False, None), (True, RuntimeError), (True, FileNotFoundError)],

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -410,3 +410,37 @@ def test_disable_vectorisation(model, tmp_path):
         plot=False,
     )
     fs.run(plot=False)
+
+
+@pytest.mark.slow_integration_test
+def test_likelihood_chunksize(model, tmp_path):
+    """Assert likelihood chunksize limits number of samples in each call"""
+
+    class TestModel(Model):
+        def __init__(self):
+            self.bounds = {"x": [-5, 5], "y": [-5, 5]}
+            self.names = ["x", "y"]
+
+        def log_prior(self, x):
+            log_p = np.log(self.in_bounds(x), dtype="float")
+            for n in self.names:
+                log_p -= self.bounds[n][1] - self.bounds[n][0]
+            return log_p
+
+        def log_likelihood(self, x):
+            # AssertionError won't be caught by nessai
+            assert not (x.size > self.likelihood_chunksize)
+            log_l = 0
+            for pn in self.names:
+                log_l += norm.logpdf(x[pn])
+            return log_l
+
+    output = tmp_path / "disable_vec"
+    output.mkdir()
+
+    model = TestModel()
+
+    fs = FlowSampler(
+        model, output=output, nlive=100, plot=False, likelihood_chunksize=10
+    )
+    fs.run(plot=False, save=False)

--- a/tests/test_utils/test_structures_utils.py
+++ b/tests/test_utils/test_structures_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from nessai.utils.structures import (
+    array_split_chunksize,
     get_subset_arrays,
     isfinite_struct,
     replace_in_list,
@@ -110,3 +111,27 @@ def test_isfinite_struct_invalid_name():
     x = np.array([(1,), (2,)], dtype=[("x", "i4")])
     with pytest.raises(ValueError):
         isfinite_struct(x, ["y"])
+
+
+def test_array_split_chunksize():
+    """Assert the correct array sizes are returned"""
+    a = np.array([1, 2, 3, 4, 5])
+    out = array_split_chunksize(a, 2)
+    assert len(out) == 3
+    np.testing.assert_array_equal(out[0], a[:2])
+    np.testing.assert_array_equal(out[1], a[2:4])
+    np.testing.assert_array_equal(out[2], a[4:])
+
+
+def test_array_split_chunksize_larger_than_array():
+    """Assert the correct array sizes are returned"""
+    a = np.array([1, 2, 3, 4, 5])
+    out = array_split_chunksize(a, 6)
+    assert len(out) == 1
+    np.testing.assert_array_equal(out[0], a)
+
+
+def test_array_split_chunksize_invalid_chunksize():
+    """Assert an error is returned if the chunksize is less than one"""
+    with pytest.raises(ValueError, match="chunksize must be greater than 1"):
+        array_split_chunksize(np.array([1, 2]), -1)


### PR DESCRIPTION
Add an option to limit the maximum chunksize (number of samples) that are passed to a vectorised likelihood in a single call. This can be useful in cases where the likelihood is vectorised, but memory constraints prevent it being computed for more than $N$ samples at once.

**Usage**

The chunksize is set with `nessai.model.Model.likelihood_chunksize`, which can be done a number of ways:

After instantiating a class:
```python
model = ModelClass(...)
model.likelihood_chunksize = 100
```

In the `init` method
```python
class ModelClass(Model):
    def __init__(self, ...):
        ...
        self.likelihood_chunksize = 100
````

As an argument (useful when using `bilby`)

```python
fs = FlowSampler(
    model,
    ...,
    likelihood_chunksize=100,
)
```