### PR TITLE
Allow non-vectorised log-prior functions

### DIFF
--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -66,6 +66,12 @@ class FlowSampler:
         likelihood values for the same point in parameter space. See
         :py:attr:`nessai.model.Model.allow_multi_valued_likelihood` for more
         details.
+    parallelise_prior : Optional[bool]
+        If true, and a multiprocessing pool has been specified, then the
+        log-prior calculation will be parallelised using multiprocessing.
+        If false, then the pool with not be used. Overrides the value of the
+        `parallelise_prior` attribute in the model class, which is false by
+        default.
     result_extension : str
         Extension used when saving the result format. Defaults to HDF5, but
         also supports JSON.
@@ -93,6 +99,7 @@ class FlowSampler:
         disable_vectorisation=False,
         likelihood_chunksize=None,
         allow_multi_valued_likelihood=None,
+        parallelise_prior=None,
         result_extension="hdf5",
         **kwargs,
     ):
@@ -133,6 +140,10 @@ class FlowSampler:
 
         if allow_multi_valued_likelihood is not None:
             model.allow_multi_valued_likelihood = allow_multi_valued_likelihood
+
+        if parallelise_prior is not None:
+            logger.debug("Overriding `parallelise_prior` in the model")
+            model.parallelise_prior = parallelise_prior
 
         self.output = os.path.join(output, "")
         os.makedirs(self.output, exist_ok=True)

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -18,8 +18,10 @@ from .livepoint import (
 from .utils.multiprocessing import (
     get_n_pool,
     log_likelihood_wrapper,
+    log_prior_wrapper,
+    batch_evaluate_function,
+    check_vectorised_function,
 )
-from .utils.structures import array_split_chunksize
 
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,15 @@ class Model(ABC):
     obj
         Multiprocessing pool for evaluating the log-likelihood.
     """
+    allow_vectorised_prior = True
+    """
+    bool
+        Allow the model to use a vectorised prior. If True, nessai will
+        try to check if the log-prior is vectorised and use call the method
+        as a vectorised function. If False, nessai won't check and, even if the
+        log-prior is vectorised, it will only evaluate the log-prior one
+        sample at a time.
+    """
     allow_vectorised = True
     """
     bool
@@ -90,7 +101,9 @@ class Model(ABC):
         variations in the likelihood across the prior.
     """
     _vectorised_likelihood = None
+    _vectorised_prior = None
     _pool_configured = False
+    n_pool = None
 
     @property
     def names(self):
@@ -182,35 +195,13 @@ class Model(ABC):
         """
         if self._vectorised_likelihood is None:
             if self.allow_vectorised:
-                x = self.new_point(N=10)
-                target = np.array(
-                    [self.log_likelihood(xx) for xx in x],
+                # Avoids calling prior on multiple points
+                x = np.concatenate([self.new_point() for _ in range(10)])
+                self._vectorised_likelihood = check_vectorised_function(
+                    self.log_likelihood,
+                    x,
                     dtype=config.livepoints.logl_dtype,
                 )
-                try:
-                    batch = self.log_likelihood(x).astype(
-                        config.livepoints.logl_dtype
-                    )
-                except (TypeError, ValueError):
-                    logger.debug(
-                        "Evaluating a batch of points returned an error. "
-                        "Assuming the likelihood is not vectorised."
-                    )
-                    self._vectorised_likelihood = False
-                else:
-                    if np.array_equal(batch, target):
-                        logger.debug(
-                            "Individual and batch likelihoods are equal."
-                        )
-                        logger.info("Likelihood is vectorised")
-                        self._vectorised_likelihood = True
-                    else:
-                        logger.debug(
-                            "Individual and batch likelihoods are not equal."
-                        )
-                        logger.debug(target)
-                        logger.debug(batch)
-                        self._vectorised_likelihood = False
             else:
                 self._vectorised_likelihood = False
         return self._vectorised_likelihood
@@ -219,6 +210,23 @@ class Model(ABC):
     def vectorised_likelihood(self, value):
         """Manually set the value for vectorised likelihood."""
         self._vectorised_likelihood = value
+
+    @property
+    def vectorised_prior(self):
+        if self._vectorised_prior is None:
+            # Avoids calling prior on multiple points
+            x = np.concatenate([self.new_point() for _ in range(10)])
+            self._vectorised_prior = check_vectorised_function(
+                self.log_prior,
+                x,
+                dtype=config.livepoints.default_float_dtype,
+            )
+        return self._vectorised_prior
+
+    @vectorised_prior.setter
+    def vectorised_prior(self, value):
+        """Manually set the value for vectorised prior."""
+        self._vectorised_prior = value
 
     @property
     def _view_dtype(self):
@@ -509,52 +517,42 @@ class Model(ABC):
             Array of log-likelihood values
         """
         st = datetime.datetime.now()
-        if self.pool is None:
-            logger.debug("Not using pool to evaluate likelihood")
-            if self.allow_vectorised and self.vectorised_likelihood:
-                if self.likelihood_chunksize:
-                    log_likelihood = np.concatenate(
-                        list(
-                            map(
-                                self.log_likelihood,
-                                array_split_chunksize(
-                                    x, self.likelihood_chunksize
-                                ),
-                            )
-                        )
-                    )
-                else:
-                    log_likelihood = self.log_likelihood(x)
-            else:
-                log_likelihood = np.array(
-                    [self.log_likelihood(xx) for xx in x],
-                ).flatten()
-        else:
-            logger.debug("Using pool to evaluate likelihood")
-            if self.allow_vectorised and self.vectorised_likelihood:
-                if self.likelihood_chunksize:
-                    log_likelihood = np.concatenate(
-                        self.pool.map(
-                            log_likelihood_wrapper,
-                            array_split_chunksize(
-                                x, self.likelihood_chunksize
-                            ),
-                        )
-                    )
-                else:
-                    log_likelihood = np.concatenate(
-                        self.pool.map(
-                            log_likelihood_wrapper,
-                            np.array_split(x, self.n_pool),
-                        )
-                    )
-            else:
-                log_likelihood = np.array(
-                    self.pool.map(log_likelihood_wrapper, x)
-                ).flatten()
+        log_likelihood = batch_evaluate_function(
+            self.log_likelihood,
+            x,
+            self.allow_vectorised and self.vectorised_likelihood,
+            chunksize=self.likelihood_chunksize,
+            func_wrapper=log_likelihood_wrapper,
+            pool=self.pool,
+            n_pool=self.n_pool,
+        )
         self.likelihood_evaluations += x.size
         self.likelihood_evaluation_time += datetime.datetime.now() - st
         return log_likelihood.astype(config.livepoints.logl_dtype)
+
+    def batch_evaluate_log_prior(self, x):
+        """Evaluate the log-prior for a batch of samples.
+
+        Uses the pool if available.
+
+        Parameters
+        ----------
+        x : :obj:`numpy.ndarray`
+            Array of samples
+
+        Returns
+        -------
+        :obj:`numpy.ndarray`
+            Array of log-prior values
+        """
+        return batch_evaluate_function(
+            self.log_prior,
+            x,
+            self.vectorised_prior,
+            func_wrapper=log_prior_wrapper,
+            pool=self.pool,
+            n_pool=self.n_pool,
+        )
 
     def unstructured_view(self, x):
         """An unstructured view of point(s) x that only contains the \

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -100,6 +100,11 @@ class Model(ABC):
         recommended when the variation is significantly smaller that the
         variations in the likelihood across the prior.
     """
+    parallelise_prior = False
+    """
+    bool
+        Parallelise calculating the log-prior using the multiprocessing pool.
+    """
     _vectorised_likelihood = None
     _vectorised_prior = None
     _pool_configured = False
@@ -550,7 +555,7 @@ class Model(ABC):
             x,
             self.vectorised_prior,
             func_wrapper=log_prior_wrapper,
-            pool=self.pool,
+            pool=self.pool if self.parallelise_prior else None,
             n_pool=self.n_pool,
         )
 

--- a/nessai/proposal/analytic.py
+++ b/nessai/proposal/analytic.py
@@ -52,7 +52,9 @@ class AnalyticProposal(Proposal):
         if N is None:
             N = self.poolsize
         self.samples = self.model.new_point(N=N)
-        self.samples["logP"] = self.model.log_prior(self.samples)
+        self.samples["logP"] = self.model.batch_evaluate_log_prior(
+            self.samples
+        )
         self.indices = np.random.permutation(self.samples.shape[0]).tolist()
         self.samples["logL"] = self.model.batch_evaluate_log_likelihood(
             self.samples

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1170,11 +1170,11 @@ class FlowProposal(RejectionProposal):
             Array of log prior probabilities
         """
         if self._reparameterisation:
-            return self.model.log_prior(
+            return self.model.batch_evaluate_log_prior(
                 x
             ) + self._reparameterisation.log_prior(x)
         else:
-            return self.model.log_prior(x)
+            return self.model.batch_evaluate_log_prior(x)
 
     def x_prime_log_prior(self, x):
         """
@@ -1297,7 +1297,7 @@ class FlowProposal(RejectionProposal):
                 )
 
             x, _ = self.inverse_rescale(x)
-        x["logP"] = self.model.log_prior(x)
+        x["logP"] = self.model.batch_evaluate_log_prior(x)
         return rfn.repack_fields(
             x[self.model.names + config.livepoints.non_sampling_parameters]
         )

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -528,7 +528,7 @@ class ImportanceFlowProposal(Proposal):
             x["logQ"], log_q_all = self.compute_log_Q(
                 x_prime, log_q_current=None, n=n_weight, log_j=log_j
             )
-            x["logP"] = self.model.log_prior(x)
+            x["logP"] = self.model.batch_evaluate_log_prior(x)
             x["logW"] = -x["logQ"]
             accept = (
                 np.isfinite(x["logP"])
@@ -765,7 +765,7 @@ class ImportanceFlowProposal(Proposal):
         )
         logger.debug(f"Mean log_q for each each flow: {log_q.mean(axis=0)}")
 
-        samples["logP"] = self.model.log_prior(samples)
+        samples["logP"] = self.model.batch_evaluate_log_prior(samples)
         samples, log_q = get_subset_arrays(
             np.isfinite(samples["logP"]), samples, log_q
         )

--- a/nessai/proposal/rejection.py
+++ b/nessai/proposal/rejection.py
@@ -77,7 +77,7 @@ class RejectionProposal(AnalyticProposal):
         log_w : :obj:`numpy.ndarray`
             Array of log-weights rescaled such that the maximum value is zero.
         """
-        x["logP"] = self.model.log_prior(x)
+        x["logP"] = self.model.batch_evaluate_log_prior(x)
         log_q = self.log_proposal(x)
         log_w = x["logP"] - log_q
         log_w -= np.nanmax(log_w)

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -453,7 +453,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
                     self.model.names,
                 )
             )
-            points["logP"] = self.model.log_prior(points)
+            points["logP"] = self.model.batch_evaluate_log_prior(points)
             accept = np.isfinite(points["logP"])
             n_it = accept.sum()
             m = min(n_it, self.n_initial - n)

--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -5,6 +5,10 @@ Utilities related to multiprocessing.
 import logging
 import multiprocessing
 
+import numpy as np
+from nessai.utils.structures import array_split_chunksize
+from nessai.config import livepoints
+
 _model = None
 logger = logging.getLogger(__name__)
 
@@ -84,3 +88,128 @@ def log_likelihood_wrapper(x):
         Array of log-likelihoods.
     """
     return _model.log_likelihood(x)
+
+
+def log_prior_wrapper(x):
+    """Wrapper for the log-prior for use with multiprocessing.
+
+    Should be used alongside
+    :py:func:`nessai.utils.multiprocessing.initialise_pool_variables`
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray`
+        Array of samples.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Array of log-prior values.
+    """
+    return _model.log_prior(x)
+
+
+def batch_evaluate_function(
+    func,
+    x,
+    vectorised,
+    chunksize=None,
+    pool=None,
+    n_pool=None,
+    func_wrapper=None,
+):
+    """Evaluate a function over a batch of inputs.
+
+    Parameters
+    ----------
+    func : Callable
+        The function to evaluate.
+    x : numpy.ndarray
+        The values over which to evaluate the function.
+    vectorised : bool
+        Boolean to indicate if the function is vectorised or not.
+    chunksize : Optional[int]
+        Maximum number of inputs that will be passed to the function at once.
+        Only applies if the function is vectorised.
+    pool : Optional[multiprocessing.Pool]
+        Multiprocessing pool used to evaluate the function.
+    n_pool : Optional[int]
+        Number of cores in the multiprocessing. Determines how values are split
+        when calling :code:`Pool.map`.
+    func_wrapper : Optional[Callable]
+        Wrapper to the function to use instead of the function when using the
+        pool.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of outputs
+    """
+    if pool is None:
+        if vectorised:
+            if chunksize:
+                out = np.concatenate(
+                    list(map(func, array_split_chunksize(x, chunksize)))
+                )
+            else:
+                out = func(x)
+        else:
+            out = np.array(
+                [func(xx) for xx in x],
+            ).flatten()
+    else:
+        if func_wrapper is None:
+            func_wrapper = func
+        if vectorised:
+            if chunksize:
+                out = np.concatenate(
+                    pool.map(func_wrapper, array_split_chunksize(x, chunksize))
+                )
+            else:
+                out = np.concatenate(
+                    pool.map(func_wrapper, np.array_split(x, n_pool))
+                )
+        else:
+            out = np.array(pool.map(func_wrapper, x)).flatten()
+    return out
+
+
+def check_vectorised_function(func, x, dtype=None):
+    """Check if a function is vectorised given a set of inputs.
+
+    Parameters
+    ----------
+    func : Callable
+        Function to test
+    x : numpy.ndarray
+        Inputs over which to evaluate the function
+    dtype :  Optional[Union[str, numpy.dtype]]
+        Dtype to cast the results to. If not specified, the default dtype
+        for livepoints is used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of outputs
+    """
+    if dtype is None:
+        dtype = livepoints.default_float_dtype
+    if len(x) <= 1:
+        raise ValueError("Input has length <= 1")
+
+    target = np.array([func(xx) for xx in x], dtype=dtype)
+
+    try:
+        batch = func(x).astype(dtype)
+    except (TypeError, ValueError, AttributeError):
+        logger.debug("Assuming function is not vectorised")
+        return False
+    else:
+        if np.array_equal(target, batch):
+            logger.debug("Function is vectorised")
+            return True
+        else:
+            logger.debug("Individual and batch likelihoods are not equal")
+            logger.debug(f"Individual: {target}")
+            logger.debug(f"Batch: {batch}")
+            return False

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -192,6 +192,27 @@ def test_allow_multi_valued_likelihood(flow_sampler, tmp_path):
     assert input_integration_model.allow_multi_valued_likelihood is True
 
 
+@pytest.mark.parametrize("value", [False, True])
+def test_parallelise_prior(flow_sampler, tmp_path, value):
+    """Assert parallise_prior is the correct value"""
+    output = tmp_path / "test"
+    output.mkdir()
+
+    integration_model = MagicMock()
+    integration_model.parallelise_prior = None
+
+    with patch("nessai.flowsampler.NestedSampler") as mock:
+        FlowSampler.__init__(
+            flow_sampler,
+            integration_model,
+            output=output,
+            parallelise_prior=value,
+        )
+    mock.assert_called_once()
+    input_integration_model = mock.call_args[0][0]
+    assert input_integration_model.parallelise_prior is value
+
+
 @pytest.mark.parametrize(
     "test_old, error",
     [(False, None), (True, RuntimeError), (True, FileNotFoundError)],

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -234,6 +234,28 @@ def test_vectorised_likelihood_setter(model):
     assert model._vectorised_likelihood == "test"
 
 
+@pytest.mark.parametrize("check_value", [True, False])
+@pytest.mark.parametrize("allow_vectorised", [True, False])
+def test_vectorised_log_prior(model, check_value, allow_vectorised):
+
+    model._vectorised_prior = None
+    model.allow_vectorised_prior = allow_vectorised
+
+    with patch(
+        "nessai.model.check_vectorised_function", return_value=check_value
+    ):
+        out = Model.vectorised_prior.__get__(model)
+
+    assert out is (check_value and allow_vectorised)
+    assert model._vectorised_prior is (check_value and allow_vectorised)
+
+
+def test_vectorised_prior_setter(model):
+    """Assert the setter sets the correct value"""
+    Model.vectorised_prior.__set__(model, "test")
+    assert model._vectorised_prior == "test"
+
+
 def test_in_bounds(model):
     """Test the `in_bounds` method.
 

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -48,7 +48,7 @@ def test_populate(proposal, N):
     proposal.poolsize = poolsize
     proposal.model = Mock()
     proposal.model.new_point = Mock(return_value=samples)
-    proposal.model.batch_evalute_log_prior = Mock(return_value=log_p)
+    proposal.model.batch_evaluate_log_prior = Mock(return_value=log_p)
     proposal.model.batch_evaluate_log_likelihood = MagicMock(
         return_value=log_l
     )

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -48,7 +48,7 @@ def test_populate(proposal, N):
     proposal.poolsize = poolsize
     proposal.model = Mock()
     proposal.model.new_point = Mock(return_value=samples)
-    proposal.model.log_prior = Mock(return_value=log_p)
+    proposal.model.batch_evalute_log_prior = Mock(return_value=log_p)
     proposal.model.batch_evaluate_log_likelihood = MagicMock(
         return_value=log_l
     )
@@ -57,7 +57,7 @@ def test_populate(proposal, N):
     if N is None:
         N = poolsize
     proposal.model.new_point.assert_called_once_with(N=N)
-    proposal.model.log_prior.assert_called_once_with(samples)
+    proposal.model.batch_evaluate_log_prior.assert_called_once_with(samples)
     proposal.model.batch_evaluate_log_likelihood.assert_called_once_with(
         proposal.samples
     )

--- a/tests/test_proposal/test_rejection.py
+++ b/tests/test_proposal/test_rejection.py
@@ -57,12 +57,14 @@ def test_compute_weights(proposal):
     """Test the compute weights method"""
     x = numpy_array_to_live_points(np.array([[1], [2], [3]]), "x")
     proposal.model = Mock()
-    proposal.model.log_prior = Mock(return_value=np.array([6, 6, 6]))
+    proposal.model.batch_evaluate_log_prior = Mock(
+        return_value=np.array([6, 6, 6])
+    )
     proposal.log_proposal = Mock(return_value=np.array([3, 4, np.nan]))
     log_w = np.array([0, -1, np.nan])
     out = RejectionProposal.compute_weights(proposal, x)
 
-    proposal.model.log_prior.assert_called_once_with(x)
+    proposal.model.batch_evaluate_log_prior.assert_called_once_with(x)
     proposal.log_proposal.assert_called_once_with(x)
     np.testing.assert_array_equal(out, log_w)
 

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -172,8 +172,13 @@ def test_sampling_uninformed(integration_model, flow_config, tmpdir, analytic):
 
 
 @pytest.mark.slow_integration_test
+@pytest.mark.parametrize("parallelise_prior", [True, False])
 def test_sampling_with_n_pool(
-    integration_model, flow_config, tmpdir, mp_context
+    integration_model,
+    flow_config,
+    tmpdir,
+    mp_context,
+    parallelise_prior,
 ):
     """
     Test running the sampler with multiprocessing.
@@ -198,6 +203,7 @@ def test_sampling_with_n_pool(
             poolsize=10,
             pytorch_threads=2,
             n_pool=2,
+            parallelise_prior=parallelise_prior,
         )
     fp.run()
     assert fp.ns.proposal.flow.weights_file is not None


### PR DESCRIPTION
Enable the use of non-vectorised log-prior functions in the `Model` class.

This also allows the use of the multiprocessing pool for evaluating the prior

**Changes**

* Implement `batch_evaluate_function` and `check_vectorised_function`
* Replace the existing logic for the log-likelihood with the above functions
* Include a `batch_evaluate_log_prior` similar to the existing function for the likelihood
* Switch to using `batch_evaluate_log_prior` throughout the code.


**To-do**

- [x] Option to disable pool for the prior
- [x] Check existing unit tests
- [x] End-to-end testing 