### PR TITLE
Add maximum figure size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rescale` reparameterisation is now an alias for `ScaleAndShift`.
 - Change the default result file extension to `hdf5`, old result file format can be recovered by setting it to `json`.
 - Optimisations to `FlowProposal.populate`, including changes to `Model.in_bounds` and how sampling from the latent prior is handled.
+- Add a maximum figure size (`nessai.config.plotting.max_figsize`) to prevent very large trace plots when the number of dimensions is very high.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a bug where setting the livepoint precision (e.g. `f16`) did not work.
+- Fix plotting failing when sampling large number of parameters.
 
 ### Removed
 

--- a/nessai/config.py
+++ b/nessai/config.py
@@ -128,6 +128,12 @@ class PlottingConfig:
         default_factory=lambda: ["-", "--", ":", "-."]
     )
     """Default line styles."""
+    max_figsize: float = 50
+    """Maximum figure size in either width or height.
+
+    Based on the default DPI in matplotlib of 100, so this will give a maximum
+    size of 5000 pixels.
+    """
 
 
 livepoints = LivepointsConfig()

--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -222,9 +222,8 @@ def plot_1d_comparison(
             "Length of colours list must match number of arrays being plotted."
         )
 
-    fig, axs = plt.subplots(
-        len(parameters), 1, sharey=False, figsize=(3, 3 * len(parameters))
-    )
+    figsize = (3, min(config.plotting.max_figsize, 3 * len(parameters)))
+    fig, axs = plt.subplots(len(parameters), 1, sharey=False, figsize=figsize)
 
     if len(parameters) > 1:
         axs = axs.ravel()
@@ -482,9 +481,8 @@ def plot_trace(
     if kwargs:
         default_kwargs.update(kwargs)
 
-    fig, axes = plt.subplots(
-        len(labels), 1, figsize=(5, 3 * len(labels)), sharex=True
-    )
+    figsize = (5, min(config.plotting.max_figsize, 3 * len(labels)))
+    fig, axes = plt.subplots(len(labels), 1, figsize=figsize, sharex=True)
     if len(labels) > 1:
         axes = axes.ravel()
     else:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -550,7 +550,7 @@ def test_corner_plot_save_error(caplog, live_points):
     ) as mock_save:
         plot.corner_plot(live_points, filename="corner.png")
     mock_save.assert_called_once()
-    assert "Could not save test plot" in str(caplog.text)
+    assert "Could not save corner plot" in str(caplog.text)
 
 
 @pytest.mark.integration_test

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -406,6 +406,22 @@ def test_trace_plot_kwargs(nested_samples):
     plt.close()
 
 
+def test_trace_plot_save_error(caplog, nested_samples):
+    """Assert a warning is printed if the figure cannot be saved"""
+    with patch.object(
+        mpl.figure.Figure,
+        "savefig",
+        side_effect=ValueError,
+    ) as mock_save:
+        plot.plot_trace(
+            np.arange(nested_samples.size),
+            nested_samples,
+            filename="trace.png",
+        )
+    mock_save.assert_called_once()
+    assert "Could not save trace plot" in str(caplog.text)
+
+
 def test_histogram_plot():
     """Test the basic histogram plot"""
     x = np.random.randn(100)
@@ -523,6 +539,18 @@ def test_corner_plot_fields_exclude_error(live_points):
     with pytest.raises(ValueError) as excinfo:
         plot.corner_plot(live_points, include=["x"], exclude=["logL"])
     assert "Cannot specify both `include` and `exclude`" in str(excinfo.value)
+
+
+def test_corner_plot_save_error(caplog, live_points):
+    """Assert a warning is printed if the figure cannot be saved"""
+    with patch.object(
+        mpl.figure.Figure,
+        "savefig",
+        side_effect=ValueError,
+    ) as mock_save:
+        plot.corner_plot(live_points, filename="corner.png")
+    mock_save.assert_called_once()
+    assert "Could not save test plot" in str(caplog.text)
 
 
 @pytest.mark.integration_test

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from nessai import plot
 from nessai import config
+from nessai.livepoint import numpy_array_to_live_points
 
 
 @pytest.fixture()
@@ -522,3 +523,16 @@ def test_corner_plot_fields_exclude_error(live_points):
     with pytest.raises(ValueError) as excinfo:
         plot.corner_plot(live_points, include=["x"], exclude=["logL"])
     assert "Cannot specify both `include` and `exclude`" in str(excinfo.value)
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize("dims", [10, 100, 200])
+def test_plot_trace_large_dims(tmp_path, dims):
+    """Test producing a trace plot with a large number of dimensions."""
+    n = 10_000
+    names = [f"x_{i}" for i in range(dims)]
+    log_x = np.arange(n)
+    x = numpy_array_to_live_points(np.random.randn(n, dims), names)
+
+    fig = plot.plot_trace(log_x, x)
+    fig.savefig(tmp_path / "trace.png")


### PR DESCRIPTION
This is a follow-up to https://github.com/mj-will/nessai/pull/281 and aims to minimize cases where the error is raised by capping the maximum figure size.

I've added a `max_figsize` float to the config file and plots that dynamically change the figure size (corner and trace) now check the figsize is at most this value.

I've also added an integration test that, without this change, produces the error reported in https://github.com/mj-will/nessai/issues/280 and a couple of tests for the changes in https://github.com/mj-will/nessai/pull/281.