### PR TITLE
Update the result file format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to construct live points without non-sampling parameters.
 - Add option to use a different estimate of the shrinkage. Default remains unchanged.
 - Add `ScaleAndShift` reparameterisation which includes Z-score normalisation.
+- Add option to specify default result file extension.
 
 ### Changed
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stricter handling of keyword arguments passed to `NestedSampler`. Unknown keyword arguments will now raise an error.
 - Rework `nessai.config` to have `config.livepoints` and `config.plot` which contain global settings. Some of the setting names have also changed.
 - `Rescale` reparameterisation is now an alias for `ScaleAndShift`.
+- Change the default result file extension to `hdf5`, old result file format can be recovered by setting it to `json`.
 
 ### Fixed
 

--- a/nessai/flowmodel/base.py
+++ b/nessai/flowmodel/base.py
@@ -3,7 +3,6 @@
 Object and functions to handle training the normalising flow.
 """
 import copy
-import json
 import logging
 import numpy as np
 import os
@@ -16,7 +15,7 @@ from .utils import update_config
 from ..flows import configure_model, reset_weights, reset_permutations
 from ..flows.base import BaseFlow
 from ..plot import plot_loss
-from ..utils import NessaiJSONEncoder, compute_minimum_distances
+from ..utils import save_to_json, compute_minimum_distances
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +89,7 @@ class FlowModel:
                 config["model_config"]["flow"]
             )
 
-        with open(output_file, "w") as f:
-            json.dump(config, f, indent=4, cls=NessaiJSONEncoder)
+        save_to_json(config, output_file)
 
     def setup_from_input_dict(self, config):
         """

