### PR TITLE
Rework nessai.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Truth input in `nessai.plot.corner_plot` can now be an iterable or a dictionary.
 - Tweak how the prior volume is computed for the final nested sample. This will also change the evidence and posterior weights.
 - Stricter handling of keyword arguments passed to `NestedSampler`. Unknown keyword arguments will now raise an error.
+- Rework `nessai.config` to have `config.livepoints` and `config.plot` which contain global settings. Some of the setting names have also changed.
+
+### Fixed
+
+- Fix a bug where setting the livepoint precision (e.g. `f16`) did not work.
 
 ### Removed
 

--- a/nessai/config.py
+++ b/nessai/config.py
@@ -24,10 +24,6 @@ class LivepointsConfig:
         default_factory=lambda: ["logP", "logL", "it"]
     )
     """List of the core non-sampling parameters included in all live points"""
-    core_parameters_defaults: Tuple = field(
-        default_factory=lambda: (np.nan, np.nan, 0)
-    )
-    """Default value for the core non-sampling parameters"""
     extra_parameters: List[str] = field(default_factory=lambda: [])
     """Additional extra parameters included in live points"""
     extra_parameters_dtype: List[str] = field(default_factory=lambda: [])
@@ -36,6 +32,7 @@ class LivepointsConfig:
     """Default values for additional extra extra"""
 
     _core_parameter_dtype: List[str] = None
+    _core_parameter_defaults: Tuple = None
     _non_sampling_defaults: List = None
     _non_sampling_parameters: Tuple = None
     _non_sampling_dtype: List[str] = None
@@ -50,6 +47,17 @@ class LivepointsConfig:
                 self.it_dtype,
             ]
         return self._core_parameter_dtype
+
+    @property
+    def core_parameters_defaults(self) -> Tuple:
+        """Tuple of default values for core non-sampling parameters."""
+        if self._core_parameter_defaults is None:
+            self._core_parameter_defaults = (
+                self.default_float_value,
+                self.default_float_value,
+                0,
+            )
+        return self._core_parameter_defaults
 
     @property
     def non_sampling_parameters(self) -> List[str]:
@@ -88,6 +96,7 @@ class LivepointsConfig:
     def reset_properties(self) -> None:
         """Reset the cached properties"""
         self._core_parameter_dtype = None
+        self._core_parameter_defaults = None
         self._non_sampling_defaults = None
         self._non_sampling_parameters = None
         self._non_sampling_dtype = None

--- a/nessai/config.py
+++ b/nessai/config.py
@@ -2,36 +2,122 @@
 """
 Global configuration for nessai.
 """
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
 import numpy as np
 
