### PR TITLE
Check invalid model config

### DIFF
--- a/examples/gw/full_gw_example.py
+++ b/examples/gw/full_gw_example.py
@@ -107,8 +107,7 @@ result = bilby.core.sampler.run_sampler(
     maximum_uninformed=4000,
     seed=150914,
     analytic_priors=True,  # Bilby priors can be sampled from directly
-    flow_config=dict(model_config=dict(n_transforms=6)),
-    max_threads=3,
+    flow_config=dict(model_config=dict(n_blocks=6)),
     n_pool=2,
 )
 

--- a/nessai/flowmodel/config.py
+++ b/nessai/flowmodel/config.py
@@ -11,6 +11,8 @@ DEFAULT_MODEL_CONFIG = dict(
     device_tag="cpu",
     flow=None,
     inference_device_tag=None,
+    distribution=None,
+    distribution_kwargs=None,
     kwargs=dict(batch_norm_between_layers=True, linear_transform="lu"),
 )
 

--- a/nessai/flows/utils.py
+++ b/nessai/flows/utils.py
@@ -141,6 +141,7 @@ def configure_model(config):
     from .realnvp import RealNVP
     from .maf import MaskedAutoregressiveFlow
     from .nsf import NeuralSplineFlow
+    from ..flowmodel import config as fmconfig
 
     kwargs = {}
     flows = {
@@ -156,6 +157,14 @@ def configure_model(config):
 
     if not isinstance(config["n_inputs"], int):
         raise TypeError("Number of inputs (n_inputs) must be an int")
+
+    allowed_keys = set(fmconfig.DEFAULT_MODEL_CONFIG.keys())
+    extra_keys = set(config.keys()) - allowed_keys
+    if extra_keys:
+        raise RuntimeError(
+            f"Unknown keys in model config: {extra_keys}. "
+            f"Known keys are: {allowed_keys}"
+        )
 
     k = config.get("kwargs", None)
     if k is not None:

--- a/tests/test_flows/test_flow_utils.py
+++ b/tests/test_flows/test_flow_utils.py
@@ -330,6 +330,15 @@ def test_configure_model_invalid_device(caplog, config):
     assert "Could not send the normalising flow to" in caplog.text
 
 
+def test_configure_model_invalid_key(config):
+    """Assert an error is raised if invalid keys are present in the config"""
+    config["invalid_key"] = True
+    with pytest.raises(
+        RuntimeError, match=r"Unknown keys in model config: {'invalid_key'}"
+    ):
+        configure_model(config)
+
+
 @pytest.mark.parametrize("linear_transform", ["lu", "permutation", "svd"])
 def test_create_linear_transform(linear_transform):
     """Test creating a linear transform."""


### PR DESCRIPTION
Add a check to make sure all the keys in `model_config` are valid. Currently, invalid keys are silently ignored, which makes it easy to misspecify an option and no notice. With change, an error is raised if a key is not recognized.