### PR TITLE
Use default bilby logging level in examples

### DIFF
--- a/examples/bilby_unbounded_priors.py
+++ b/examples/bilby_unbounded_priors.py
@@ -10,7 +10,7 @@ outdir = "./outdir/"
 label = "bilby_unbounded_priors"
 
 # Setup the bilby logger
-bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level="WARNING")
+bilby.core.utils.setup_logger(outdir=outdir, label=label)
 
 # Define a likelihood using Bilby
 

--- a/examples/gw/basic_gw_example.py
+++ b/examples/gw/basic_gw_example.py
@@ -12,7 +12,7 @@ import numpy as np
 outdir = "./outdir/"
 label = "basic_gw_example"
 
-bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level="WARNING")
+bilby.core.utils.setup_logger(outdir=outdir, label=label)
 
 duration = 4.0
 sampling_frequency = 2048.0

--- a/examples/gw/calibration_example.py
+++ b/examples/gw/calibration_example.py
@@ -16,7 +16,7 @@ sampling_frequency = 2048.0
 
 outdir = "./outdir/"
 label = "calibration_example"
-bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level="WARNING")
+bilby.core.utils.setup_logger(outdir=outdir, label=label)
 
 np.random.seed(150914)
 

--- a/examples/gw/full_gw_example.py
+++ b/examples/gw/full_gw_example.py
@@ -13,7 +13,7 @@ import numpy as np
 outdir = "./outdir/"
 label = "full_gw_example"
 
-bilby.core.utils.setup_logger(outdir=outdir, label=label, log_level="WARNING")
+bilby.core.utils.setup_logger(outdir=outdir, label=label)
 
 duration = 4.0
 sampling_frequency = 2048.0


### PR DESCRIPTION
Now that the default logging level in `nessai` is `INFO` we don't need to set the logging level in the bilby examples.