-# Settings for live points
-LOGL_DTYPE = "f8"
-IT_DTYPE = "i4"
-DEFAULT_FLOAT_DTYPE = "f8"
-DEFAULT_FLOAT_VALUE = np.nan
-CORE_PARAMETERS = ["logP", "logL", "it"]
-CORE_PARAMETERS_DEFAULTS = [np.nan, np.nan, 0]
-CORE_PARAMETERS_DTYPE = [DEFAULT_FLOAT_DTYPE, LOGL_DTYPE, IT_DTYPE]
-EXTRA_PARAMETERS = []
-EXTRA_PARAMETERS_DEFAULTS = []
-EXTRA_PARAMETERS_DTYPE = []
-NON_SAMPLING_PARAMETERS = CORE_PARAMETERS + EXTRA_PARAMETERS
-NON_SAMPLING_DEFAULTS = CORE_PARAMETERS_DEFAULTS + EXTRA_PARAMETERS_DEFAULTS
-NON_SAMPLING_DEFAULT_DTYPE = CORE_PARAMETERS_DTYPE + EXTRA_PARAMETERS_DTYPE
-# Plotting config
-DISABLE_STYLE = False
-"""Disable nessai's custom plotting style globally.
 
-Useful since all plotting functions use the
-:py:func:`~nessai.plot.nessai_style` decorator by default.
-"""
-SNS_STYLE = "ticks"
-"""Default seaborn style."""
-BASE_COLOUR = "#02979d"
-"""Base colour for plots."""
-HIGHLIGHT_COLOUR = "#f5b754"
-"""Highlight colour for plots."""
-LINE_COLOURS = ["#4575b4", "#d73027", "#fad117", "#ff8c00"]
-"""Default line colours."""
-LINE_STYLES = ["-", "--", ":", "-."]
-"""Default line styles."""
+@dataclass
+class LivepointsConfig:
+    """Configuration for live points."""
+
+    logl_dtype: str = "f8"
+    """Default log-likelihood dtype"""
+    it_dtype: str = "i4"
+    """Default dtype for iteration parameter"""
+    default_float_dtype: str = "f8"
+    """Default dtype for parameters"""
+    default_float_value: float = np.nan
+    """Default value for parameters"""
+    core_parameters: List[str] = field(
+        default_factory=lambda: ["logP", "logL", "it"]
+    )
+    """List of the core non-sampling parameters included in all live points"""
+    core_parameters_defaults: Tuple = field(
+        default_factory=lambda: (np.nan, np.nan, 0)
+    )
+    """Default value for the core non-sampling parameters"""
+    extra_parameters: List[str] = field(default_factory=lambda: [])
+    """Additional extra parameters included in live points"""
+    extra_parameters_dtype: List[str] = field(default_factory=lambda: [])
+    """Defaults dtype for extra parameters"""
+    extra_parameters_defaults: Tuple = field(default_factory=lambda: ())
+    """Default values for additional extra extra"""
+
+    _core_parameter_dtype: List[str] = None
+    _non_sampling_defaults: List = None
+    _non_sampling_parameters: Tuple = None
+    _non_sampling_dtype: List[str] = None
+
+    @property
+    def core_parameters_dtype(self) -> List[str]:
+        """List of dtypes for the core non-sampling parameters"""
+        if self._core_parameter_dtype is None:
+            self._core_parameter_dtype = [
+                self.default_float_dtype,
+                self.logl_dtype,
+                self.it_dtype,
+            ]
+        return self._core_parameter_dtype
+
+    @property
+    def non_sampling_parameters(self) -> List[str]:
+        """List of all the non-sampling parameters"""
+        if self._non_sampling_parameters is None:
+            self._non_sampling_parameters = (
+                self.core_parameters + self.extra_parameters
+            )
+        return self._non_sampling_parameters
+
+    @property
+    def non_sampling_defaults(self) -> Tuple:
+        """List of default values for all the non-sampling parameters"""
+        if self._non_sampling_defaults is None:
+            self._non_sampling_defaults = (
+                self.core_parameters_defaults + self.extra_parameters_defaults
+            )
+        return self._non_sampling_defaults
+
+    @property
+    def non_sampling_dtype(self) -> List[str]:
+        """List of the dtype for all the non-sampling parameters"""
+        if self._non_sampling_dtype is None:
+            self._non_sampling_dtype = (
+                self.core_parameters_dtype + self.extra_parameters_dtype
+            )
+        return self._non_sampling_dtype
+
+    def reset(self) -> None:
+        """Reset the extra parameters and properties"""
+        self.extra_parameters = []
+        self.extra_parameters_defaults = ()
+        self.extra_parameters_dtype = []
+        self.reset_properties()
+
+    def reset_properties(self) -> None:
+        """Reset the cached properties"""
+        self._core_parameter_dtype = None
+        self._non_sampling_defaults = None
+        self._non_sampling_parameters = None
+        self._non_sampling_dtype = None
+
+
+@dataclass
+class PlottingConfig:
+    """Configuration for plotting."""
+
+    disable_style: bool = False
+    """Disable nessai's custom plotting style globally.
+
+    Useful since all plotting functions use the
+    :py:func:`~nessai.plot.nessai_style` decorator by default.
+    """
+    sns_style: str = "ticks"
+    """Default seaborn style."""
+    base_colour: str = "#02979d"
+    """Base colour for plots."""
+    highlight_colour: str = "#f5b754"
+    """Highlight colour for plots."""
+    line_colours: List[str] = field(
+        default_factory=lambda: ["#4575b4", "#d73027", "#fad117", "#ff8c00"]
+    )
+    """Default line colours."""
+    line_styles: List[str] = field(
+        default_factory=lambda: ["-", "--", ":", "-."]
+    )
+    """Default line styles."""
+
+
+livepoints = LivepointsConfig()
+plotting = PlottingConfig()

