### PR TITLE
Fix in bounds bug

### DIFF
--- a/nessai/model.py
+++ b/nessai/model.py
@@ -406,10 +406,12 @@ class Model(ABC):
             Array with the same length as x where True indicates the point
             is within the prior bounds.
         """
-        x_view = self.unstructured_view(x)
         return ~np.any(
-            (x_view > self.upper_bounds) + (x_view < self.lower_bounds),
-            axis=-1,
+            [
+                (x[n] < self.bounds[n][0]) | (x[n] > self.bounds[n][1])
+                for n in self.names
+            ],
+            axis=0,
         )
 
     def sample_parameter(self, name, n=1):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -278,12 +278,11 @@ def test_in_bounds(model):
 
     Tests both finite and infinite prior bounds.
     """
-    x_view = np.array([[0.5, 1.0], [2.0, 1.0]])
-    x = numpy_array_to_live_points(x_view, ["x", "y"])
+    x = numpy_array_to_live_points(
+        np.array([[0.5, 1.0], [2.0, 1.0]]), ["x", "y"]
+    )
     model.names = ["x", "y"]
-    model.unstructured_view = MagicMock(return_value=x_view)
-    model.lower_bounds = np.array([0, -np.inf])
-    model.upper_bounds = np.array([1, np.inf])
+    model.bounds = {"x": [0, 1], "y": [-np.inf, np.inf]}
     val = Model.in_bounds(model, x)
     np.testing.assert_array_equal(val, np.array([True, False]))
 


### PR DESCRIPTION
The change in https://github.com/mj-will/nessai/pull/277 to `Model.in_bounds` broke sampling with reparameterisations that introduce extra parameters because of how the view works. This PR reverts to the old method whilst keeping some of the other improvements that were introduced in https://github.com/mj-will/nessai/pull/277.