--- a/nessai/utils/__init__.py
+++ b/nessai/utils/__init__.py
@@ -9,7 +9,9 @@ from .io import (
     NessaiJSONEncoder,
     is_jsonable,
     safe_file_dump,
+    save_dict_to_hdf5,
     save_live_points,
+    save_to_json,
 )
 from .logging import setup_logger
 from .rescaling import (
@@ -74,7 +76,9 @@ __all__ = [
     "rescaling_functions",
     "safe_file_dump",
     "sampling",
+    "save_dict_to_hdf5",
     "save_live_points",
+    "save_to_json",
     "setup_logger",
     "sigmoid",
     "spatial",

--- a/nessai/utils/io.py
+++ b/nessai/utils/io.py
@@ -129,6 +129,26 @@ def save_live_points(live_points, filename):
         json.dump(d, wf, indent=4, cls=NessaiJSONEncoder)
 
 
+def encode_for_hdf5(value):
+    """Encode a value for HDF5 file format.
+
+    Parameters
+    ----------
+    value : Any
+        Value to encode.
+
+    Returns
+    -------
+    Any
+        Encoded value.
+    """
+    if value is None:
+        output = "__none__"
+    else:
+        output = value
+    return output
+
+
 def add_dict_to_hdf5_file(hdf5_file, path, d):
     """Save a dictionary to a HDF5 file.
 
@@ -147,7 +167,7 @@ def add_dict_to_hdf5_file(hdf5_file, path, d):
         if isinstance(value, dict):
             add_dict_to_hdf5_file(hdf5_file, path + key + "/", value)
         else:
-            hdf5_file[path + key] = value
+            hdf5_file[path + key] = encode_for_hdf5(value)
 
 
 def save_dict_to_hdf5(d, filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ seaborn
 scipy>=0.16,<1.10
 torch>=1.7.0
 tqdm
-nflows
+glasflow
+h5py>=3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     torch>=1.11.0
     tqdm
     glasflow
+    h5py
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     torch>=1.11.0
     tqdm
     glasflow
-    h5py
+    h5py>=3.0
 
 [options.extras_require]
 test =

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -8,12 +8,15 @@ import signal
 import sys
 import time
 from threading import Thread
+from unittest.mock import MagicMock, create_autospec, patch
 
+
+import h5py
 import pytest
 from nessai.evidence import _NSIntegralState
 from nessai.flowsampler import FlowSampler
+from nessai.livepoint import numpy_array_to_live_points
 import numpy as np
-from unittest.mock import MagicMock, create_autospec, patch
 
 
 @pytest.fixture()
@@ -32,6 +35,21 @@ def reset_handlers():
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
     except AttributeError:
         print("Cannot set signal attributes on this system.")
+
+
+@pytest.fixture()
+def names():
+    return ["x", "y"]
+
+
+@pytest.fixture()
+def posterior_samples(names):
+    return numpy_array_to_live_points(np.random.randn(10, len(names)), names)
+
+
+@pytest.fixture()
+def nested_samples(names):
+    return numpy_array_to_live_points(np.random.randn(20, len(names)), names)
 
 
 @pytest.mark.parametrize("resume", [False, True])
@@ -357,6 +375,7 @@ def test_run(
     flow_sampler.ns.state.plot_state = MagicMock()
     flow_sampler.save_results = MagicMock()
     flow_sampler.close_pool = True
+    flow_sampler.result_extension = "hdf5"
 
     FlowSampler.run(flow_sampler, save=save, plot=plot)
 
@@ -365,7 +384,10 @@ def test_run(
         nested_samples, log_w=log_w, method="rejection_sampling"
     )
     if save:
-        flow_sampler.save_results.assert_called_once()
+        flow_sampler.save_results.assert_called_once_with(
+            os.path.join(output, "result"),
+            extension="hdf5",
+        )
     else:
         flow_sampler.save_results.assert_not_called()
 
@@ -483,28 +505,69 @@ def test_save_kwargs(flow_sampler, tmpdir, test_class):
     assert os.path.exists(os.path.join(flow_sampler.output, "config.json"))
 
 
-def test_save_results(flow_sampler, tmpdir):
-    """Test the save results method"""
-    output = str(tmpdir.mkdir("test"))
-    filename = os.path.join(output, "result.json")
+@pytest.mark.parametrize(
+    "filename, extension", [("result", "json"), ("result.json", None)]
+)
+def test_save_result_json(
+    flow_sampler, posterior_samples, filename, extension
+):
+    """Test saving with a JSON file."""
     d = dict(a=1)
-
     ns = MagicMock()
     ns.get_result_dictionary = MagicMock(return_value=d)
-
     flow_sampler.ns = ns
-    flow_sampler.posterior_samples = np.array([0.1], dtype=[("x", "f8")])
-    flow_sampler.nested_samples = np.array([0.1], dtype=[("x", "f8")])
+    flow_sampler.posterior_samples = posterior_samples
 
-    FlowSampler.save_results(flow_sampler, filename)
+    with patch("nessai.flowsampler.save_to_json") as mock_save:
+        FlowSampler.save_results(flow_sampler, filename, extension=extension)
 
-    assert os.path.exists(filename)
-    ns.get_result_dictionary.assert_called_once()
-    with open(filename, "r") as fp:
-        out = json.load(fp)
+    mock_save.assert_called_once_with(d, "result.json")
 
-    assert out["a"] == 1
-    assert "posterior_samples" in out
+
+@pytest.mark.parametrize(
+    "filename, extension", [("result", "hdf5"), ("result.hdf5", None)]
+)
+def test_save_result_hdf5(
+    flow_sampler, posterior_samples, filename, extension
+):
+    """Test saving with an HDF5 file."""
+    d = dict(a=1)
+    ns = MagicMock()
+    ns.get_result_dictionary = MagicMock(return_value=d)
+    flow_sampler.ns = ns
+    flow_sampler.posterior_samples = posterior_samples
+
+    with patch("nessai.flowsampler.save_dict_to_hdf5") as mock_save:
+        FlowSampler.save_results(flow_sampler, filename, extension=extension)
+
+    mock_save.assert_called_once_with(d, "result.hdf5")
+
+
+def test_save_result_no_extension(flow_sampler, posterior_samples):
+    """Assert an error is raised if a file extension is not given or included
+    in the filename.
+    """
+    d = dict(a=1)
+    ns = MagicMock()
+    ns.get_result_dictionary = MagicMock(return_value=d)
+    flow_sampler.ns = ns
+    flow_sampler.posterior_samples = posterior_samples
+    with pytest.raises(
+        RuntimeError,
+        match=r"Must specify file extension if not present in filename!",
+    ):
+        FlowSampler.save_results(flow_sampler, "result")
+
+
+def test_save_result_error(flow_sampler, posterior_samples):
+    """Assert an error is raised if the extension is not recognised"""
+    d = dict(a=1)
+    ns = MagicMock()
+    ns.get_result_dictionary = MagicMock(return_value=d)
+    flow_sampler.ns = ns
+    flow_sampler.posterior_samples = posterior_samples
+    with pytest.raises(RuntimeError, match=r"Unknown file extension: pkl"):
+        FlowSampler.save_results(flow_sampler, "result.pkl")
 
 
 def test_terminate_run(flow_sampler):
@@ -625,3 +688,36 @@ def test_signal_handling_disabled(tmp_path, caplog, model):
             raise
 
     assert "Signal handling is disabled" in str(caplog.text)
+
+
+@pytest.mark.parametrize("extension", ["json", "hdf5"])
+@pytest.mark.integration_test
+def test_save_results_integration(
+    flow_sampler, tmpdir, posterior_samples, extension
+):
+    """Test the save results method"""
+    output = str(tmpdir.mkdir("test"))
+    filename = os.path.join(output, ".".join(["result", extension]))
+    d = dict(a=1)
+
+    ns = MagicMock()
+    ns.get_result_dictionary = MagicMock(return_value=d)
+
+    flow_sampler.ns = ns
+    flow_sampler.posterior_samples = posterior_samples
+
+    FlowSampler.save_results(flow_sampler, filename)
+
+    assert os.path.exists(filename)
+    ns.get_result_dictionary.assert_called_once()
+
+    if extension == "hdf5":
+        out = h5py.File(filename, "r")
+    else:
+        with open(filename, "r") as fp:
+            out = json.load(fp)
+
+    assert "posterior_samples" in out
+    np.testing.assert_array_equal(
+        out["posterior_samples"]["x"], posterior_samples["x"]
+    )

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -200,7 +200,7 @@ def test_sampling_with_n_pool(model, flow_config, tmpdir, mp_context):
     fp.run()
     assert fp.ns.proposal.flow.weights_file is not None
     assert fp.ns.proposal.training_count == 1
-    assert os.path.exists(os.path.join(output, "result.json"))
+    assert os.path.exists(os.path.join(output, "result.hdf5"))
 
 
 @pytest.mark.slow_integration_test
@@ -541,3 +541,21 @@ def test_invalid_keyword_argument(model, tmp_path):
             plot=False,
             not_a_valid_kwarg=True,
         )
+
+
+@pytest.mark.parametrize("extension", ["hdf5", "h5", "json"])
+@pytest.mark.slow_integration_test
+def test_sampling_result_extension(model, tmp_path, extension):
+    """Assert the correct extension is used"""
+    output = tmp_path / "test"
+    output.mkdir()
+    fs = FlowSampler(
+        model,
+        output=output,
+        nlive=100,
+        plot=False,
+        proposal_plots=False,
+        result_extension=extension,
+    )
+    fs.run(plot=False)
+    assert os.path.exists(os.path.join(output, f"result.{extension}"))

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -4,6 +4,7 @@ Test io utilities.
 """
 import os
 import json
+import h5py
 import numpy as np
 import pickle
 import pytest
@@ -13,10 +14,29 @@ from nessai import config
 from nessai.livepoint import numpy_array_to_live_points
 from nessai.utils.io import (
     NessaiJSONEncoder,
+    add_dict_to_hdf5_file,
+    encode_for_hdf5,
     is_jsonable,
     safe_file_dump,
+    save_dict_to_hdf5,
     save_live_points,
+    save_to_json,
 )
+
+
+@pytest.fixture
+def data_dict():
+    data = dict(
+        a=np.array([1, 2, 3]),
+        b=np.array([(1, 2)], dtype=[("x", "f4"), ("y", "f4")]),
+        cls=object(),
+        l=[1, 2, 3],
+        dict1={"a": None, "b": 2},
+        dict2={"c": [1, 2, 3], "array": np.array([3, 4, 5])},
+        s="A string",
+        nan=None,
+    )
+    return data
 
 
 def test_is_jsonable_true():
@@ -63,6 +83,32 @@ def test_JSON_encoder_other():
         output = NessaiJSONEncoder.default(e, input)
     m.assert_called_once_with(input)
     assert output == "Hello"
+
+
+def test_save_to_json():
+    """Assert json.dump is called with the correct arguments"""
+    d = dict(a=1)
+    expected_kwargs = dict(indent=4, cls=NessaiJSONEncoder, test=True)
+    mop = mock_open()
+    filename = "test.json"
+    with patch("builtins.open", mop, create=True), patch(
+        "json.dump"
+    ) as mock_dump:
+        save_to_json(d, filename, test=True)
+    fp = mop()
+    mock_dump.assert_called_once_with(d, fp, **expected_kwargs)
+
+
+@pytest.mark.integration_test
+def test_save_to_json_integration(tmp_path, data_dict):
+    """Integration test for save to json"""
+    filename = tmp_path / "result.json"
+    save_to_json(data_dict, filename)
+    assert os.path.exists(filename)
+
+    with open(filename, "r") as fp:
+        out = json.load(fp)
+    assert list(data_dict.keys()) == list(out.keys())
 
 
 def test_safe_file_dump():
@@ -135,3 +181,48 @@ def test_save_live_points(tmp_path):
         d_out = json.load(fp)
 
     np.testing.assert_equal(d_out, d)
+
+
+@pytest.mark.parametrize(
+    "value, expected", [(None, "__none__"), ([1, 2], [1, 2])]
+)
+def test_encode_to_hdf5(value, expected):
+    """Assert values are correctly encoded."""
+    assert encode_for_hdf5(value) == expected
+
+
+def test_add_dict_to_hdf5_file(tmp_path, data_dict):
+    """Assert dictionaries is correctly converted"""
+    data_dict.pop("cls")
+    with h5py.File(tmp_path / "test.h5", "w") as f:
+        add_dict_to_hdf5_file(f, "/", data_dict)
+        assert list(f.keys()) == sorted(data_dict.keys())
+        assert f["/dict1/a"][()].decode() == "__none__"
+        np.testing.assert_array_equal(
+            f["dict2/array"][:], data_dict["dict2"]["array"]
+        )
+
+
+def test_save_dict_to_hdf5(data_dict):
+    """Assert the correct arguments are specified"""
+    f = mock_open()
+    filename = "result.h5"
+    with patch("h5py.File", f) as mock_file, patch(
+        "nessai.utils.io.add_dict_to_hdf5_file"
+    ) as mock_add:
+        save_dict_to_hdf5(data_dict, filename)
+    mock_file.assert_called_once_with(filename, "w")
+    mock_add.assert_called_once_with(f(), "/", data_dict)
+
+
+@pytest.mark.integration_test
+def test_save_dict_to_hdf5_integration(tmp_path, data_dict):
+    """Test saving a dict to HDF5 integration"""
+    # Do not need to support saving a class to HDF5
+    data_dict.pop("cls")
+    filename = tmp_path / "result.hdf5"
+    save_dict_to_hdf5(data_dict, filename)
+
+    with h5py.File(filename, "r") as f:
+        keys = list(f.keys())
+    assert keys == sorted(list(data_dict.keys()))


### PR DESCRIPTION
Add support for saving the results as HDF5 as well as JSON. Change the default to HDF5, since it is far more efficient.

Adds `h5py` as a new requirement

**To-Do**
- [x] Add tests for new save functions
- [x] Update requirements file