--- a/nessai/config.py
+++ b/nessai/config.py
@@ -16,6 +16,8 @@ class LivepointsConfig:
     """Default log-likelihood dtype"""
     it_dtype: str = "i4"
     """Default dtype for iteration parameter"""
+    it_default: int = 0
+    """Default value for the iteration parameter"""
     default_float_dtype: str = "f8"
     """Default dtype for parameters"""
     default_float_value: float = np.nan
@@ -55,7 +57,7 @@ class LivepointsConfig:
             self._core_parameter_defaults = (
                 self.default_float_value,
                 self.default_float_value,
-                0,
+                self.it_default,
             )
         return self._core_parameter_defaults
 

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -184,7 +184,7 @@ class Model(ABC):
             if self.allow_vectorised:
                 x = self.new_point(N=10)
                 target = np.fromiter(
-                    map(self.log_likelihood, x), config.LOGL_DTYPE
+                    map(self.log_likelihood, x), config.livepoints.logl_dtype
                 )
                 try:
                     batch = self.log_likelihood(x)
@@ -524,7 +524,7 @@ class Model(ABC):
                     log_likelihood = self.log_likelihood(x)
             else:
                 log_likelihood = np.fromiter(
-                    map(self.log_likelihood, x), config.LOGL_DTYPE
+                    map(self.log_likelihood, x), config.livepoints.logl_dtype
                 )
         else:
             logger.debug("Using pool to evaluate likelihood")

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -44,15 +44,15 @@ def nessai_style(line_styles=True):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if config.DISABLE_STYLE:
+            if config.plotting.disable_style:
                 return func(*args, **kwargs)
-            c = cycler(color=config.LINE_COLOURS)
+            c = cycler(color=config.plotting.line_colours)
             if line_styles:
-                c += cycler(linestyle=config.LINE_STYLES)
+                c += cycler(linestyle=config.plotting.line_styles)
             d = {
                 "axes.prop_cycle": c,
             }
-            with sns.axes_style(config.SNS_STYLE), mpl.rc_context(
+            with sns.axes_style(config.plotting.sns_style), mpl.rc_context(
                 {**_rcparams, **d}
             ):
                 return func(*args, **kwargs)
@@ -97,13 +97,13 @@ def plot_live_points(
             bins="auto",
             lw=1.5,
             density=True,
-            color=config.BASE_COLOUR,
+            color=config.plotting.base_colour,
         ),
         plot_kws=dict(
             s=1.0,
             edgecolor=None,
             palette="viridis",
-            color=config.BASE_COLOUR,
+            color=config.plotting.base_colour,
         ),
     )
     pairplot_kwargs.update(kwargs)
@@ -135,13 +135,13 @@ def plot_live_points(
                 v[0],
                 ls=":",
                 alpha=0.5,
-                color=config.HIGHLIGHT_COLOUR,
+                color=config.plotting.highlight_colour,
             )
             fig.axes[i, i].axvline(
                 v[1],
                 ls=":",
                 alpha=0.5,
-                color=config.HIGHLIGHT_COLOUR,
+                color=config.plotting.highlight_colour,
             )
 
     if filename is not None:
