### PR TITLE
Fix close_pool bug

### DIFF
--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -173,7 +173,7 @@ class FlowSampler:
                     model,
                     output=self.output,
                     resume_file=resume_file,
-                    close_pool=not self.close_pool,
+                    close_pool=False,
                     **kwargs,
                 )
             else:
@@ -210,7 +210,7 @@ class FlowSampler:
                 model,
                 output=self.output,
                 resume_file=resume_file,
-                close_pool=not self.close_pool,
+                close_pool=False,
                 **kwargs,
             )
 


### PR DESCRIPTION
Fix a bug where the pool was being closed even when `close_pool=False` .

The nested sampler class should never close the pool when being run through `FlowSampler` so this is now hard coded to False.