### PR TITLE
Allow multi-valued likelihood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to reverse reparameterisations in `FlowProposal`.
 - Add `disable_vectorisation` to `FlowSampler`.
 - Add `likelihood_chunksize` which allows the user to limit how many points are passed to a vectorised likelihood function at once.
+- Add `allow_multi_valued_likelihood` which allows for multi-valued likelihoods, e.g. that include numerical integration.
 
 ### Changed
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -54,6 +54,11 @@ class FlowSampler:
         Chunksize used when evaluating a vectorised likelihood. Overrides the
         of :py:attr:`nessai.model.Model.likelihood_chunksize`. Set to None to
         evaluate the likelihood with all available points.
+    allow_multi_valued_likelihood : Optional[bool]
+        Allow for a multi-valued likelihood function that will return different
+        likelihood values for the same point in parameter space. See
+        :py:attr:`nessai.model.Model.allow_multi_valued_likelihood` for more
+        details.
     kwargs :
         Keyword arguments passed to
         :obj:`~nessai.samplers.nestedsampler.NestedSampler`.
@@ -73,6 +78,7 @@ class FlowSampler:
         close_pool=True,
         disable_vectorisation=False,
         likelihood_chunksize=None,
+        allow_multi_valued_likelihood=None,
         **kwargs,
     ):
 
@@ -92,6 +98,9 @@ class FlowSampler:
 
         if likelihood_chunksize:
             model.likelihood_chunksize = likelihood_chunksize
+
+        if allow_multi_valued_likelihood:
+            model.allow_multi_valued_likelihood = allow_multi_valued_likelihood
 
         self.output = os.path.join(output, "")
         if resume:

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -99,7 +99,7 @@ class FlowSampler:
         if likelihood_chunksize:
             model.likelihood_chunksize = likelihood_chunksize
 
-        if allow_multi_valued_likelihood:
+        if allow_multi_valued_likelihood is not None:
             model.allow_multi_valued_likelihood = allow_multi_valued_likelihood
 
         self.output = os.path.join(output, "")

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -126,6 +126,26 @@ def test_likelihood_chunksize(flow_sampler, tmp_path):
     assert input_model.likelihood_chunksize == 100
 
 