@@ -569,8 +569,8 @@ def corner_plot(
     default_kwargs = dict(
         bins=32,
         smooth=0.9,
-        color=config.BASE_COLOUR,
-        truth_color=config.HIGHLIGHT_COLOUR,
+        color=config.plotting.base_colour,
+        truth_color=config.plotting.highlight_colour,
         quantiles=[0.16, 0.84],
         levels=(1 - np.exp(-0.5), 1 - np.exp(-2), 1 - np.exp(-9 / 2.0)),
         plot_density=True,

--- a/nessai/proposal/augmented.py
+++ b/nessai/proposal/augmented.py
@@ -201,7 +201,8 @@ class AugmentedFlowProposal(FlowProposal):
         valid = np.isfinite(log_prob)
         x, log_prob = x[valid], log_prob[valid]
         x = numpy_array_to_live_points(
-            x.astype(config.DEFAULT_FLOAT_DTYPE), self.rescaled_names
+            x.astype(config.livepoints.default_float_dtype),
+            self.rescaled_names,
         )
         # Apply rescaling in rescale=True
         if rescale:

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -310,7 +310,9 @@ class FlowProposal(RejectionProposal):
     def x_dtype(self):
         """Return the dtype for the x space"""
         if not self._x_dtype:
-            self._x_dtype = get_dtype(self.names, config.DEFAULT_FLOAT_DTYPE)
+            self._x_dtype = get_dtype(
+                self.names, config.livepoints.default_float_dtype
+            )
         return self._x_dtype
 
     @property
@@ -318,7 +320,7 @@ class FlowProposal(RejectionProposal):
         """Return the dtype for the x prime space"""
         if not self._x_prime_dtype:
             self._x_prime_dtype = get_dtype(
-                self.rescaled_names, config.DEFAULT_FLOAT_DTYPE
+                self.rescaled_names, config.livepoints.default_float_dtype
             )
         return self._x_prime_dtype
 
@@ -776,7 +778,7 @@ class FlowProposal(RejectionProposal):
                     start = count * n
                     end = (count + 1) * n
                     block = x_out[f][start:end]
-                    if f in config.NON_SAMPLING_PARAMETERS:
+                    if f in config.livepoints.non_sampling_parameters:
                         if not np.allclose(block, target, equal_nan=True):
                             raise RuntimeError(
                                 f"Non-sampling parameter {f} changed in "
@@ -824,7 +826,7 @@ class FlowProposal(RejectionProposal):
             x, x_prime, log_J, compute_radius=compute_radius, **kwargs
         )
 
-        for p in config.NON_SAMPLING_PARAMETERS:
+        for p in config.livepoints.non_sampling_parameters:
             x_prime[p] = x[p]
         return x_prime, log_J
 
@@ -851,7 +853,7 @@ class FlowProposal(RejectionProposal):
             x, x_prime, log_J, **kwargs
         )
 
-        for p in config.NON_SAMPLING_PARAMETERS:
+        for p in config.livepoints.non_sampling_parameters:
             x[p] = x_prime[p]
         return x, log_J
 
@@ -1099,7 +1101,8 @@ class FlowProposal(RejectionProposal):
         valid = np.isfinite(log_prob)
         x, log_prob = x[valid], log_prob[valid]
         x = numpy_array_to_live_points(
-            x.astype(config.DEFAULT_FLOAT_DTYPE), self.rescaled_names
+            x.astype(config.livepoints.default_float_dtype),
+            self.rescaled_names,
         )
         # Apply rescaling in rescale=True
         if rescale:
@@ -1279,7 +1282,7 @@ class FlowProposal(RejectionProposal):
             x, _ = self.inverse_rescale(x)
         x["logP"] = self.model.log_prior(x)
         return rfn.repack_fields(
-            x[self.model.names + config.NON_SAMPLING_PARAMETERS]
+            x[self.model.names + config.livepoints.non_sampling_parameters]
         )
 
     def populate(self, worst_point, N=10000, plot=True, r=None):

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -981,7 +981,7 @@ class NestedSampler(BaseNestedSampler):
                 logX_its,
                 rolling_mean(np.abs(self.state.gradients), self.nlive // 10),
                 c="C1",
-                ls=config.LINE_STYLES[1],
+                ls=config.plotting.line_styles[1],
                 label="Gradient",
             )
             ax_logX_grad.set_ylabel(r"$|d\log L/d \log X|$")
@@ -1005,7 +1005,7 @@ class NestedSampler(BaseNestedSampler):
             self.dZ_history,
             label="dZ",
             c="C1",
-            ls=config.LINE_STYLES[1],
+            ls=config.plotting.line_styles[1],
         )
         ax_dz.set_ylabel("dZ")
         handles, labels = ax[3].get_legend_handles_labels()
@@ -1028,7 +1028,7 @@ class NestedSampler(BaseNestedSampler):
             self.population_radii,
             label="Radius",
             color="C2",
