### PR TITLE
ci: upgrade codecov action to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         python -m pytest --cov-report=xml --without-integration --without-slow-integration
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests


### PR DESCRIPTION
Upgrade the codecov action from v1 to v3 since the former is deprecated: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1