### PR TITLE
Fix delta phase sign

### DIFF
--- a/nessai/gw/reparameterisations.py
+++ b/nessai/gw/reparameterisations.py
@@ -181,7 +181,7 @@ class DeltaPhaseReparameterisation(Reparameterisation):
             Updated log Jacobian determinant
         """
         x_prime[self.prime_parameters[0]] = (
-            x[self.parameters[0]] - np.sign(np.cos(x["theta_jn"])) * x["psi"]
+            x[self.parameters[0]] + np.sign(np.cos(x["theta_jn"])) * x["psi"]
         )
         return x, x_prime, log_j
 
@@ -208,7 +208,7 @@ class DeltaPhaseReparameterisation(Reparameterisation):
         """
         x[self.parameters[0]] = np.mod(
             x_prime[self.prime_parameters[0]]
-            + np.sign(np.cos(x["theta_jn"])) * x["psi"],
+            - np.sign(np.cos(x["theta_jn"])) * x["psi"],
             2 * np.pi,
         )
         return x, x_prime, log_j

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -658,7 +658,8 @@ class FlowProposal(RejectionProposal):
             r = rc(prior_bounds=prior_bounds, **default_config)
             self._reparameterisation.add_reparameterisations(r)
 
-        self.add_default_reparameterisations()
+        if self.use_default_reparameterisations:
+            self.add_default_reparameterisations()
 
         other_params = [
             n

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -203,9 +203,15 @@ def test_delta_phase_inverse_invertible():
     x_prime["theta_jn"] = x["theta_jn"]
     log_j = np.zeros(n)
     x_f, x_prime_f, log_j_f = reparam.reparameterise(x, x_prime, log_j)
+
+    x_in = x_f.copy()
+    x_in["phase"] = np.nan
+
     assert_structured_arrays_equal(x_f, x)
     np.testing.assert_array_equal(log_j_f, log_j)
-    x_i, x_prime_i, log_j_i = reparam.reparameterise(x_f, x_prime_f, log_j_f)
+    x_i, x_prime_i, log_j_i = reparam.inverse_reparameterise(
+        x_in, x_prime_f.copy(), log_j_f.copy()
+    )
     assert_structured_arrays_equal(x_prime_i, x_prime_f)
-    assert_structured_arrays_equal(x_i, x)
+    assert_structured_arrays_equal(x_i, x, rtol=1e-15)
     np.testing.assert_array_equal(log_j_i, log_j_f)

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -155,7 +155,7 @@ def test_delta_phase_reparameterise(delta_phase_reparam):
         delta_phase_reparam, x, x_prime, log_j
     )
     assert x_out == x
-    assert x_prime_out["delta_phase"] == 0.5
+    assert x_prime_out["delta_phase"] == 1.5
     assert log_j_out == 0
 
 
@@ -176,7 +176,7 @@ def test_delta_phase_inverse_reparameterise(delta_phase_reparam):
         delta_phase_reparam, x, x_prime, log_j
     )
     assert x_prime_out == x_prime
-    assert x["phase"] == 1.0
+    assert x["phase"] == 0.0
     assert log_j_out == 0
 
 


### PR DESCRIPTION
Whilst trying to use the `delta-phase` reparameterisation I identified two minor bugs:

* The sign in `DeltaPhase` is wrong
* Setting `use_default_reparameterisations` does not prevent the default GW reparameterisations from being added due to a missing if statement.

If this all work, I plan to make a v0.8.1 with just these bug fixes.

**To-Do**

- [x] Test on example BBH
- [x] Fix broken tests