-            ls=config.LINE_STYLES[2],
+            ls=config.plotting.line_styles[2],
         )
         ax_r.set_ylabel("Population radius")
         handles_r, labels_r = ax_r.get_legend_handles_labels()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for the config module"""
+from nessai.config import LivepointsConfig
+import numpy as np
+
+
+def test_livepoint_config_reset_properties():
+    """Assert the properties are reset"""
+    conf = LivepointsConfig()
+
+    assert conf.core_parameters == ["logP", "logL", "it"]
+    assert conf.core_parameters_dtype == ["f8", "f8", "i4"]
+    assert conf.core_parameters_defaults == (np.nan, np.nan, 0)
+    assert conf.extra_parameters == []
+    assert conf.extra_parameters_dtype == []
+    assert conf.extra_parameters_defaults == ()
+
+    assert conf.non_sampling_dtype == ["f8", "f8", "i4"]
+    assert conf.non_sampling_defaults == (np.nan, np.nan, 0)
+
+    conf.default_float_value = -np.inf
+    conf.extra_parameters = ["a"]
+    conf.extra_parameters_defaults = (0.0,)
+    conf.extra_parameters_dtype = ["f4"]
+
+    assert conf.non_sampling_defaults == (np.nan, np.nan, 0)
+
+    conf.reset_properties()
+
+    assert conf.core_parameters_defaults == (-np.inf, -np.inf, 0)
+    assert conf.non_sampling_parameters == ["logP", "logL", "it", "a"]
+    assert conf.non_sampling_dtype == ["f8", "f8", "i4", "f4"]
+    assert conf.non_sampling_defaults == (-np.inf, -np.inf, 0, 0.0)
+
+
+def test_livepoint_config_reset():
+    """Assert the reset method clears the values"""
+    conf = LivepointsConfig(
+        extra_parameters=["a", "b"],
+        extra_parameters_dtype=["f4", "i4"],
+        extra_parameters_defaults=[0.0, 0],
+    )
+    assert conf.non_sampling_parameters == ["logP", "logL", "it", "a", "b"]
+    conf.reset()
+    assert conf.extra_parameters == []
+    assert conf.extra_parameters_dtype == []
+    assert conf.extra_parameters_defaults == ()
+    assert conf.non_sampling_parameters == ["logP", "logL", "it"]

--- a/tests/test_livepoint.py
+++ b/tests/test_livepoint.py
@@ -10,7 +10,8 @@ from nessai.utils.testing import assert_structured_arrays_equal
 EXTRA_PARAMS_DTYPE = [
     (nsp, d)
     for nsp, d in zip(
-        config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULT_DTYPE
+        config.livepoints.non_sampling_parameters,
+        config.livepoints.non_sampling_dtype,
     )
 ]
 
@@ -20,7 +21,7 @@ def assert_lp_equal(x, y, non_sampling_parameters=True):
     if non_sampling_parameters:
         assert_structured_arrays_equal(x, y)
     else:
-        for nsp in config.NON_SAMPLING_PARAMETERS:
+        for nsp in config.livepoints.non_sampling_parameters:
             if nsp in x.dtype.names:
                 raise AttributeError(
                     "x has non-sampling parameters but "
@@ -28,7 +29,9 @@ def assert_lp_equal(x, y, non_sampling_parameters=True):
                 )
 
         names = [
-            n for n in x.dtype.names if n not in config.NON_SAMPLING_PARAMETERS
+            n
+            for n in x.dtype.names
+            if n not in config.livepoints.non_sampling_parameters
         ]
         y = np.lib.recfunctions.repack_fields(y[names])
         assert_structured_arrays_equal(x, y)
@@ -43,12 +46,14 @@ def non_sampling_parameters(request):
 def extra_parameters(request):
     """Add (and remove) extra parameters for the tests."""
     # Before every test
+    lp.reset_extra_live_points_parameters()
     lp.add_extra_parameters_to_live_points(request.param)
     global EXTRA_PARAMS_DTYPE
     EXTRA_PARAMS_DTYPE = [
         (nsp, d)
         for nsp, d in zip(
-            config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULT_DTYPE
+            config.livepoints.non_sampling_parameters,
+            config.livepoints.non_sampling_dtype,
         )
     ]
 
@@ -60,19 +65,32 @@ def extra_parameters(request):
     EXTRA_PARAMS_DTYPE = [
         (nsp, d)
         for nsp, d in zip(
-            config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULT_DTYPE
+            config.livepoints.non_sampling_parameters,
+            config.livepoints.non_sampling_dtype,
         )
     ]
+
+
+@pytest.fixture(params=["f4", "f16"])
+def change_dtype(request):
+    """Fixture that changes the default float dtype"""
+    dtype = request.param
+    current_dtype = config.livepoints.default_float_dtype
+    config.livepoints.default_float_dtype = dtype
+
+    yield dtype
+
+    config.livepoints.default_float_dtype = current_dtype
 
 
 @pytest.fixture
 def live_point():
     return np.array(
-        [(1.0, 2.0, 3.0, *config.NON_SAMPLING_DEFAULTS)],
+        [(1.0, 2.0, 3.0, *config.livepoints.non_sampling_defaults)],
         dtype=[
-            ("x", config.DEFAULT_FLOAT_DTYPE),
-            ("y", config.DEFAULT_FLOAT_DTYPE),
-            ("z", config.DEFAULT_FLOAT_DTYPE),
+            ("x", config.livepoints.default_float_dtype),
+            ("y", config.livepoints.default_float_dtype),
+            ("z", config.livepoints.default_float_dtype),
         ]
         + EXTRA_PARAMS_DTYPE,
     )
@@ -82,13 +100,13 @@ def live_point():
 def live_points():
     return np.array(
         [
-            (1.0, 2.0, 3.0, *config.NON_SAMPLING_DEFAULTS),
-            (4.0, 5.0, 6.0, *config.NON_SAMPLING_DEFAULTS),
+            (1.0, 2.0, 3.0, *config.livepoints.non_sampling_defaults),
+            (4.0, 5.0, 6.0, *config.livepoints.non_sampling_defaults),
         ],
         dtype=[
-            ("x", config.DEFAULT_FLOAT_DTYPE),
-            ("y", config.DEFAULT_FLOAT_DTYPE),
-            ("z", config.DEFAULT_FLOAT_DTYPE),
+            ("x", config.livepoints.default_float_dtype),
+            ("y", config.livepoints.default_float_dtype),
+            ("z", config.livepoints.default_float_dtype),
         ]
         + EXTRA_PARAMS_DTYPE,
     )
@@ -99,12 +117,22 @@ def empty_live_point():
     return np.empty(
         0,
         dtype=[
-            ("x", config.DEFAULT_FLOAT_DTYPE),
-            ("y", config.DEFAULT_FLOAT_DTYPE),
-            ("z", config.DEFAULT_FLOAT_DTYPE),
+            ("x", config.livepoints.default_float_dtype),
+            ("y", config.livepoints.default_float_dtype),
+            ("z", config.livepoints.default_float_dtype),
         ]
         + EXTRA_PARAMS_DTYPE,
     )
+
+
+def test_add_extra_parameters(caplog):
+    """Assert a warning is raised when adding a parameter name twice."""
+    lp.add_extra_parameters_to_live_points(["test"], [1.0])
+    assert "test" in config.livepoints.extra_parameters
+    loc = config.livepoints.extra_parameters.index("test")
+    assert config.livepoints.extra_parameters_defaults[loc] == 1.0
+    lp.add_extra_parameters_to_live_points(["test"], [1.0])
+    assert "Extra parameter `test` has already been added" in str(caplog.text)
 
 
 def test_get_dtype():
@@ -113,14 +141,25 @@ def test_get_dtype():
     expected = (
         [("x", "f4"), ("y", "f4")]
         + [
-            ("logP", config.DEFAULT_FLOAT_DTYPE),
-            ("logL", config.LOGL_DTYPE),
-            ("it", config.IT_DTYPE),
+            ("logP", config.livepoints.default_float_dtype),
+            ("logL", config.livepoints.logl_dtype),
+            ("it", config.livepoints.it_dtype),
         ]
-        + list(zip(config.EXTRA_PARAMETERS, config.EXTRA_PARAMETERS_DTYPE))
+        + list(
+            zip(
+                config.livepoints.extra_parameters,
+                config.livepoints.extra_parameters_dtype,
+            )
+        )
     )
     dtype = lp.get_dtype(names, array_dtype="f4")
     assert dtype == expected
+
+
+def test_get_dtype_change_dtype(change_dtype):
+    """Assert the dtype can be changed"""
+    dtype = lp.get_dtype(["x"])
+    assert dtype.fields["x"][0] == np.dtype(change_dtype)
 
 
 def test_empty_structured_array_names(non_sampling_parameters):
@@ -132,10 +171,11 @@ def test_empty_structured_array_names(non_sampling_parameters):
     )
     for f in fields:
         np.testing.assert_array_equal(
-            array[f], config.DEFAULT_FLOAT_VALUE * np.ones(n)
+            array[f], config.livepoints.default_float_value * np.ones(n)
         )
     for nsp, v in zip(
-        config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULTS
+        config.livepoints.non_sampling_parameters,
+        config.livepoints.non_sampling_defaults,
     ):
         if non_sampling_parameters:
             np.testing.assert_array_equal(array[nsp], v * np.ones(n))
@@ -154,7 +194,7 @@ def test_empty_structured_array_dtype(non_sampling_parameters):
     )
     for f in ["x", "y"]:
         np.testing.assert_array_equal(
-            array[f], config.DEFAULT_FLOAT_VALUE * np.ones(n)
+            array[f], config.livepoints.default_float_value * np.ones(n)
         )
     assert array.dtype == dtype
 
@@ -178,6 +218,12 @@ def test_empty_structured_array_dtype_missing():
     with pytest.raises(ValueError) as excinfo:
         lp.empty_structured_array(n, dtype=dtype)
     assert "non-sampling parameters" in str(excinfo.value)
+
+
+def test_empty_structured_array_change_dtype(change_dtype):
+    """Assert changing the default dtype changes the output"""
+    array = lp.empty_structured_array(1, names=["x"])
+    assert array.dtype.fields["x"][0] == np.dtype(change_dtype)
 
 
 def test_parameters_to_live_point(live_point, non_sampling_parameters):
@@ -314,7 +360,7 @@ def test_live_point_to_numpy_array(live_point):
     Test conversion from a live point to an unstructured numpy array
     """
     (
-        np.array([[1, 2, 3, *config.NON_SAMPLING_DEFAULTS]]),
+        np.array([[1, 2, 3, *config.livepoints.non_sampling_defaults]]),
         lp.live_points_to_array(live_point),
     )
 
