### PR TITLE
Change install order in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,9 +31,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r dev_requirements.txt
-        pip install -e .
+        pip install .[test]
+        pip install .[dev,nflows,gw]
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,7 +32,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install .[dev,nflows,gw]
+        pip install .[dev,nflows]
+        pip install .[gw]
+    - name: Check dependencies
+      if: success() || failure()
+      run: |
+        python -m pip check
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r dev_requirements.txt
-        pip install -e .
+        pip install .[test]
+        pip install .[dev,nflows,gw]
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install .[dev,nflows,gw]
+        pip install .[dev,nflows]
+        pip install .[gw]
+    - name: Check dependencies
+      if: success() || failure()
+      run: |
+        python -m pip check
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ test =
     pytest-rerunfailures
     pytest-integration
 gw =
-    lalsuite
+    lalsuite; sys_platform != 'win32'
     bilby
     astropy
 nflows =


### PR DESCRIPTION
Change the order packages are installed in the CI. This should ensure pytest is always installed.

