### PR TITLE
Fix reparam regex bug

### DIFF
--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -644,7 +644,9 @@ class FlowProposal(RejectionProposal):
                         matches = []
                         for pattern in patterns:
                             r = re.compile(pattern)
-                            matches += list(filter(r.match, self.model.names))
+                            matches += list(
+                                filter(r.fullmatch, self.model.names)
+                            )
                         default_config["parameters"] = matches
                     else:
                         logger.warning(

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
@@ -86,7 +86,7 @@ def test_default_reparameterisations(caplog, tmpdir):
     """Assert that by default the reparameterisation is RescaleToBounds"""
     caplog.set_level("INFO")
     model = MagicMock()
-    model.names = ["x", "y"]
+    model.names = ["x1", "x10", "x11"]
     model.bounds = {p: [-1, 1] for p in model.names}
     model.reparameterisations = None
     proposal = FlowProposal(
@@ -97,4 +97,5 @@ def test_default_reparameterisations(caplog, tmpdir):
     proposal.initialise()
     reparams = list(proposal._reparameterisation.values())
     assert len(reparams) == 1
-    assert reparams[0].parameters == ["x", "y"]
+    assert reparams[0].parameters == ["x1", "x10", "x11"]
+    assert proposal.rescale_parameters == ["x1", "x10", "x11"]


### PR DESCRIPTION
Use `fullmatch` instead of `match` for regex pattern matching.

Also add a test to check for this bug in future.

Closes https://github.com/mj-will/nessai/issues/320