@@ -339,7 +385,8 @@ def test_live_point_to_dict(live_point):
         {
             k: v
             for k, v in zip(
-                config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULTS
+                config.livepoints.non_sampling_parameters,
+                config.livepoints.non_sampling_defaults,
             )
         }
     )
@@ -369,7 +416,8 @@ def test_multiple_live_points_to_dict(live_points):
         {
             k: 2 * [v]
             for k, v in zip(
-                config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULTS
+                config.livepoints.non_sampling_parameters,
+                config.livepoints.non_sampling_defaults,
             )
         }
     )

--- a/tests/test_livepoint.py
+++ b/tests/test_livepoint.py
@@ -1,3 +1,6 @@
+"""Tests for livepoint functions"""
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -75,6 +78,8 @@ def extra_parameters(request):
 def change_dtype(request):
     """Fixture that changes the default float dtype"""
     dtype = request.param
+    if dtype == "f16" and sys.platform.startswith("win"):
+        pytest.skip("Skipping test with float128 on Windows.")
     current_dtype = config.livepoints.default_float_dtype
     config.livepoints.default_float_dtype = dtype
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -39,7 +39,7 @@ def auto_close_figures():
 
 @pytest.mark.parametrize("line_styles", [True, False])
 def test_nessai_style_enabled(line_styles):
