### PR TITLE
Fix bug when resuming with multiprocessing pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug that led to the multiprocessing pool not being used when resuming.
+
 ## [0.7.0]
 
 **Important:** in this release the flow backend changed from `nflows` to `glasflow` which increased the minimum version of PyTorch to 1.11.0.

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -76,6 +76,13 @@ class FlowSampler:
         self.close_pool = close_pool
 
         self.output = os.path.join(output, "")
+        os.makedirs(self.output, exist_ok=True)
+        self.save_kwargs(kwargs)
+
+        model.configure_pool(
+            n_pool=kwargs.pop("n_pool", None), pool=kwargs.pop("pool", None)
+        )
+
         if resume:
             if not resume_file:
                 raise RuntimeError(
@@ -133,8 +140,6 @@ class FlowSampler:
                 close_pool=not self.close_pool,
                 **kwargs,
             )
-
-        self.save_kwargs(kwargs)
 
         if signal_handling:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.9
 pandas
 matplotlib>=2.0
 seaborn
-scipy>=0.16
+scipy>=0.16,<1.10
 torch>=1.7.0
 tqdm
 nflows

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     pandas
     matplotlib>=2.0
     seaborn
-    scipy>=0.16
+    scipy>=0.16,<1.10
     torch>=1.11.0
     tqdm
     glasflow

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -68,7 +68,7 @@ def integration_model():
 
 @pytest.fixture
 def model():
-    return create_autospec(Model, set_spec=True, _pool_configured=False)
+    return create_autospec(Model, _pool_configured=False)
 
 
 @pytest.fixture

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -68,7 +68,7 @@ def integration_model():
 
 @pytest.fixture
 def model():
-    return create_autospec(Model)
+    return create_autospec(Model, set_spec=True, _pool_configured=False)
 
 
 @pytest.fixture

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -869,6 +869,15 @@ def test_configure_pool_none(model, caplog):
     )
 
 
+def test_configure_pool_already_configured(model, caplog):
+    """Assert configuration is skipped if the pool is already configured"""
+    model._pool_configured = True
+    model.n_pool = 2
+    Model.configure_pool(model, n_pool=4)
+    assert model.n_pool == 2
+    assert "pool has already been configured" in str(caplog.text)
+
+
 @pytest.mark.parametrize("code", [10, 2])
 def test_close_pool(model, code):
     """Test closing the pool"""

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -197,13 +197,22 @@ def test_sampling_resume(model, flow_config, tmpdir):
         seed=1234,
         max_iteration=11,
         poolsize=10,
+        n_pool=1,
     )
+    assert fp.ns.model.n_pool == 1
     fp.run()
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
+    # Make sure the pool is already closed
+    model.close_pool()
 
     fp = FlowSampler(
-        model, output=output, resume=True, flow_config=flow_config
+        model,
+        output=output,
+        resume=True,
+        flow_config=flow_config,
+        n_pool=1,
     )
+    assert fp.ns.model.n_pool == 1
     assert fp.ns.iteration == 11
     fp.ns.max_iteration = 21
     fp.run()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -197,21 +197,63 @@ def test_sampling_resume(model, flow_config, tmpdir):
         seed=1234,
         max_iteration=11,
         poolsize=10,
-        n_pool=1,
     )
-    assert fp.ns.model.n_pool == 1
     fp.run()
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
-    # Make sure the pool is already closed
-    model.close_pool()
 
     fp = FlowSampler(
         model,
         output=output,
         resume=True,
         flow_config=flow_config,
-        n_pool=1,
     )
+    assert fp.ns.iteration == 11
+    fp.ns.max_iteration = 21
+    fp.run()
+    assert fp.ns.iteration == 21
+    assert os.path.exists(
+        os.path.join(output, "nested_sampler_resume.pkl.old")
+    )
+
+
+@pytest.mark.slow_integration_test
+def test_sampling_resume_w_pool(model, flow_config, tmpdir, mp_context):
+    """
+    Test resuming the sampler with a pool.
+    """
+    output = str(tmpdir.mkdir("resume"))
+    with patch("multiprocessing.Pool", mp_context.Pool):
+        fp = FlowSampler(
+            model,
+            output=output,
+            resume=True,
+            nlive=100,
+            plot=False,
+            flow_config=flow_config,
+            training_frequency=10,
+            maximum_uninformed=9,
+            rescale_parameters=True,
+            checkpoint_on_iteration=True,
+            checkpoint_frequency=5,
+            seed=1234,
+            max_iteration=11,
+            poolsize=10,
+            n_pool=1,
+        )
+    assert fp.ns.model.n_pool == 1
+    fp.run()
+    assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
+    # Make sure the pool is already closed
+    model.close_pool()
+
+    with patch("multiprocessing.Pool", mp_context.Pool):
+        fp = FlowSampler(
+            model,
+            output=output,
+            resume=True,
+            flow_config=flow_config,
+            n_pool=1,
+        )
     assert fp.ns.model.n_pool == 1
     assert fp.ns.iteration == 11
     fp.ns.max_iteration = 21


### PR DESCRIPTION
In the current release, when the sampler is resumed the multiprocessing is not initialised and the sampler runs with a single core.

**Fix**

Configured the multiprocessing pool in `FlowSampler` instead of the nested sampler. It will now always be configured irrespective of whether the sampler is being run for the first time or not.