### PR TITLE
Regex for reparameterisations

### DIFF
--- a/examples/gw/calibration_example.py
+++ b/examples/gw/calibration_example.py
@@ -118,8 +118,6 @@ calib_phases = [
     "recalib_L1_phase_1",
 ]
 
-calib_parameters = calib_amplitudes + calib_phases
-
 # Entry 8 is the detector (H or L)
 for name in calib_amplitudes:
     priors[name] = bilby.prior.Gaussian(
@@ -154,5 +152,5 @@ result = bilby.run_sampler(
     plot=True,
     sampler="nessai",
     flow_class="gwflowproposal",
-    reparameterisations={"null": {"parameters": calib_parameters}},
+    reparameterisations={"z-score": {"parameters": "recalib.*"}},
 )

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -7,6 +7,7 @@ import datetime
 from functools import partial
 import logging
 import os
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -630,6 +631,26 @@ class FlowProposal(RejectionProposal):
                 try:
                     rc, default_config = self.get_reparameterisation(k)
                     default_config.update(cfg)
+                    parameters = default_config.get("parameters")
+
+                    if parameters is not None:
+                        if not isinstance(parameters, list):
+                            if isinstance(parameters, str):
+                                patterns = [parameters]
+                            else:
+                                patterns = list(parameters)
+                        else:
+                            patterns = parameters.copy()
+                        matches = []
+                        for pattern in patterns:
+                            r = re.compile(pattern)
+                            matches += list(filter(r.match, self.model.names))
+                        default_config["parameters"] = matches
+                    else:
+                        logger.warning(
+                            "Reparameterisation might be missing parameters!"
+                        )
+
                 except ValueError:
                     raise RuntimeError(
                         f"{k} is not a parameter in the model or a known "

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -252,6 +252,43 @@ def test_configure_reparameterisations_dict_reparam(mocked_class, proposal):
     assert mocked_class.called_once
 
 
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        "x.*",
+        [
+            "x.*",
+        ],
+        ("x.*",),
+    ],
+)
+@patch("nessai.reparameterisations.CombinedReparameterisation")
+def test_configure_reparameterisations_regex(
+    mocked_class, proposal, parameters
+):
+    """Test configuration for reparameterisations dictionary"""
+    proposal.add_default_reparameterisations = MagicMock()
+    proposal.get_reparameterisation = get_reparameterisation
+    proposal.model.names = ["x_0", "x_1", "y"]
+    proposal.model.bounds = {"x_0": [-1, 1], "x_1": [-1, 1], "y": [-1, 1]}
+    proposal.fallback_reparameterisation = None
+    FlowProposal.configure_reparameterisations(
+        proposal,
+        {"z-score": {"parameters": parameters}},
+    )
+
+    proposal.add_default_reparameterisations.assert_not_called()
+    assert proposal.rescaled_names == ["x_0_prime", "x_1_prime", "y"]
+    assert proposal.parameters_to_rescale == ["x_0", "x_1"]
+    assert proposal._reparameterisation.parameters == ["x_0", "x_1", "y"]
+    assert proposal._reparameterisation.prime_parameters == [
+        "x_0_prime",
+        "x_1_prime",
+        "y",
+    ]
+    assert mocked_class.called_once
+
+
 @patch("nessai.reparameterisations.CombinedReparameterisation")
 def test_configure_reparameterisations_none(mocked_class, proposal):
     """Test configuration when input is None"""

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -94,6 +94,25 @@ def test_sampling_with_inversion(model, flow_config, tmpdir):
     assert fp.ns.proposal.training_count == 1
 
 
+def test_sampling_regex_reparams(model, flow_config, tmp_path):
+    """Test using regex to specify reparameterisations"""
+    model._names = ["x_0", "x_1"]
+    model._bounds = {"x_0": [-5, 5], "x_1": [-5, 5]}
+
+    fs = FlowSampler(
+        model,
+        nlive=100,
+        output=tmp_path / "test_regex",
+        flow_config=flow_config,
+        reparameterisations={"z-score": {"parameters": ["x.*"]}},
+        maximum_uninformed=50,
+        max_iteration=100,
+        plot=False,
+    )
+    fs.run()
+    assert fs.ns._flow_proposal.rescaled_names == ["x_0_prime", "x_1_prime"]
+
+
 @pytest.mark.slow_integration_test
 def test_sampling_without_rescale(model, flow_config, tmpdir):
     """


### PR DESCRIPTION
Support using regex in `parameters` key for reparameterisations.

Closes https://github.com/mj-will/nessai/issues/301

**Example**

When specifying the reparameterisations dictionary, you can now use regex:

```python
reparameterisations = {
    "z-score": {"parameters": "recalib.*"}
}
```

**Note:** this does not work when specifying `<parameter> : <reparam>`