### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/nessai/__init__.py
+++ b/nessai/__init__.py
@@ -6,12 +6,7 @@ normalising flows. It is designed for applications where the Bayesian
 likelihood is computationally expensive.
 """
 import logging
-
-try:
-    from importlib.metadata import version, PackageNotFoundError
-except ImportError:  # for Python < 3.8
-    from importlib_metadata import version, PackageNotFoundError
-
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,4 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310']

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ url = https://github.com/mj-will/nessai
 project_urls =
     Documentation = https://nessai.readthedocs.io/
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -19,7 +18,7 @@ keywords = nested sampling, normalising flows, machine learning
 
 [options]
 packages = find:
-python requires = >=3.7
+python requires = >=3.8
 install_requires =
     numpy>=1.9
     pandas


### PR DESCRIPTION
This PR removes support for Python 3.7.

Python 3.7 has yet to reach it's end-of-life but plenty of packages have stopped supporting it in new releases following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). So far it has been easy to support 3.7 but some changes (e.g. https://github.com/mj-will/nessai/pull/285) will be easier if we drop 3.7.