### PR TITLE
Pin black to 2022 version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff"
+          version: "22.12"
   flake8:
     name: Lint - Flake8
     runs-on: ubuntu-latest


### PR DESCRIPTION
The black linting job is failing because black has changed its style for 2023. This should be reverted later once we bump the version and lint the code.