### PR TITLE
Support forkserver and spawn multiprocessing methods

### DIFF
--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -39,14 +39,15 @@ def get_n_pool(pool):
 def check_multiprocessing_start_method():
     """Check the multiprocessing start method.
 
-    Raise an error if the start method is not `fork`.
+    Raise an error if the start method is not `fork` or `forkserver`.
     """
     start_method = multiprocessing.get_start_method()
-    if start_method != "fork":
+    if start_method not in ["fork", "forkserver"]:
         raise RuntimeError(
-            "nessai only supports multiprocessing using the 'fork' start "
-            f"method. Actual start method is: {start_method}. See the "
-            "multiprocessing documentation for more details."
+            "nessai only supports multiprocessing using the 'fork' or "
+            "'forkserver' start methods. Actual start method "
+            f"is: {start_method}. See the multiprocessing documentation for "
+            "more details."
         )
 
 

--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -39,15 +39,15 @@ def get_n_pool(pool):
 def check_multiprocessing_start_method():
     """Check the multiprocessing start method.
 
-    Raise an error if the start method is not `fork` or `forkserver`.
+    Print a warning if the start method is not `fork`.
     """
     start_method = multiprocessing.get_start_method()
-    if start_method not in ["fork", "forkserver"]:
-        raise RuntimeError(
-            "nessai only supports multiprocessing using the 'fork' or "
-            "'forkserver' start methods. Actual start method "
-            f"is: {start_method}. See the multiprocessing documentation for "
-            "more details."
+    if start_method != "fork":
+        logger.warning(
+            f"Using {start_method} start method for multiprocessing. "
+            "This may lead to high memory usage or errors. "
+            "Consider using the `fork` start method. "
+            "See the multiprocessing documentation for more details."
         )
 
 

--- a/nessai/utils/testing.py
+++ b/nessai/utils/testing.py
@@ -4,6 +4,25 @@ Utilities for the test suite.
 """
 import numpy as np
 
+from ..model import Model
+
+
+class IntegrationTestModel(Model):
+    """Complete nessai model for use with integration tests"""
+
+    def __init__(self, dims=2):
+        self.bounds = {f"x_{i}": [-5.0, 5.0] for i in range(dims)}
+        self.names = list(self.bounds.keys())
+
+    def log_prior(self, x):
+        log_p = np.log(self.in_bounds(x), dtype="float")
+        for n in self.names:
+            log_p -= np.log(self.bounds[n][1] - self.bounds[n][0])
+        return log_p
+
+    def log_likelihood(self, x):
+        return np.sum(-0.5 * (self.unstructured_view(x) ** 2), axis=-1)
+
 
 def assert_structured_arrays_equal(x, y, atol=0.0, rtol=0.0):
     """Assert structured arrays are equal.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,8 @@ def wait():
 @pytest.fixture(params=["fork", "forkserver", "spawn"])
 def mp_context(request):
     """Multiprocessing context to test"""
+    if sys.platform == "win32" and request.param != "spawn":
+        pytest.skip("Windows only supports the 'spawn' start method")
     return multiprocessing.get_context(request.param)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from nessai.livepoint import (
     reset_extra_live_points_parameters,
 )
 from nessai.model import Model
+from nessai.utils.testing import IntegrationTestModel
 
 
 seed(170817)
@@ -54,6 +55,11 @@ def model():
             return x_out
 
     return TestModel()
+
+
+@pytest.fixture()
+def integration_model():
+    return IntegrationTestModel()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,16 +84,9 @@ def wait():
     return func
 
 
-@pytest.fixture(params=["fork", "spawn"])
+@pytest.fixture(params=["fork", "forkserver", "spawn"])
 def mp_context(request):
     """Multiprocessing context to test"""
-    if request.param == "spawn":
-        pytest.skip(
-            "nessai does not currently support multiprocessing with the "
-            "'spawn' method."
-        )
-    if sys.platform == "win32":
-        pytest.skip("Windows does not support 'fork' method")
     return multiprocessing.get_context(request.param)
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,7 +17,6 @@ from nessai.utils.multiprocessing import (
     log_likelihood_wrapper,
 )
 from nessai.utils.testing import (
-    IntegrationTestModel,
     assert_structured_arrays_equal,
 )
 
@@ -51,11 +50,6 @@ class BasicModel(Model):
 @pytest.fixture
 def model():
     return create_autospec(Model, _pool_configured=False)
-
-
-@pytest.fixture()
-def integration_model():
-    return IntegrationTestModel()
 
 
 @pytest.fixture

--- a/tests/test_utils/test_multiprocessing_utils.py
+++ b/tests/test_utils/test_multiprocessing_utils.py
@@ -30,24 +30,18 @@ def test_pool_variables():
     initialise_pool_variables(None)
 
 
-def test_check_multiprocessing_start_method():
-    """Test check multiprocessing start method passes for 'fork'"""
-    with patch("multiprocessing.get_start_method", return_value="fork"):
+@pytest.mark.parametrize("method", ["fork", "forkserver", "spawn"])
+def test_check_multiprocessing_start_method(method, caplog):
+    """
+    Test check multiprocessing start method passes for all methods
+    """
+    with patch("multiprocessing.get_start_method", return_value=method):
         check_multiprocessing_start_method()
-
-
-@pytest.mark.parametrize("method", ["spawn", "forkserver"])
-def test_check_multiprocessing_start_method_error(method):
-    """Assert an error is raised if the start method is not fork."""
-    error_msg = r"nessai only supports multiprocessing using the 'fork' .*"
-    with patch(
-        "multiprocessing.get_start_method", return_value=method
-    ), pytest.raises(RuntimeError, match=error_msg):
-        check_multiprocessing_start_method()
+    if method != "fork":
+        assert "This may lead to high memory usage or errors" in caplog.text
 
 
 @pytest.mark.integration_test
-@pytest.mark.skip_on_windows
 def test_check_multiprocessing_start_method_integration():
     """Integration test for checking the start method."""
     mp = multiprocessing.get_context("fork")
@@ -55,15 +49,15 @@ def test_check_multiprocessing_start_method_integration():
         check_multiprocessing_start_method()
 
 
+@pytest.mark.parametrize("method", ["fork", "forkserver", "spawn"])
 @pytest.mark.integration_test
-def test_check_multiprocessing_start_method_error_integration():
-    """Integration test for checking the start method raises an error."""
-    mp = multiprocessing.get_context("spawn")
-    error_msg = r"nessai only supports multiprocessing using the 'fork' .*"
-    with patch(
-        "multiprocessing.get_start_method", mp.get_start_method
-    ), pytest.raises(RuntimeError, match=error_msg):
+def test_check_multiprocessing_start_method_error_integration(method, caplog):
+    """Integration test for checking the start method prints a warning"""
+    mp = multiprocessing.get_context(method)
+    with patch("multiprocessing.get_start_method", mp.get_start_method):
         check_multiprocessing_start_method()
+    if method != "fork":
+        assert "This may lead to high memory usage or errors" in caplog.text
 
 
 def test_model_error():

--- a/tests/test_utils/test_multiprocessing_utils.py
+++ b/tests/test_utils/test_multiprocessing_utils.py
@@ -5,6 +5,7 @@ Tests for rescaling functions
 import multiprocessing
 from multiprocessing.dummy import Pool
 import pytest
+import sys
 from unittest.mock import MagicMock, patch
 
 from nessai.utils.multiprocessing import (
@@ -42,6 +43,7 @@ def test_check_multiprocessing_start_method(method, caplog):
 
 
 @pytest.mark.integration_test
+@pytest.mark.skip_on_windows
 def test_check_multiprocessing_start_method_integration():
     """Integration test for checking the start method."""
     mp = multiprocessing.get_context("fork")
@@ -53,6 +55,8 @@ def test_check_multiprocessing_start_method_integration():
 @pytest.mark.integration_test
 def test_check_multiprocessing_start_method_error_integration(method, caplog):
     """Integration test for checking the start method prints a warning"""
+    if sys.platform == "win32" and method != "spawn":
+        pytest.skip("Windows only supports the 'spawn' start method")
     mp = multiprocessing.get_context(method)
     with patch("multiprocessing.get_start_method", mp.get_start_method):
         check_multiprocessing_start_method()

--- a/tests/test_utils/test_testing_utils.py
+++ b/tests/test_utils/test_testing_utils.py
@@ -4,7 +4,25 @@ Test the testing utilities
 import numpy as np
 import pytest
 
-from nessai.utils.testing import assert_structured_arrays_equal
+from nessai.utils.testing import (
+    IntegrationTestModel,
+    assert_structured_arrays_equal,
+)
+
+
+@pytest.mark.parametrize("n", [1, 10])
+@pytest.mark.parametrize("dims", [2, 4])
+def test_integration_test_model(n, dims):
+    """Assert the model is valid"""
+    model = IntegrationTestModel(dims)
+    model.verify_model()
+    x = model.new_point(n)
+    log_p = model.log_prior(x)
+    log_l = model.log_likelihood(x)
+    assert np.isfinite(log_p).all()
+    assert np.isfinite(log_l).all()
+    assert len(log_p) == len(x)
+    assert len(log_l) == len(x)
 
 
 def test_assert_struct_arrays_different_fields():


### PR DESCRIPTION
Add support for the forkserver and spawn multiprocessing methods.

**Note:** these methods only work when the model is pickeable and can also result in higher memory usage.

Closes https://github.com/mj-will/nessai/issues/303