### PR TITLE
Refactor settings utils

### DIFF
--- a/nessai/utils/bilbyutils.py
+++ b/nessai/utils/bilbyutils.py
@@ -2,93 +2,12 @@
 """
 Utilities to make interfacing with bilby easier.
 """
-from inspect import signature
-from typing import List, Callable
+from warnings import warn
 
+from .settings import get_all_kwargs, get_run_kwargs_list  # noqa
 
-def _get_standard_methods() -> List[Callable]:
-    """Get a list of the methods used by the standard sampler"""
-    from ..flowsampler import FlowSampler
-    from ..proposal import AugmentedFlowProposal, FlowProposal
-    from ..samplers import NestedSampler
-
-    methods = [
-        FlowSampler.run_standard_sampler,
-        AugmentedFlowProposal,
-        FlowProposal,
-        NestedSampler,
-        FlowSampler,
-    ]
-    return methods
-
-
-def _get_importance_methods() -> list:
-    """Get a list of the methods used by the importance nested sampler"""
-    from ..flowsampler import FlowSampler
-    from ..proposal.importance import ImportanceFlowProposal
-    from ..samplers import ImportanceNestedSampler
-
-    methods = [
-        FlowSampler.run_importance_nested_sampler,
-        ImportanceFlowProposal,
-        ImportanceNestedSampler,
-        FlowSampler,
-    ]
-    return methods
-
-
-def get_all_kwargs(importance_nested_sampler: bool = False) -> dict:
-    """Get a dictionary of all possible kwargs and their default values.
-
-    Parameters
-    ----------
-    importance_nested_sampler
-        Indicates whether the importance nested sampler will be used or not.
-        Defaults to :code:`False` for backwards compatibility.
-
-    Returns
-    -------
-    Dictionary of kwargs and their default values.
-    """
-    if importance_nested_sampler:
-        methods = _get_importance_methods()
-    else:
-        methods = _get_standard_methods()
-
-    kwargs = {}
-    for m in methods:
-        kwargs.update(
-            {
-                k: v.default
-                for k, v in signature(m).parameters.items()
-                if v.default is not v.empty
-            }
-        )
-    return kwargs
-
-
-def get_run_kwargs_list(importance_nested_sampler: bool = False) -> List[str]:
-    """Get a list of kwargs used in the run method
-
-    Parameters
-    ----------
-    importance_nested_sampler
-        Indicates whether the importance nested sampler will be used or not.
-        Defaults to :code:`False` for backwards compatibility.
-
-    Returns
-    -------
-    List of kwargs.
-    """
-    from ..flowsampler import FlowSampler
-
-    if importance_nested_sampler:
-        method = FlowSampler.run_importance_nested_sampler
-    else:
-        method = FlowSampler.run_standard_sampler
-    run_kwargs_list = [
-        k
-        for k, v in signature(method).parameters.items()
-        if v.default is not v.empty
-    ]
-    return run_kwargs_list
+msg = (
+    "`nessai.utils.bilbyutils` is deprecated and will be removed in a future "
+    "release. Use `nessai.utils.settings` instead."
+)
+warn(msg, FutureWarning)

--- a/nessai/utils/settings.py
+++ b/nessai/utils/settings.py
@@ -1,0 +1,117 @@
+"""Utilities for determing the settings available in nessai.
+
+Used for bilby and pycbc-inference.
+"""
+from inspect import signature
+from typing import List, Callable, Tuple
+
+
+def _get_standard_methods() -> Tuple[List[Callable], List[Callable]]:
+    """Get a list of the methods used by the standard sampler and the run
+    method.
+    """
+    from ..flowsampler import FlowSampler
+    from ..proposal import AugmentedFlowProposal, FlowProposal
+    from ..samplers import NestedSampler
+
+    methods = [
+        AugmentedFlowProposal,
+        FlowProposal,
+        NestedSampler,
+        FlowSampler,
+    ]
+    run_methods = [
+        FlowSampler.run_standard_sampler,
+    ]
+    return methods, run_methods
+
+
+def _get_importance_methods() -> Tuple[List[Callable], List[Callable]]:
+    """Get a list of the methods used by the importance nested sampler and by
+    the run method.
+    """
+    from ..flowsampler import FlowSampler
+    from ..proposal.importance import ImportanceFlowProposal
+    from ..samplers import ImportanceNestedSampler
+
+    methods = [
+        ImportanceFlowProposal,
+        ImportanceNestedSampler,
+        FlowSampler,
+    ]
+    run_methods = [
+        FlowSampler.run_importance_nested_sampler,
+    ]
+    return methods, run_methods
+
+
+def get_all_kwargs(
+    importance_nested_sampler: bool = False,
+    split_kwargs: bool = False,
+) -> dict:
+    """Get a dictionary of all possible kwargs and their default values.
+
+    Parameters
+    ----------
+    importance_nested_sampler
+        Indicates whether the importance nested sampler will be used or not.
+        Defaults to :code:`False` for backwards compatibility.
+    split_kwargs
+        If True, the kwards are split into kwargs passed to :code:`FlowSampler`
+        and those passes to :code:`FlowSampler.run`. If False, all kwargs are
+        return in a single dictionary.
+
+    Returns
+    -------
+    Dictionary of kwargs and their default values.
+    """
+    if importance_nested_sampler:
+        methods, run_methods = _get_importance_methods()
+    else:
+        methods, run_methods = _get_standard_methods()
+
+
+    kwargs = {}
+    run_kwargs = {}
+    for kwds, methods in zip([kwargs, run_kwargs], [methods, run_methods]):
+        for m in methods:
+            kwds.update(
+                {
+                    k: v.default
+                    for k, v in signature(m).parameters.items()
+                    if v.default is not v.empty
+                }
+            )
+
+    if split_kwargs:
+        return kwargs, run_kwargs
+    else:
+        kwargs.update(run_kwargs)
+        return kwargs
+
+
+def get_run_kwargs_list(importance_nested_sampler: bool = False) -> List[str]:
+    """Get a list of kwargs used in the run method
+
+    Parameters
+    ----------
+    importance_nested_sampler
+        Indicates whether the importance nested sampler will be used or not.
+        Defaults to :code:`False` for backwards compatibility.
+
+    Returns
+    -------
+    List of kwargs.
+    """
+    from ..flowsampler import FlowSampler
+
+    if importance_nested_sampler:
+        method = FlowSampler.run_importance_nested_sampler
+    else:
+        method = FlowSampler.run_standard_sampler
+    run_kwargs_list = [
+        k
+        for k, v in signature(method).parameters.items()
+        if v.default is not v.empty
+    ]
+    return run_kwargs_list