+def test_allow_multi_valued_likelihood(flow_sampler, tmp_path):
+    """Assert allow_multi_valued_likelihood is true"""
+    output = tmp_path / "test"
+    output.mkdir()
+
+    model = MagicMock()
+    model.allow_multi_value_likelihood = False
+
+    with patch("nessai.flowsampler.NestedSampler") as mock:
+        FlowSampler.__init__(
+            flow_sampler,
+            model,
+            output=output,
+            allow_multi_valued_likelihood=True,
+        )
+    mock.assert_called_once()
+    input_model = mock.call_args[0][0]
+    assert input_model.allow_multi_valued_likelihood is True
+
+
 @pytest.mark.parametrize(
     "test_old, error",
     [(False, None), (True, RuntimeError), (True, FileNotFoundError)],

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -796,6 +796,7 @@ def test_verify_model_likelihood_repeated_calls():
 
     class BrokenModel(TestModel):
         count = 0
+        allow_multi_valued_likelihood = False
 
         def log_likelihood(self, x):
             self.count += 1
@@ -806,6 +807,22 @@ def test_verify_model_likelihood_repeated_calls():
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
     assert "Repeated calls" in str(excinfo.value)
+
+
+def test_verify_model_likelihood_repeated_calls_allowed(caplog):
+    """Assert allow multi valued likelihood prevents an error from being
+    raised.
+    """
+
+    class MultiValuedModel(TestModel):
+        allow_multi_valued_likelihood = True
+
+        def log_likelihood(self, x):
+            return np.random.rand()
+
+    model = MultiValuedModel()
+    model.verify_model()
+    assert "Multi-valued likelihood is allowed." in str(caplog.text)
 
 
 def test_configure_pool_with_pool(model):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -18,6 +18,26 @@ from nessai.model import Model
 torch.set_num_threads(1)
 
 
+class BaseModel(Model):
+    """Base model class for sampling tests"""
+
+    def __init__(self):
+        self.bounds = {"x": [-5, 5], "y": [-5, 5]}
+        self.names = ["x", "y"]
+
+    def log_prior(self, x):
+        log_p = np.log(self.in_bounds(x), dtype="float")
+        for n in self.names:
+            log_p -= self.bounds[n][1] - self.bounds[n][0]
+        return log_p
+
+    def log_likelihood(self, x):
+        log_l = np.zeros(x.size)
+        for pn in self.names:
+            log_l += norm.logpdf(x[pn])
+        return log_l
+
+
 @pytest.mark.slow_integration_test
 def test_sampling_with_rescale(model, flow_config, tmpdir):
     """
@@ -442,5 +462,28 @@ def test_likelihood_chunksize(model, tmp_path):
 
     fs = FlowSampler(
         model, output=output, nlive=100, plot=False, likelihood_chunksize=10
+    )
+    fs.run(plot=False, save=False)
+
+
+@pytest.mark.slow_integration_test
+def test_allow_multi_valued_likelihood(model, tmp_path):
+    """Assert a multi valued likelihood can be sampled from"""
+
+    class TestModel(BaseModel):
+        def log_likelihood(self, x):
+            return super().log_likelihood(x) + 1e-10 * np.random.randn(x.size)
+
+    output = tmp_path / "multi_value"
+    output.mkdir()
+
+    model = TestModel()
+
+    fs = FlowSampler(
+        model,
+        output=output,
+        nlive=100,
+        plot=False,
+        allow_multi_valued_likelihood=True,
     )
     fs.run(plot=False, save=False)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -398,24 +398,11 @@ def test_debug_log_level(model, tmpdir):
 def test_disable_vectorisation(model, tmp_path):
     """Assert vectorisation can be disabled"""
 
-    class TestModel(Model):
-        def __init__(self):
-            self.bounds = {"x": [-5, 5], "y": [-5, 5]}
-            self.names = ["x", "y"]
-
-        def log_prior(self, x):
-            log_p = np.log(self.in_bounds(x), dtype="float")
-            for n in self.names:
-                log_p -= self.bounds[n][1] - self.bounds[n][0]
-            return log_p
-
+    class TestModel(BaseModel):
         def log_likelihood(self, x):
             # AssertionError won't be caught by nessai
             assert not (x.size > 1)
-            log_l = 0
-            for pn in self.names:
-                log_l += norm.logpdf(x[pn])
-            return log_l
+            return super().log_likelihood(x)
 
     output = tmp_path / "disable_vec"
     output.mkdir()
@@ -436,24 +423,11 @@ def test_disable_vectorisation(model, tmp_path):
 def test_likelihood_chunksize(model, tmp_path):
     """Assert likelihood chunksize limits number of samples in each call"""
 
-    class TestModel(Model):
-        def __init__(self):
-            self.bounds = {"x": [-5, 5], "y": [-5, 5]}
-            self.names = ["x", "y"]
-
-        def log_prior(self, x):
-            log_p = np.log(self.in_bounds(x), dtype="float")
-            for n in self.names:
-                log_p -= self.bounds[n][1] - self.bounds[n][0]
-            return log_p
-
+    class TestModel(BaseModel):
         def log_likelihood(self, x):
             # AssertionError won't be caught by nessai
             assert not (x.size > self.likelihood_chunksize)
-            log_l = 0
-            for pn in self.names:
-                log_l += norm.logpdf(x[pn])
-            return log_l
+            return super().log_likelihood(x)
 
     output = tmp_path / "disable_vec"
     output.mkdir()


### PR DESCRIPTION
There are some cases where the user-defined likelihood can be unavoidably multi-valued, for example, when it includes a numerical integration. Currently, `nessai` cannot sample such likelihoods because of the checks in `Model.verify_model`.

This PR adds an option to disable this specific check, but prints a warning when doing so. This generally isn't recommended, but there are cases where it cannot be avoided and the scale of the variation is small enough that it shouldn't significantly impact results.