### PR TITLE
Add option to resume from data

### DIFF
--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -202,14 +202,14 @@ class FlowSampler:
     def check_resume(self, resume_file, resume_data):
         """Check if it is possible to resume the sampler"""
         return (
-            any(
+            resume_file
+            and any(
                 (
                     os.path.exists(os.path.join(self.output, f))
                     for f in [resume_file, resume_file + ".old"]
                 )
             )
-            or resume_data is not None
-        )
+        ) or resume_data is not None
 
     def _resume_from_file(
         self,

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -177,6 +177,7 @@ class FlowSampler:
                     flow_config=kwargs.get("flow_config"),
                 )
         else:
+            logger.debug("Not resuming sampler")
             self.ns = SamplerClass(
                 model,
                 output=self.output,
@@ -218,6 +219,7 @@ class FlowSampler:
         weights_path,
         flow_config,
     ):
+        logger.info(f"Trying to resume sampler from {resume_file}")
         try:
             ns = SamplerClass.resume(
                 os.path.join(self.output, resume_file),
@@ -255,6 +257,7 @@ class FlowSampler:
         weights_path,
         flow_config,
     ):
+        logger.info("Trying to resume sampler from `resume_data`")
         return SamplerClass.resume_from_pickled_sampler(
             resume_data,
             model,

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -171,8 +171,8 @@ class FlowSampler:
             else:
                 self.ns = self._resume_from_file(
                     SamplerClass,
-                    resume_file=resume_file,
                     model=model,
+                    resume_file=resume_file,
                     weights_path=weights_path,
                     flow_config=kwargs.get("flow_config"),
                 )
@@ -214,8 +214,8 @@ class FlowSampler:
     def _resume_from_file(
         self,
         SamplerClass,
-        model,
         resume_file,
+        model,
         weights_path,
         flow_config,
     ):

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1898,29 +1898,31 @@ class ImportanceNestedSampler(BaseNestedSampler):
         return d
 
     @classmethod
-    def resume(cls, filename, model, flow_config=None, weights_path=None):
-        """
-        Resumes the interrupted state from a checkpoint pickle file.
+    def resume_from_pickled_sampler(
+        cls, sampler, model, flow_config=None, weights_path=None
+    ):
+        """Resume from a pickled sampler.
 
         Parameters
         ----------
-        filename : str
-            Pickle pickle to resume from
+        sampler : Any
+            Pickled sampler.
         model : :obj:`nessai.model.Model`
             User-defined model
-        flow_config : dict, optional
+        flow_config : Optional[dict]
             Dictionary for configuring the flow
-        weights_path : str, optional
+        weights_path : Optional[dict]
             Path to the weights files that will override the value stored in
             the proposal.
 
         Returns
         -------
-        obj
-            Instance of ImportanceNestedSampler
+        Instance of ImportanceNestedSampler
         """
         cls.add_fields()
-        obj = super().resume(filename, model)
+        obj = super(ImportanceNestedSampler, cls).resume_from_pickled_sampler(
+            sampler, model
+        )
         if flow_config is None:
             flow_config = {}
         obj.proposal.resume(model, flow_config, weights_path=weights_path)

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -1341,28 +1341,30 @@ class NestedSampler(BaseNestedSampler):
         return d
 
     @classmethod
-    def resume(cls, filename, model, flow_config=None, weights_path=None):
-        """
-        Resumes the interrupted state from a checkpoint pickle file.
+    def resume_from_pickled_sampler(
+        cls, sampler, model, flow_config=None, weights_path=None
+    ):
+        """Resume from a pickled sampler.
 
         Parameters
         ----------
-        filename : str
-            Pickle pickle to resume from
+        sampler: Any
+            Pickled sampler.
         model : :obj:`nessai.model.Model`
             User-defined model
-        flow_config : dict, optional
+        flow_config : Optional[dict]
             Dictionary for configuring the flow
-        weights_path : str, optional
+        weights_path : Optional[str]
             Weights file to use in place of the weights file stored in the
             pickle file.
 
         Returns
         -------
-        obj
-            Instance of NestedSampler
+        Instance of NestedSampler
         """
-        obj = super().resume(filename, model)
+        obj = super(NestedSampler, cls).resume_from_pickled_sampler(
+            sampler, model
+        )
         obj._uninformed_proposal.resume(model)
         if flow_config is None:
             flow_config = {}

--- a/nessai/utils/testing.py
+++ b/nessai/utils/testing.py
@@ -23,6 +23,18 @@ class IntegrationTestModel(Model):
     def log_likelihood(self, x):
         return np.sum(-0.5 * (self.unstructured_view(x) ** 2), axis=-1)
 
+    def to_unit_hypercube(self, x):
+        x_out = x.copy()
+        for n in self.names:
+            x_out[n] = (x[n] - self.bounds[n][0]) / np.ptp(self.bounds[n])
+        return x_out
+
+    def from_unit_hypercube(self, x):
+        x_out = x.copy()
+        for n in self.names:
+            x_out[n] = np.ptp(self.bounds[n]) * x[n] + self.bounds[n][0]
+        return x_out
+
 
 def assert_structured_arrays_equal(x, y, atol=0.0, rtol=0.0):
     """Assert structured arrays are equal.

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -3,7 +3,9 @@
 Tests for the FlowSampler class.
 """
 import json
+import logging
 import os
+import pickle
 import signal
 import sys
 import time
@@ -16,6 +18,7 @@ import pytest
 from nessai import config as nessai_config
 from nessai.evidence import _NSIntegralState
 from nessai.flowsampler import FlowSampler
+from nessai.samplers import NestedSampler
 from nessai.livepoint import numpy_array_to_live_points
 import numpy as np
 
@@ -55,6 +58,58 @@ def nested_samples(names):
     return numpy_array_to_live_points(np.random.randn(20, len(names)), names)
 
 
+def test_nested_samples_final(flow_sampler):
+    flow_sampler._final_samples = [
+        1,
+    ]
+    flow_sampler._nested_samples = [
+        2,
+    ]
+    assert (
+        FlowSampler.nested_samples.__get__(flow_sampler)
+        is flow_sampler._final_samples
+    )
+
+
+def test_nested_samples_ns(flow_sampler):
+    flow_sampler._final_samples = None
+    flow_sampler._nested_samples = [
+        2,
+    ]
+    assert (
+        FlowSampler.nested_samples.__get__(flow_sampler)
+        is flow_sampler._nested_samples
+    )
+
+
+def test_check_resume_data_only(flow_sampler):
+    assert (
+        FlowSampler.check_resume(
+            flow_sampler, resume_file=None, resume_data=object()
+        )
+        is True
+    )
+
+
+def test_check_resume_neither(flow_sampler):
+    assert (
+        FlowSampler.check_resume(
+            flow_sampler, resume_file=None, resume_data=None
+        )
+        is False
+    )
+
+
+def test_check_resume_files_do_not_exist(flow_sampler, tmp_path):
+    flow_sampler.output = tmp_path / "test"
+    assert (
+        FlowSampler.check_resume(
+            flow_sampler, resume_file="test.pkl", resume_data=None
+        )
+        is False
+    )
+
+
 @pytest.mark.parametrize("resume", [False, True])
 @pytest.mark.parametrize("use_ins", [False, True])
 def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
@@ -76,6 +131,7 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
     sampler_class = "ImportanceNestedSampler" if use_ins else "NestedSampler"
 
     flow_sampler.save_kwargs = MagicMock()
+    flow_sampler.check_resume = MagicMock(return_value=False)
 
     with patch(
         f"nessai.flowsampler.{sampler_class}", return_value="ns"
@@ -111,7 +167,48 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
     flow_sampler.save_kwargs.assert_called_once_with(kwargs)
 
 
-def test_init_eps(tmp_path):
+def test_resume_from_resume_data(flow_sampler, model, tmp_path):
+    """Test for resume from data"""
+    output = tmp_path / "test"
+    data = object()
+    flow_sampler.check_resume = MagicMock(return_value=True)
+    flow_sampler._resume_from_data = MagicMock()
+    FlowSampler.__init__(
+        flow_sampler, model, output=output, resume_data=data, resume=True
+    )
+    flow_sampler._resume_from_data.assert_called_once_with(
+        NestedSampler,
+        resume_data=data,
+        model=model,
+        weights_path=None,
+        flow_config=None,
+    )
+
+
+def test_resume_from_resume_file(flow_sampler, model, tmp_path):
+    """Test for resume from data"""
+    output = tmp_path / "test"
+    resume_file = "resume.pkl"
+    flow_sampler.check_resume = MagicMock(return_value=True)
+    flow_sampler._resume_from_file = MagicMock()
+    FlowSampler.__init__(
+        flow_sampler,
+        model,
+        output=output,
+        resume_data=None,
+        resume=True,
+        resume_file=resume_file,
+    )
+    flow_sampler._resume_from_file.assert_called_once_with(
+        NestedSampler,
+        resume_file=resume_file,
+        model=model,
+        weights_path=None,
+        flow_config=None,
+    )
+
+
+def test_init_eps(flow_sampler, tmp_path):
     initial_eps = nessai_config.general.eps
 
     model = MagicMock()
@@ -139,6 +236,7 @@ def test_disable_vectorisation(flow_sampler, tmp_path):
 
     integration_model = MagicMock()
     integration_model.allow_vectorised = True
+    flow_sampler.check_resume = MagicMock(return_value=False)
 
     with patch("nessai.flowsampler.NestedSampler") as mock:
         FlowSampler.__init__(
@@ -159,6 +257,7 @@ def test_likelihood_chunksize(flow_sampler, tmp_path):
 
     integration_model = MagicMock()
     integration_model.likelihood_chunksize = None
+    flow_sampler.check_resume = MagicMock(return_value=False)
 
     with patch("nessai.flowsampler.NestedSampler") as mock:
         FlowSampler.__init__(
@@ -179,6 +278,7 @@ def test_allow_multi_valued_likelihood(flow_sampler, tmp_path):
 
     integration_model = MagicMock()
     integration_model.allow_multi_value_likelihood = False
+    flow_sampler.check_resume = MagicMock(return_value=False)
 
     with patch("nessai.flowsampler.NestedSampler") as mock:
         FlowSampler.__init__(
@@ -200,6 +300,7 @@ def test_parallelise_prior(flow_sampler, tmp_path, value):
 
     integration_model = MagicMock()
     integration_model.parallelise_prior = None
+    flow_sampler.check_resume = MagicMock(return_value=False)
 
     with patch("nessai.flowsampler.NestedSampler") as mock:
         FlowSampler.__init__(
@@ -217,7 +318,8 @@ def test_parallelise_prior(flow_sampler, tmp_path, value):
     "test_old, error",
     [(False, None), (True, RuntimeError), (True, FileNotFoundError)],
 )
-def test_init_resume(flow_sampler, tmp_path, test_old, error):
+@pytest.mark.integration_test
+def test_init_resume(tmp_path, test_old, error):
     """Test the init method when the sampler should resume.
 
     Tests the case where the first file works and the case where the first
@@ -249,15 +351,12 @@ def test_init_resume(flow_sampler, tmp_path, test_old, error):
         flow_config=flow_config,
     )
 
-    flow_sampler.save_kwargs = MagicMock()
-
     with patch(
         "nessai.flowsampler.NestedSampler.resume", side_effect=side_effect
     ) as mock_resume, patch(
         "nessai.flowsampler.configure_threads"
     ) as mock_threads:
-        FlowSampler.__init__(
-            flow_sampler,
+        fs = FlowSampler(
             integration_model,
             output=output,
             resume=resume,
@@ -280,9 +379,7 @@ def test_init_resume(flow_sampler, tmp_path, test_old, error):
         weights_path=weights_file,
     )
 
-    assert flow_sampler.ns == "ns"
-
-    flow_sampler.save_kwargs.assert_called_once_with(kwargs)
+    assert fs.ns == "ns"
 
 
 def test_init_resume_error_cannot_resume(flow_sampler, tmp_path):
@@ -290,7 +387,6 @@ def test_init_resume_error_cannot_resume(flow_sampler, tmp_path):
     integration_model = MagicMock()
     output = tmp_path / "test"
     output.mkdir()
-    resume = True
     resume_file = "test.pkl"
     expected_rf = output / (resume_file + ".old")
     expected_rf.write_text("contents")
@@ -300,20 +396,51 @@ def test_init_resume_error_cannot_resume(flow_sampler, tmp_path):
 
     assert os.path.exists(expected_rf)
 
+    flow_sampler.output = output
+
     with patch(
         "nessai.flowsampler.NestedSampler.resume", side_effect=side_effect
     ), patch("nessai.flowsampler.configure_threads"), pytest.raises(
-        RuntimeError
-    ) as excinfo:
-        FlowSampler.__init__(
+        RuntimeError, match=r"Could not resume sampler with error:"
+    ):
+        FlowSampler._resume_from_file(
             flow_sampler,
+            NestedSampler,
             integration_model,
-            output=output,
-            resume=resume,
-            resume_file=resume_file,
+            resume_file,
+            weights_path=None,
             flow_config=None,
         )
-    assert "Could not resume sampler with error: " in str(excinfo.value)
+
+
+@pytest.mark.integration_test
+def test_init_cannot_resume_integration(tmp_path, integration_model):
+    """Integration test for invalid resume files"""
+    output = tmp_path / "test"
+    output.mkdir()
+    resume_file = "test.pkl"
+    expected_rf = output / (resume_file + ".old")
+    expected_rf.write_text("contents")
+    side_effect = [RuntimeError, RuntimeError]
+    output = str(output)
+    expected_rf = str(expected_rf)
+
+    assert os.path.exists(expected_rf)
+
+    flow_sampler.output = output
+
+    with patch(
+        "nessai.flowsampler.NestedSampler.resume", side_effect=side_effect
+    ), pytest.raises(
+        RuntimeError, match=r"Could not resume sampler with error"
+    ):
+        FlowSampler(
+            integration_model,
+            output=output,
+            resume_file=resume_file,
+            resume_data=None,
+            resume=True,
+        )
 
 
 def test_init_resume_error_no_file(flow_sampler, tmp_path):
@@ -323,11 +450,13 @@ def test_init_resume_error_no_file(flow_sampler, tmp_path):
     integration_model = MagicMock()
     output = tmp_path / "test"
     output.mkdir()
-    output = str(output)
+    output = str(output)  #
 
-    with patch("nessai.flowsampler.configure_threads"), pytest.raises(
-        RuntimeError
-    ) as excinfo:
+    flow_sampler.check_resume = MagicMock(return_value=False)
+
+    with patch("nessai.flowsampler.configure_threads"), patch(
+        "nessai.flowsampler.NestedSampler"
+    ) as mock_init:
         FlowSampler.__init__(
             flow_sampler,
             integration_model,
@@ -335,7 +464,28 @@ def test_init_resume_error_no_file(flow_sampler, tmp_path):
             resume=True,
             resume_file=None,
         )
-    assert "`resume_file` must be specified" in str(excinfo.value)
+
+    mock_init.assert_called_once()
+
+
+def test_resume_from_data(flow_sampler, model):
+    """Test the resume from data method"""
+    data = MagicMock()
+    SamplerClass = MagicMock()
+    weights_path = "test.pkl"
+    flow_config = {"n_neurons": 24}
+    FlowSampler._resume_from_data(
+        flow_sampler,
+        SamplerClass,
+        data,
+        model,
+        weights_path,
+        flow_config,
+    )
+
+    SamplerClass.resume_from_pickled_sampler.assert_called_once_with(
+        data, model, weights_path=weights_path, flow_config=flow_config
+    )
 
 
 def test_init_signal_handling_enabled(flow_sampler, tmp_path):
@@ -563,11 +713,12 @@ def test_run_standard_plots_disabled(flow_sampler):
     flow_sampler.state.plot.assert_not_called()
 
 
-def test_run_ins(flow_sampler):
+@pytest.mark.parametrize("close_pool", [False, True])
+def test_run_ins(flow_sampler, close_pool):
     """Test running the importance nested sampler"""
     flow_sampler.importance_nested_sampler = True
 
-    flow_sampler.close_pool = False
+    flow_sampler.close_pool = close_pool
     logZ = 0.0
     logZ_err = 0.1
     nested_samples = np.array([1, 2, 3])
@@ -576,6 +727,7 @@ def test_run_ins(flow_sampler):
     ns.nested_sampling_loop = MagicMock(return_value=(logZ, nested_samples))
     ns.state.log_evidence_error = logZ_err
     ns.draw_posterior_samples = MagicMock(return_value=post)
+    ns.close_pool = MagicMock()
     flow_sampler.ns = ns
 
     FlowSampler.run_importance_nested_sampler(
@@ -591,6 +743,8 @@ def test_run_ins(flow_sampler):
     assert flow_sampler.logZ_error is logZ_err
     assert flow_sampler.initial_posterior_samples is post
     assert flow_sampler.posterior_samples is post
+    if close_pool:
+        ns.close_pool.assert_called_once()
 
 
 def test_run_ins_redraw(flow_sampler):
@@ -888,3 +1042,49 @@ def test_save_results_integration(
     np.testing.assert_array_equal(
         out["posterior_samples"]["x"], posterior_samples["x"]
     )
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize("ins", [True, False])
+def test_resume_from_data_integration(
+    integration_model, tmp_path, caplog, ins
+):
+    output = tmp_path / "test"
+
+    caplog.set_level(logging.INFO)
+
+    kwargs = {}
+    if ins:
+        kwargs["min_samples"] = 1
+
+    fs = FlowSampler(
+        integration_model,
+        nlive=10,
+        output=output,
+        max_iteration=5,
+        checkpointing=False,
+        resume_file=None,
+        importance_nested_sampler=ins,
+        **kwargs,
+    )
+    fs.run()
+
+    pickled_sampler = pickle.dumps(fs.ns)
+    resume_data = pickle.loads(pickled_sampler)
+
+    fs_resume = FlowSampler(
+        integration_model,
+        nlive=10,
+        output=output,
+        max_iteration=5,
+        checkpointing=False,
+        resume_data=resume_data,
+        resume_file=None,
+        importance_nested_sampler=ins,
+        **kwargs,
+    )
+
+    fs_resume.ns.iteration == fs.ns.iteration
+    fs_resume.ns.log_evidence == fs.ns.log_evidence
+
+    assert "Trying to resume sampler from `resume_data`" in str(caplog.text)

--- a/tests/test_samplers/test_importance_nested_sampler/test_resume.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_resume.py
@@ -35,9 +35,9 @@ def test_getstate_model(ins):
     assert proposal is ins.proposal
 
 
-def test_resume(model, tmp_path, samples):
+def test_resume_from_pickled_Sampler(model, samples):
 
-    filename = str(tmp_path / "test.pkl")
+    sampler = MagicMock()
 
     obj = MagicMock()
     obj.log_q = None
@@ -49,9 +49,11 @@ def test_resume(model, tmp_path, samples):
     obj.proposal.compute_meta_proposal_samples = MagicMock(return_value=log_q)
 
     with patch(
-        "nessai.samplers.importancesampler.BaseNestedSampler.resume",
+        "nessai.samplers.importancesampler.BaseNestedSampler.resume_from_pickled_sampler",  # noqa
         return_value=obj,
-    ):
-        out = INS.resume(filename, model)
+    ) as mock_resume:
+        out = INS.resume_from_pickled_sampler(sampler, model)
+
+    mock_resume.assert_called_once_with(sampler, model)
 
     assert out.log_q is log_q

--- a/tests/test_samplers/test_nested_sampler/test_resume.py
+++ b/tests/test_samplers/test_nested_sampler/test_resume.py
@@ -62,17 +62,20 @@ def test_resume(model, flow_config):
 
     weights_file = "weight.pt"
 
+    sampler = MagicMock()
+
     with patch(
-        "nessai.samplers.base.BaseNestedSampler.resume", return_value=obj
+        "nessai.samplers.base.BaseNestedSampler.resume_from_pickled_sampler",
+        return_value=obj,
     ) as mock:
-        out = NestedSampler.resume(
-            "test.pkl",
+        out = NestedSampler.resume_from_pickled_sampler(
+            sampler,
             model,
             flow_config=flow_config,
             weights_path=weights_file,
         )
     assert out is obj
-    mock.assert_called_once_with("test.pkl", model)
+    mock.assert_called_once_with(sampler, model)
     obj._uninformed_proposal.resume.assert_called_once_with(
         model,
     )

--- a/tests/test_utils/test_testing_utils.py
+++ b/tests/test_utils/test_testing_utils.py
@@ -23,6 +23,10 @@ def test_integration_test_model(n, dims):
     assert np.isfinite(log_l).all()
     assert len(log_p) == len(x)
     assert len(log_l) == len(x)
+    x_hyper = model.to_unit_hypercube(x)
+    x_re = model.from_unit_hypercube(x_hyper)
+    assert_structured_arrays_equal(x_re, x)
+    assert len(x_hyper) == len(x)
 
 
 def test_assert_struct_arrays_different_fields():


### PR DESCRIPTION
Add the option to resume the sampler from the contents of a pickle file rather than using a file.

This is needed for the pycbc inference interface.

**To-do**

- [x] Write tests