--- a/nessai/utils/settings.py
+++ b/nessai/utils/settings.py
@@ -70,7 +70,6 @@ def get_all_kwargs(
     else:
         methods, run_methods = _get_standard_methods()
 
-
     kwargs = {}
     run_kwargs = {}
     for kwds, methods in zip([kwargs, run_kwargs], [methods, run_methods]):

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -27,3 +27,11 @@ def test_lulinear_warning():
     assert "`nessai.flows.transforms.LULinear` is deprecated" in str(
         record[0].message
     )
+
+
+def test_bilbyutils_warning():
+    """Assert a warning is raised if bilbyutils is imported"""
+    with pytest.warns(
+        FutureWarning, match=r"`nessai.utils.bilbyutils` is deprecated"
+    ):
+        from nessai.utils.bilbyutils import get_all_kwargs  # noqa

--- a/tests/test_utils/test_settings.py
+++ b/tests/test_utils/test_settings.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-Tests for bilbyutils
+Tests for settings utilities.
 """
 from unittest.mock import patch
 
 import pytest
 from nessai.flowsampler import FlowSampler
-from nessai.utils.bilbyutils import (
+from nessai.utils.settings import (
     get_all_kwargs,
     get_run_kwargs_list,
     _get_importance_methods,
@@ -16,14 +16,16 @@ from nessai.utils.bilbyutils import (
 
 def test_get_standard_methods():
     """Assert a list of methods is returned"""
-    out = _get_standard_methods()
-    assert len(out) == 5
+    kwds, run = _get_standard_methods()
+    assert len(kwds) == 4
+    assert len(run) == 1
 
 
 def test_get_importance_methods():
     """Assert a list of methods is returned"""
-    out = _get_importance_methods()
-    assert len(out) == 4
+    kwds, run = _get_importance_methods()
+    assert len(kwds) == 3
+    assert len(run) == 1
 
 
 @pytest.mark.parametrize(
@@ -45,10 +47,37 @@ def test_get_all_kwargs(ins, get_method):
     expected = dict(c=2, d=None, g=3, h=True)
 
     with patch(
-        f"nessai.utils.bilbyutils.{get_method}",
-        return_value=[func0, func1],
+        f"nessai.utils.settings.{get_method}",
+        return_value=[[func0,], [func1,]],
     ):
-        out = get_all_kwargs(importance_nested_sampler=ins)
+        out = get_all_kwargs(importance_nested_sampler=ins, split_kwargs=False)
+
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "ins, get_method",
+    [(False, "_get_standard_methods"), (True, "_get_importance_methods")],
+)
+def test_get_all_kwargs_split(ins, get_method):
+    """Assert the correct dictionary is returned.
+
+    Positional arguments should be ignored.
+    """
+
+    def func0(a, b, c=2, d=None):
+        pass
+
+    def func1(e, f, g=3, h=True):
+        pass
+
+    expected = (dict(c=2, d=None), dict(g=3, h=True))
+
+    with patch(
+        f"nessai.utils.settings.{get_method}",
+        return_value=[[func0,], [func1,]],
+    ):
+        out = get_all_kwargs(importance_nested_sampler=ins, split_kwargs=True)
 
     assert out == expected
 
@@ -69,3 +98,4 @@ def test_get_run_kwargs_list(ins, run_method):
         out = get_run_kwargs_list(importance_nested_sampler=ins)
 
     assert out == expected
+

--- a/tests/test_utils/test_settings.py
+++ b/tests/test_utils/test_settings.py
@@ -48,7 +48,14 @@ def test_get_all_kwargs(ins, get_method):
 
     with patch(
         f"nessai.utils.settings.{get_method}",
-        return_value=[[func0,], [func1,]],
+        return_value=[
+            [
+                func0,
+            ],
+            [
+                func1,
+            ],
+        ],
     ):
         out = get_all_kwargs(importance_nested_sampler=ins, split_kwargs=False)
 
@@ -75,7 +82,14 @@ def test_get_all_kwargs_split(ins, get_method):
 
     with patch(
         f"nessai.utils.settings.{get_method}",
-        return_value=[[func0,], [func1,]],
+        return_value=[
+            [
+                func0,
+            ],
+            [
+                func1,
+            ],
+        ],
     ):
         out = get_all_kwargs(importance_nested_sampler=ins, split_kwargs=True)
 
@@ -98,4 +112,3 @@ def test_get_run_kwargs_list(ins, run_method):
         out = get_run_kwargs_list(importance_nested_sampler=ins)
 
     assert out == expected
-


### PR DESCRIPTION
Rename `bilbyutils` to `settings` and add functionality that will make integration with pycbc inference easier.

The main addition is the option to return the keyword arguments for the run function separately rather than altogether.


**To-do**

- [ ] Test for deprecation warning