-    """Assert the style is applied with config.DISABLE_STYLE=False
+    """Assert the style is applied with config.plotting.disable_style=False
 
     Tests with `line_styles` True and False
     """
@@ -47,7 +47,7 @@ def test_nessai_style_enabled(line_styles):
     def func(a, b):
         return a + b
 
-    with patch("nessai.plot.config.DISABLE_STYLE", False), patch(
+    with patch("nessai.plot.config.plotting.disable_style", False), patch(
         "seaborn.axes_style"
     ) as mock_style, patch("matplotlib.rc_context") as mock_rc:
         out = plot.nessai_style(line_styles=line_styles)(func)(1, 2)
@@ -56,19 +56,21 @@ def test_nessai_style_enabled(line_styles):
     mock_rc.assert_called_once()
     d = mock_rc.call_args[0][0]["axes.prop_cycle"].by_key()
     if line_styles:
-        d["linestyle"] == config.LINE_STYLES
-        d["color"] == config.LINE_COLOURS
+        d["linestyle"] == config.plotting.line_styles
+        d["color"] == config.plotting.line_colours
     else:
         assert "linestyle" not in d
 
 
 def test_nessai_style_disabled():
-    """Assert the style isn't applied with config.DISABLE_STYLE=True"""
+    """
+    Assert the style isn't applied with config.plotting.disable_style=True
+    """
 
     def func(a, b):
         return a + b
 
