### PR TITLE
Reduce the size of INS checkpoint files

### DIFF
--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -288,7 +288,7 @@ class BaseNestedSampler(ABC):
         obj
             Instance of BaseNestedSampler
         """
-        logger.info("Resuming NestedSampler from " + filename)
+        logger.info(f"Resuming {cls.__name__} from {filename}")
         with open(filename, "rb") as f:
             obj = pickle.load(f)
         model.likelihood_evaluations += obj._previous_likelihood_evaluations

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1898,7 +1898,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         return d
 
     @classmethod
-    def resume(cls, filename, model, flow_config={}, weights_path=None):
+    def resume(cls, filename, model, flow_config=None, weights_path=None):
         """
         Resumes the interrupted state from a checkpoint pickle file.
 
@@ -1921,6 +1921,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """
         cls.add_fields()
         obj = super().resume(filename, model)
+        if flow_config is None:
+            flow_config = {}
         obj.proposal.resume(model, flow_config, weights_path=weights_path)
 
         if obj.log_q is None:

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1948,7 +1948,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             ].likelihood_evaluation_time.total_seconds()
         else:
             state["_previous_likelihood_evaluations"] = 0
-            state["_previous_likelihood_evaluations_time"] = 0
+            state["_previous_likelihood_evaluation_time"] = 0
         state["log_q"] = None
         return state, self.proposal
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_resume.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_resume.py
@@ -1,0 +1,57 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
+
+
+def test_getstate_no_model(ins):
+    ins.proposal = MagicMock()
+    ins.model = None
+    state, proposal = INS.__getstate__(ins)
+    assert state["log_q"] is None
+    assert "model" not in state
+    assert state["_previous_likelihood_evaluations"] == 0
+    assert state["_previous_likelihood_evaluation_time"] == 0
+    assert proposal is ins.proposal
+
+
+def test_getstate_model(ins):
+
+    evals = 10
+    time = datetime.timedelta(seconds=30)
+
+    ins.proposal = MagicMock()
+    ins.model = MagicMock()
+    ins.model.likelihood_evaluations = evals
+    ins.model.likelihood_evaluation_time = time
+
+    state, proposal = INS.__getstate__(ins)
+    assert state["log_q"] is None
+    assert "model" not in state
+    assert state["_previous_likelihood_evaluations"] == evals
+    assert state["_previous_likelihood_evaluation_time"] == 30
+    assert proposal is ins.proposal
+
+
+def test_resume(model, tmp_path, samples):
+
+    filename = str(tmp_path / "test.pkl")
+
+    obj = MagicMock()
+    obj.log_q = None
+    obj.log_evidence = 0.0
+    obj.log_evidence_error = 1.0
+    obj.proposal = MagicMock()
+    obj.samples = samples
+    log_q = np.log(np.random.rand(len(samples)))
+    obj.proposal.compute_meta_proposal_samples = MagicMock(return_value=log_q)
+
+    with patch(
+        "nessai.samplers.importancesampler.BaseNestedSampler.resume",
+        return_value=obj,
+    ):
+        out = INS.resume(filename, model)
+
+    assert out.log_q is log_q

--- a/tests/test_sampling/test_ins_sampling.py
+++ b/tests/test_sampling/test_ins_sampling.py
@@ -2,6 +2,7 @@
 import os
 
 from nessai.flowsampler import FlowSampler
+import numpy as np
 import pytest
 
 
@@ -22,6 +23,8 @@ def test_ins_resume(tmp_path, model, flow_config):
     )
     fp.run()
 
+    original_log_q = fp.ns.log_q.copy()
+
     assert fp.ns.iteration == 2
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
@@ -33,6 +36,8 @@ def test_ins_resume(tmp_path, model, flow_config):
         plot=False,
         importance_nested_sampler=True,
     )
+    new_log_q = fp.ns.log_q.copy()
 
     assert fp.ns.max_iteration == 2
     assert fp.ns.finalised is True
+    np.testing.assert_array_almost_equal(new_log_q, original_log_q)


### PR DESCRIPTION
Reduce the size of the checkpoint files by recomputing `log_q` when resuming the sampler.

Note: due to how pytorch works, the value of log_q can change when resuming because different batch sizes are used. See https://github.com/pytorch/pytorch/issues/34060