### PR TITLE
Fix model bounds bug

### DIFF
--- a/nessai/model.py
+++ b/nessai/model.py
@@ -150,7 +150,7 @@ class Model(ABC):
 
     def _set_upper_lower(self):
         """Set the upper and lower bounds arrays"""
-        bounds_array = np.array(list(self.bounds.values()))
+        bounds_array = np.array([self.bounds[n] for n in self.names])
         self._lower = bounds_array[:, 0]
         self._upper = bounds_array[:, 1]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -145,10 +145,11 @@ def test_dims_no_names(model):
 
 def test_set_upper_lower(model):
     """Assert the upper and lower bounds are set correctly."""
-    model.bounds = {"x": [-1, 1], "y": [-1, 1]}
+    model.names = ["y", "x"]
+    model.bounds = {"x": [0, 1], "y": [-1, 2]}
     Model._set_upper_lower(model)
-    np.testing.assert_array_equal(model._lower, np.array([-1, -1]))
-    np.testing.assert_array_equal(model._upper, np.array([1, 1]))
+    np.testing.assert_array_equal(model._lower, np.array([-1, 0]))
+    np.testing.assert_array_equal(model._upper, np.array([2, 1]))
 
 
 def test_lower_bounds(model):


### PR DESCRIPTION
Fix a bug where the lower and upper bounds properties were incorrect because they assumed the order of the keys in `bounds` matches the order in `names`.