### PR TITLE
Fix resume bug with fallback reparameterisation

### DIFF
--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -704,7 +704,7 @@ class FlowProposal(RejectionProposal):
 
         self.names = self._reparameterisation.parameters
         self.rescaled_names = self._reparameterisation.prime_parameters
-        self.rescale_parameters = [
+        self.parameters_to_rescale = [
             p
             for p in self._reparameterisation.parameters
             if p not in self._reparameterisation.prime_parameters
@@ -740,7 +740,7 @@ class FlowProposal(RejectionProposal):
         self.configure_reparameterisations(self.reparameterisations)
 
         logger.info(f"x space parameters: {self.names}")
-        logger.info(f"parameters to rescale: {self.rescale_parameters}")
+        logger.info(f"parameters to rescale: {self.parameters_to_rescale}")
         logger.info(f"x prime space parameters: {self.rescaled_names}")
         self.rescaling_set = True
 
@@ -911,7 +911,7 @@ class FlowProposal(RejectionProposal):
                 filename=os.path.join(output, "x_generated.png"),
             )
 
-        if self.rescale_parameters:
+        if self.parameters_to_rescale:
             if self._plot_training == "all":
                 plot_live_points(
                     self.training_data_prime,

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
@@ -116,7 +116,6 @@ def test_training(proposal, tmpdir, save, plot, plot_training):
     proposal.populated = True
     proposal._plot_training = plot_training
     proposal.save_training_data = save
-    proposal.rescale_parameters = ["x"]
     proposal.rescaled_names = ["x_prime", "y_prime"]
     proposal.output = output
 

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_integration.py
@@ -92,6 +92,8 @@ def test_flowproposal_populate_edge_cases(
     )
 
     fp.initialise()
+    assert fp.rescale_parameters is False
+    assert fp.parameters_to_rescale == []
     worst = numpy_array_to_live_points(0.01 * np.ones(fp.dims), fp.names)
     fp.populate(worst, N=n_draw)
 

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_plots.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_plots.py
@@ -38,7 +38,8 @@ def test_training_plots(proposal, tmpdir, plot):
         array["logL"] = 0.0
 
     proposal.dims = 2
-    proposal.rescale_parameters = names
+    proposal.rescale_parameters = True
+    proposal.parameters_to_rescale = names
     proposal.rescaled_names = prime_names
 
     proposal.forward_pass = MagicMock(return_value=(z, None))

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -226,7 +226,7 @@ def test_configure_reparameterisations_str(mocked_class, proposal):
 
     proposal.add_default_reparameterisations.assert_not_called()
     assert proposal.rescaled_names == ["x_prime", "y"]
-    assert proposal.rescale_parameters == ["x"]
+    assert proposal.parameters_to_rescale == ["x"]
     assert proposal._reparameterisation.parameters == ["x", "y"]
     assert proposal._reparameterisation.prime_parameters == ["x_prime", "y"]
     assert mocked_class.called_once
@@ -246,7 +246,7 @@ def test_configure_reparameterisations_dict_reparam(mocked_class, proposal):
 
     proposal.add_default_reparameterisations.assert_not_called()
     assert proposal.rescaled_names == ["x_prime", "y"]
-    assert proposal.rescale_parameters == ["x"]
+    assert proposal.parameters_to_rescale == ["x"]
     assert proposal._reparameterisation.parameters == ["x", "y"]
     assert proposal._reparameterisation.prime_parameters == ["x_prime", "y"]
     assert mocked_class.called_once
@@ -264,7 +264,7 @@ def test_configure_reparameterisations_none(mocked_class, proposal):
     proposal.add_default_reparameterisations.assert_not_called()
     assert proposal.rescaled_names == ["x", "y"]
 
-    assert proposal.rescale_parameters == []
+    assert proposal.parameters_to_rescale == []
     assert proposal._reparameterisation.parameters == ["x", "y"]
     assert proposal._reparameterisation.prime_parameters == ["x", "y"]
     assert all(
@@ -288,7 +288,7 @@ def test_configure_reparameterisations_fallback(mocked_class, proposal):
     proposal.add_default_reparameterisations.assert_not_called()
     assert proposal.rescaled_names == ["x_prime", "y_prime"]
 
-    assert proposal.rescale_parameters == ["x", "y"]
+    assert proposal.parameters_to_rescale == ["x", "y"]
     assert proposal._reparameterisation.parameters == ["x", "y"]
     assert proposal._reparameterisation.prime_parameters == [
         "x_prime",
@@ -360,7 +360,7 @@ def test_set_rescaling_with_model(proposal, model):
 
     def update(self):
         proposal.names = model.names
-        proposal.rescale_parameters = ["x"]
+        proposal.parameters_to_rescale = ["x"]
         proposal.rescaled_names = ["x_prime"]
 
     proposal.configure_reparameterisations = MagicMock()
@@ -385,7 +385,7 @@ def test_set_rescaling_with_reparameterisations(proposal, model):
 
     def update(self):
         proposal.names = model.names
-        proposal.rescale_parameters = ["x"]
+        proposal.parameters_to_rescale = ["x"]
         proposal.rescaled_names = ["x_prime"]
 
     proposal.configure_reparameterisations = MagicMock()
@@ -418,7 +418,7 @@ def test_set_rescaling_parameters(proposal, model, rescale_parameters):
 
     def update(self):
         proposal.names = model.names
-        proposal.rescale_parameters = _rescale_parameters
+        proposal.parameters_to_rescale = _rescale_parameters
         proposal.rescaled_names = rescaled_names
 
     proposal.model = model
@@ -452,6 +452,7 @@ def test_set_rescaling_parameters(proposal, model, rescale_parameters):
     proposal.configure_reparameterisations.assert_called_with(
         reparameterisations
     )
+    proposal.parameters_to_rescale == _rescale_parameters
 
 
 @pytest.mark.parametrize("n", [1, 10])


### PR DESCRIPTION
This PR fixes a bug that lead to the wrong reparameterisation being used in some cases.

If running with:

```
rescale_parameters=False,
use_default_reparameterisation=False
fallback_reparameterisation="z-score"
```
then when resuming, the fallback reparameterisation would not be used.

This occurred because `self.rescale_parameters` was being updated when settings the reparameterisations.

**Fix**

Use a different attribute to store the list of parameters that will be rescaled.
