### PR TITLE
Add log-scaling to state plot

### DIFF
--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -985,7 +985,8 @@ class NestedSampler(BaseNestedSampler):
 
         ax[2].plot(it, self.likelihood_evaluations, label="Evaluations")
         ax[2].set_ylabel("Likelihood\n evaluations")
-
+        ax[2].set_yscale('log')
+        
         ax[3].plot(it, self.logZ_history, label="logZ")
         ax[3].set_ylabel(r"$\log Z$")
         ax[3].legend(frameon=False)
@@ -998,6 +999,7 @@ class NestedSampler(BaseNestedSampler):
             c="C1",
             ls=config.plotting.line_styles[1],
         )
+        ax_dz.set_yscale('log')
         ax_dz.set_ylabel(r"$dZ$")
         handles, labels = ax[3].get_legend_handles_labels()
         handles_dz, labels_dz = ax_dz.get_legend_handles_labels()
@@ -1010,7 +1012,7 @@ class NestedSampler(BaseNestedSampler):
             label="Population",
         )
         ax[4].set_ylabel("Acceptance")
-        ax[4].set_ylim((-0.1, 1.1))
+        ax[4].set_ylim(top=1.1)
         handles, labels = ax[4].get_legend_handles_labels()
 
         ax_r = plt.twinx(ax[4])
@@ -1024,7 +1026,7 @@ class NestedSampler(BaseNestedSampler):
         ax_r.set_ylabel("Population radius")
         handles_r, labels_r = ax_r.get_legend_handles_labels()
         ax[4].legend(handles + handles_r, labels + labels_r, frameon=False)
-
+        ax[4].set_yscale('log')
         dtrain = np.array(self.training_iterations[1:]) - np.array(
             self.training_iterations[:-1]
         )


### PR DESCRIPTION
Modify `dZ`, `Acceptance` and `Likelihood evaluations` to use log-scale in state plot for visual clarity.