### PR TITLE
Change new shrinkage weights to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework logging statements to reduce the amount of information printed by default.
 - Refactor `nessai.proposal.FlowProposal.verify_rescaling` to be stricter.
 - Truth input in `nessai.plot.corner_plot` can now be an iterable or a dictionary.
+- Tweak how the prior volume is computed for the final nested sample. This will also change the evidence and posterior weights.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `allow_multi_valued_likelihood` which allows for multi-valued likelihoods, e.g. that include numerical integration.
 - Add `parameters` keyword argument to `nessai.plot.plot_trace` and pass additional keyword arguments to the plotting function.
 - Add option to construct live points without non-sampling parameters.
+- Add option to use a different estimate of the shrinkage. Default remains unchanged.
 
 ### Changed
 
 - Refactor `nessai.reparameterisations` into a submodule.
 - Use `torch.inference_mode` instead of `torch.no_grad`.
 - Changed `CombinedReparameterisations` to sort and add reparameterisations based on their requirements.
-- Changed evidence calculation and posterior weights to use a better estimate of the shrinkage.
 - Refactor `nessai.evidence._NSIntegralState` to inherit from a base class.
 - Revert default logging level to `INFO`
 - Rework logging statements to reduce the amount of information printed by default.

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -140,6 +140,9 @@ class NestedSampler(BaseNestedSampler):
     acceptance_threshold : float (0.01)
         Threshold to determine if the flow should be retrained, will not
         retrain if cooldown is not satisfied.
+    shrinkage_expectation : str, {"t", "logt"}
+        Method used to compute the expectation value for the shrinkage t.
+        Choose between log <t> or <log t>. Defaults to <log t>.
     kwargs :
         Keyword arguments passed to the flow proposal class
     """
@@ -182,6 +185,7 @@ class NestedSampler(BaseNestedSampler):
         retrain_acceptance=True,
         reset_acceptance=False,
         acceptance_threshold=0.01,
+        shrinkage_expectation="logt",
         **kwargs,
     ):
 
@@ -231,7 +235,11 @@ class NestedSampler(BaseNestedSampler):
         self.logLmax = -np.inf
         self.nested_samples = []
         self.logZ = None
-        self.state = _NSIntegralState(self.nlive, track_gradients=plot)
+        self.state = _NSIntegralState(
+            self.nlive,
+            track_gradients=plot,
+            expectation=shrinkage_expectation,
+        )
 
         # Timing
         self.training_time = datetime.timedelta()

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -5,6 +5,7 @@ Test functions related to drawing posterior samples
 import logging
 import numpy as np
 import pytest
+from unittest.mock import patch
 
 from nessai.livepoint import numpy_array_to_live_points
 from nessai.posterior import compute_weights, draw_posterior_samples
@@ -27,15 +28,32 @@ def method(request):
     return request.param
 
 
-@pytest.mark.parametrize("nlive", [10, np.ones(20)])
-def test_compute_weights(nlive):
+@pytest.mark.parametrize("nlive", [10, 10 * np.ones(20)])
+@pytest.mark.parametrize("expectation", ["logt", "t"])
+def test_compute_weights(nlive, expectation):
     """Test computing the weights for set of likelihood values."""
     log_l = np.random.randn(20)
 
-    log_z, log_w = compute_weights(log_l, nlive)
+    log_z, log_w = compute_weights(log_l, nlive, expectation=expectation)
 
     assert len(log_w) == len(log_l)
     assert np.isfinite(log_z)
+
+
+@pytest.mark.parametrize("expectation", ["logt", "t"])
+def test_compute_weights_correct_weights(expectation):
+    """Assert the weights (X_i) are correct"""
+    nlive = 10
+    log_l = np.random.randn(20)
+    out = -np.log1p(1 / nlive) * np.ones(len(log_l))
+    with patch("numpy.log1p", return_value=out) as mock_log1p, patch(
+        "nessai.posterior.logsubexp", return_value=np.random.rand(21)
+    ), patch("nessai.posterior.log_integrate_log_trap", return_value=0.0):
+        compute_weights(log_l, nlive=nlive, expectation=expectation)
+    if expectation == "t":
+        mock_log1p.assert_called_once()
+    else:
+        mock_log1p.assert_not_called()
 
 
 def test_compute_weights_invalid_nlive():

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -64,6 +64,14 @@ def test_compute_weights_invalid_nlive():
         compute_weights([1, 2, 3], [4, 5])
 
 
+def test_compute_weights_invalid_expectation():
+    """Assert an error is raised if expectation is invalid"""
+    with pytest.raises(
+        ValueError, match=r"Expectation must be t or logt, got: a"
+    ):
+        compute_weights(np.random.randn(10), 10, expectation="a")
+
+
 def test_draw_posterior_samples(ns, method):
     """Test drawing posterior samples."""
     ns["logL"] = np.log(np.random.rand(ns.size))


### PR DESCRIPTION
We changed how the shrinkage is computed in https://github.com/mj-will/nessai/pull/248. In this PR, I add an option to use the new method or the old one and set the default to be the old method.

You can now set `shrinkage_expectation` to `t` or `logt` to choose between the two.
