### PR TITLE
Pass kwargs in RealNVP to the coupling class

### DIFF
--- a/nessai/flows/realnvp.py
+++ b/nessai/flows/realnvp.py
@@ -69,6 +69,8 @@ class RealNVP(NFlow):
     actnorm : bool
         Include activation normalisation as described in arXiv:1807.03039.
         Batch norm between layers must be disabled if using this option.
+    kwargs :
+        Keyword arguments are passed to the coupling class.
     """
 
     def __init__(
@@ -90,6 +92,7 @@ class RealNVP(NFlow):
         pre_transform_kwargs=None,
         actnorm=False,
         distribution=None,
+        **kwargs,
     ):
 
         if features <= 1:
@@ -193,7 +196,9 @@ class RealNVP(NFlow):
                     create_linear_transform(linear_transform, features)
                 )
             transform = coupling_constructor(
-                mask=mask[i], transform_net_create_fn=create_net
+                mask=mask[i],
+                transform_net_create_fn=create_net,
+                **kwargs,
             )
             layers.append(transform)
             if batch_norm_between_layers:

--- a/tests/test_flows/test_specific_flows.py
+++ b/tests/test_flows/test_specific_flows.py
@@ -27,6 +27,7 @@ from nessai.flows import (
         dict(mask=[1, -1]),
         dict(pre_transform="batch_norm"),
         dict(pre_transform="batch_norm", pre_transform_kwargs=dict(eps=1e-8)),
+        dict(scale_activation=lambda x: torch.sigmoid(x + 2) + 1e-3),
     ],
 )
 def test_with_realnvp_kwargs(kwargs):


### PR DESCRIPTION
Pass additional kwargs in `RealNVP` to the coupling class being called.

This allows the user to set any additional settings, e.g. `scale_activation`