### PR TITLE
Fix reparameterisations bugs

### DIFF
--- a/nessai/gw/reparameterisations.py
+++ b/nessai/gw/reparameterisations.py
@@ -181,7 +181,7 @@ class DeltaPhaseReparameterisation(Reparameterisation):
             Updated log Jacobian determinant
         """
         x_prime[self.prime_parameters[0]] = (
-            x[self.parameters[0]] - np.sign(np.cos(x["theta_jn"])) * x["psi"]
+            x[self.parameters[0]] + np.sign(np.cos(x["theta_jn"])) * x["psi"]
         )
         return x, x_prime, log_j
 
@@ -208,7 +208,7 @@ class DeltaPhaseReparameterisation(Reparameterisation):
         """
         x[self.parameters[0]] = np.mod(
             x_prime[self.prime_parameters[0]]
-            + np.sign(np.cos(x["theta_jn"])) * x["psi"],
+            - np.sign(np.cos(x["theta_jn"])) * x["psi"],
             2 * np.pi,
         )
         return x, x_prime, log_j

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -658,7 +658,8 @@ class FlowProposal(RejectionProposal):
             r = rc(prior_bounds=prior_bounds, **default_config)
             self._reparameterisation.add_reparameterisations(r)
 
-        self.add_default_reparameterisations()
+        if self.use_default_reparameterisations:
+            self.add_default_reparameterisations()
 
         other_params = [
             n

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -155,7 +155,7 @@ def test_delta_phase_reparameterise(delta_phase_reparam):
         delta_phase_reparam, x, x_prime, log_j
     )
     assert x_out == x
-    assert x_prime_out["delta_phase"] == 0.5
+    assert x_prime_out["delta_phase"] == 1.5
     assert log_j_out == 0
 
 
@@ -176,7 +176,7 @@ def test_delta_phase_inverse_reparameterise(delta_phase_reparam):
         delta_phase_reparam, x, x_prime, log_j
     )
     assert x_prime_out == x_prime
-    assert x["phase"] == 1.0
+    assert x["phase"] == 0.0
     assert log_j_out == 0
 
 


### PR DESCRIPTION
Whilst trying to use the `delta-phase` reparameterisation I identified two minor bugs:

* The sign in `DeltaPhase` is wrong
* Setting `use_default_reparameterisations` does not prevent the default GW reparameterisations from being added due to a missing if statement.

If this all work, I plan to make a v0.8.1 with just these bug fixes.

**To-Do**

- [ ] Test on example BBH
- [ ] Fix broken tests