-    with patch("nessai.plot.config.DISABLE_STYLE", True), patch(
+    with patch("nessai.plot.config.plotting.disable_style", True), patch(
         "seaborn.axes_style"
     ) as mock_style:
         out = plot.nessai_style(func)(1, 2)
@@ -88,9 +90,9 @@ def test_nessai_style_integration(line_styles):
         )
 
     colours, line_styles = plot.nessai_style(line_styles=line_styles)(func)()
-    assert colours == config.LINE_COLOURS
+    assert colours == config.plotting.line_colours
     if line_styles:
-        assert line_styles == config.LINE_STYLES
+        assert line_styles == config.plotting.line_styles
     else:
         assert line_styles is None
 
@@ -367,7 +369,7 @@ def test_trace_plot_unstructured():
 
 
 @pytest.mark.parametrize(
-    "labels", [None, ["x", "y"] + config.NON_SAMPLING_PARAMETERS]
+    "labels", [None, ["x", "y"] + config.livepoints.non_sampling_parameters]
 )
 def test_trace_plot_labels(nested_samples, labels):
     """Test trace plot generation with labels."""
@@ -442,7 +444,8 @@ def test_corner_plot_check_inputs(live_points):
 
 
 @pytest.mark.parametrize(
-    "labels", [["x", "y"], ["x", "y"] + config.NON_SAMPLING_PARAMETERS]
+    "labels",
+    [["x", "y"], ["x", "y"] + config.livepoints.non_sampling_parameters],
 )
 def test_corner_plot_w_labels(live_points, labels):
     """Test the corner plot with labels"""
@@ -501,7 +504,9 @@ def test_corner_plot_all_nans(caplog, live_points):
     live_points["x"] = np.nan
     fig = plot.corner_plot(live_points)
     assert fig is not None
-    assert str(["x"] + config.NON_SAMPLING_PARAMETERS) in caplog.text
+    assert (
+        str(["x"] + config.livepoints.non_sampling_parameters) in caplog.text
+    )
 
 
 def test_corner_plot_save(tmpdir, live_points):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_population.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_population.py
@@ -188,7 +188,7 @@ def test_convert_to_samples(proposal):
     out_samples = FlowProposal.convert_to_samples(proposal, samples, plot=True)
 
     assert out_samples.dtype.names == ("x",) + tuple(
-        config.NON_SAMPLING_PARAMETERS
+        config.livepoints.non_sampling_parameters
     )
 
 
@@ -216,7 +216,7 @@ def test_convert_to_samples_with_prime(mock_plot, proposal):
     )
     proposal.inverse_rescale.assert_called_once()
     assert out_samples.dtype.names == ("x",) + tuple(
-        config.NON_SAMPLING_PARAMETERS
+        config.livepoints.non_sampling_parameters
     )
 
 

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_properties.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_properties.py
@@ -7,7 +7,8 @@ from nessai.proposal import FlowProposal
 EXTRA_PARAMS_DTYPE = [
     (nsp, d)
     for nsp, d in zip(
-        config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULT_DTYPE
+        config.livepoints.non_sampling_parameters,
+        config.livepoints.non_sampling_dtype,
     )
 ]
 

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -120,7 +120,8 @@ def test_save_live_points(tmp_path):
         {
             k: 2 * [v]
             for k, v in zip(
-                config.NON_SAMPLING_PARAMETERS, config.NON_SAMPLING_DEFAULTS
+                config.livepoints.non_sampling_parameters,
+                config.livepoints.non_sampling_defaults,
             )
         }
     )


### PR DESCRIPTION
Rework `nessai.config` to fix the issue described in https://github.com/mj-will/nessai/issues/264 and use a more robust method for setting global settings.

**Summary of changes**
Now use dataclasses for the config and have a different config for livepoints and plotting. All config values that are derived from other values are now properties rather than attributes.

**Related issues and pull requests**
Closes https://github.com/mj-will/nessai/issues/264

**To-Do**
- [x] Tests for `nessai.config`
- [x] Update changelog