### PR TITLE
Improve trace plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `disable_vectorisation` to `FlowSampler`.
 - Add `likelihood_chunksize` which allows the user to limit how many points are passed to a vectorised likelihood function at once.
 - Add `allow_multi_valued_likelihood` which allows for multi-valued likelihoods, e.g. that include numerical integration.
+- Add `parameters` keyword argument to `nessai.plot.plot_trace` and pass additional keyword arguments to the plotting function.
 
 ### Changed
 

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -431,7 +431,12 @@ def plot_loss(epoch, history, filename=None):
 
 @nessai_style()
 def plot_trace(
-    log_x, nested_samples, parameters=None, labels=None, filename=None
+    log_x,
+    nested_samples,
+    parameters=None,
+    labels=None,
+    filename=None,
+    **kwargs,
 ):
     """Produce trace plot for the nested samples.
 
@@ -452,7 +457,14 @@ def plot_trace(
     filename : str, optional
         Filename for saving the plot, if none plot is not saved and figure
         is returned instead.
+    kwargs :
+        Keyword arguments passed to :code:`matplotlib.pyplot.plot`.
     """
+    default_kwargs = dict(
+        marker=",",
+        linestyle="",
+    )
+
     nested_samples = np.asarray(nested_samples)
     if not nested_samples.dtype.names:
         raise TypeError("Nested samples must be a structured array")
@@ -467,6 +479,8 @@ def plot_trace(
             f"List of labels is the wrong length ({len(labels)}) for the "
             f"parameters: {parameters}."
         )
+    if kwargs:
+        default_kwargs.update(kwargs)
 
     fig, axes = plt.subplots(
         len(labels), 1, figsize=(5, 3 * len(labels)), sharex=True
@@ -477,7 +491,7 @@ def plot_trace(
         axes = [axes]
 
     for i, name in enumerate(parameters):
-        axes[i].plot(log_x, nested_samples[name], ",")
+        axes[i].plot(log_x, nested_samples[name], **default_kwargs)
         axes[i].set_ylabel(labels[i])
 
     axes[-1].set_xlabel("log X")

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -430,18 +430,23 @@ def plot_loss(epoch, history, filename=None):
 
 
 @nessai_style()
-def plot_trace(log_x, nested_samples, labels=None, filename=None):
-    """Produce trace plot for all of the parameters.
+def plot_trace(
+    log_x, nested_samples, parameters=None, labels=None, filename=None
+):
+    """Produce trace plot for the nested samples.
 
-    This includes all parameters in the sampler, not just those included in the
-    model being sampled.
+    By default this includes all parameters in the samples, not just those
+    included in the model being sampled.
 
     Parameters
     ----------
     log_x : array_like
-        Array of log prior volumnes
-    nested_samples : ndrray
+        Array of log prior volumes
+    nested_samples : ndarray
         Array of nested samples to plot
+    parameters : list, optional
+        List of parameters to include the trace plot. If not specified, all of
+        the parameters in the nested samples are included.
     labels : list, optional
         List of labels to use instead of the names of parameters
     filename : str, optional
@@ -452,14 +457,15 @@ def plot_trace(log_x, nested_samples, labels=None, filename=None):
     if not nested_samples.dtype.names:
         raise TypeError("Nested samples must be a structured array")
 
-    names = nested_samples.dtype.names
+    if parameters is None:
+        parameters = nested_samples.dtype.names
     if labels is None:
-        labels = names
+        labels = parameters
 
-    if not len(labels) == len(names):
+    if not len(labels) == len(parameters):
         raise RuntimeError(
-            "Missing labels. List of labels does not have enough entries "
-            f"({len(labels)}) for parameters: {nested_samples.dtype.names}"
+            f"List of labels is the wrong length ({len(labels)}) for the "
+            f"parameters: {parameters}."
         )
 
     fig, axes = plt.subplots(
@@ -470,7 +476,7 @@ def plot_trace(log_x, nested_samples, labels=None, filename=None):
     else:
         axes = [axes]
 
-    for i, name in enumerate(names):
+    for i, name in enumerate(parameters):
         axes[i].plot(log_x, nested_samples[name], ",")
         axes[i].set_ylabel(labels[i])
 

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -1067,7 +1067,7 @@ class NestedSampler(BaseNestedSampler):
         else:
             return fig
 
-    def plot_trace(self, filename=None):
+    def plot_trace(self, filename=None, **kwargs):
         """
         Make trace plots for the nested samples.
 
@@ -1076,10 +1076,16 @@ class NestedSampler(BaseNestedSampler):
         filename : str, optional
             If filename is None, the figure is returned. Else the figure
             is saved with that file name.
+        kwargs :
+            Additional keyword arguments passed to
+            :py:func:`nessai.plot.plot_trace`.
         """
         if self.nested_samples:
             fig = plot_trace(
-                self.state.log_vols[1:], self.nested_samples, filename=filename
+                self.state.log_vols[1:],
+                self.nested_samples,
+                filename=filename,
+                **kwargs,
             )
             return fig
         else:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -379,10 +379,17 @@ def test_trace_plot_labels(nested_samples, labels):
 def test_trace_plot_labels_error(nested_samples):
     """Test to ensure error is raised if labels are incompatible"""
     log_x = np.linspace(-10, 0, nested_samples.size)
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(
+        RuntimeError, match=r"List of labels is the wrong length \(3\)"
+    ):
         plot.plot_trace(log_x, nested_samples, labels=["1", "2", "3"])
 
-    assert "Missing labels" in str(excinfo.value)
+
+def test_trace_plot_parameters(nested_samples):
+    """Assert the parameters arguments works"""
+    log_x = np.linspace(-10, 0, nested_samples.size)
+    plot.plot_trace(log_x, nested_samples, parameters=["x"])
+    plt.close()
 
 
 def test_histogram_plot():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -7,7 +7,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from nessai import plot
 from nessai import config
@@ -389,6 +389,17 @@ def test_trace_plot_parameters(nested_samples):
     """Assert the parameters arguments works"""
     log_x = np.linspace(-10, 0, nested_samples.size)
     plot.plot_trace(log_x, nested_samples, parameters=["x"])
+    plt.close()
+
+
+def test_trace_plot_kwargs(nested_samples):
+    """Assert the kwargs are passed to the plotting function."""
+    log_x = np.linspace(-10, 0, nested_samples.size)
+    mock_axes = MagicMock()
+    mock_axes.plot = MagicMock()
+    with patch("matplotlib.pyplot.subplots", return_value=(None, mock_axes)):
+        plot.plot_trace(log_x, nested_samples, marker="^", parameters=["x"])
+    mock_axes.plot.call_args[0][1] == dict(marker="^")
     plt.close()
 
 


### PR DESCRIPTION
This PR adds the `parameters` keyword argument to `plot_trace` which allows the user to control which parameters are plotted.

I also change `plot_trace` so that kwargs can be passed to `plt.plot`. This will allow the user to customize the plots.