### PR TITLE
Rework truncation based on log q

### DIFF
--- a/nessai/flowmodel/base.py
+++ b/nessai/flowmodel/base.py
@@ -775,6 +775,23 @@ class FlowModel:
             x = self.model.sample(int(n))
         return x.cpu().numpy().astype(np.float64)
 
+    def sample_latent_distribution(self, n: int = 1) -> np.ndarray:
+        """Sample from the latent distribution.
+
+        Parameters
+        ----------
+        n : int
+            Number of samples to draw
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of samples
+        """
+        with torch.inference_mode():
+            z = self.model.sample_latent_distribution(n)
+        return z.cpu().numpy().astype(np.float64)
+
     def sample_and_log_prob(self, N=1, z=None, alt_dist=None):
         """
         Generate samples from samples drawn from the base distribution or

--- a/nessai/flows/base.py
+++ b/nessai/flows/base.py
@@ -77,6 +77,11 @@ class BaseFlow(Module, ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def sample_latent_distribution(self, n, context=None):
+        """Sample from the latent distribution."""
+        raise NotImplementedError
+
+    @abstractmethod
     def base_distribution_log_prob(self, z, context=None):
         """
         Computes the log probability of samples in the latent for
@@ -236,6 +241,11 @@ class NFlow(BaseFlow):
         noise, logabsdet = self._transform(inputs, context=context)
         log_prob = self._distribution.log_prob(noise)
         return log_prob + logabsdet
+
+    def sample_latent_distribution(self, n, context=None):
+        if context is not None:
+            raise NotImplementedError
+        return self._distribution.sample(n)
 
     def base_distribution_log_prob(self, z, context=None):
         """

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1164,7 +1164,10 @@ class FlowProposal(RejectionProposal):
         """
         r = np.sqrt(np.sum(z**2.0, axis=-1))
         i = np.nanargmax(r)
-        return (r[i],) + (a[i] for a in arrays)
+        if arrays:
+            return (r[i],) + tuple(a[i] for a in arrays)
+        else:
+            return r[i]
 
     def log_prior(self, x):
         """
@@ -1372,7 +1375,7 @@ class FlowProposal(RejectionProposal):
                 logger.debug("Using previous live points to compute radius")
             worst_z = self.forward_pass(
                 worst_point, rescale=True, compute_radius=True
-            )
+            )[0]
             r = self.radius(worst_z)
             if self.max_radius and r > self.max_radius:
                 r = self.max_radius

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1382,7 +1382,7 @@ class FlowProposal(RejectionProposal):
         if self.truncate_log_q:
             log_q_live_points = self.forward_pass(self.training_data)[1]
             min_log_q = log_q_live_points.min()
-            logger.debug("Truncating with log_q={min_log_q:.3f}")
+            logger.debug(f"Truncating with log_q={min_log_q:.3f}")
         else:
             min_log_q = None
 

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1373,6 +1373,7 @@ class FlowProposal(RejectionProposal):
             logger.debug(f"Populating with worst point: {worst_point}")
             if self.compute_radius_with_all:
                 logger.debug("Using previous live points to compute radius")
+                worst_point = self.training_data
             worst_z = self.forward_pass(
                 worst_point, rescale=True, compute_radius=True
             )[0]

--- a/tests/test_flowmodel/test_flowmodel_base.py
+++ b/tests/test_flowmodel/test_flowmodel_base.py
@@ -423,6 +423,17 @@ def test_sample(model):
     np.testing.assert_array_equal(out, x.numpy())
 
 
+def test_sample_latent_distribution(model):
+    """Assert the correct method is called"""
+    n = 10
+    z = torch.randn(n, 2)
+    model.model = MagicMock()
+    model.model.sample_latent_distribution = MagicMock(return_value=z)
+    out = FlowModel.sample_latent_distribution(model, n)
+    model.model.sample_latent_distribution.assert_called_once_with(n)
+    np.testing.assert_array_equal(out, z.numpy())
+
+
 def test_move_to_update_default(model):
     """Ensure the stored device is updated"""
     model.device = "cuda"

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -43,6 +43,7 @@ def test_base_flow_abstract_methods():
         "base_distribution_log_prob",
         "forward_and_log_prob",
         "sample_and_log_prob",
+        "sample_latent_distribution",
     ],
 )
 def test_base_flow_methods(method, flow):

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -3,6 +3,7 @@
 Test the base flow class
 """
 import pytest
+import torch
 from unittest.mock import MagicMock, create_autospec, patch
 
 from nessai.flows.base import BaseFlow, NFlow
@@ -140,3 +141,16 @@ def test_nflow_unfreeze(nflow):
     nflow._transform.requires_grad_ = MagicMock()
     NFlow.unfreeze_transform(nflow)
     nflow._transform.requires_grad_.assert_called_once_with(True)
+
+
+def test_nflow_sample_latent_distribution(nflow):
+    n = 10
+    NFlow.sample_latent_distribution(nflow, n)
+    nflow._distribution.sample.assert_called_once_with(n)
+
+
+def test_nflow_sample_latent_distribution_context(nflow):
+    n = 10
+    context = torch.randn(10)
+    with pytest.raises(NotImplementedError):
+        NFlow.sample_latent_distribution(nflow, n, context=context)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_configuration.py
@@ -92,6 +92,7 @@ def test_configure_plotting(proposal, plot, plot_pool, plot_train):
         ("uniform", "draw_uniform"),
         ("uniform_nsphere", "draw_nsphere"),
         ("uniform_nball", "draw_nsphere"),
+        ("flow", None),
     ],
 )
 def test_configure_latent_prior(proposal, latent_prior, prior_func):
@@ -99,7 +100,10 @@ def test_configure_latent_prior(proposal, latent_prior, prior_func):
     proposal.latent_prior = latent_prior
     proposal.flow_config = {"model_config": {}}
     FlowProposal.configure_latent_prior(proposal)
-    assert proposal._draw_latent_prior == getattr(utils, prior_func)
+    if prior_func:
+        assert proposal._draw_latent_prior == getattr(utils, prior_func)
+    else:
+        assert proposal._draw_latent_prior is None
 
 
 def test_configure_latent_prior_unknown(proposal):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
@@ -86,7 +86,9 @@ def test_backward_pass(proposal, model, log_p):
     )
     proposal.rescaled_names = model.names
     proposal.alt_dist = None
-    proposal.check_prior_bounds = MagicMock(side_effect=lambda a, b: (a, b))
+    proposal.check_prior_bounds = MagicMock(
+        side_effect=lambda a, b, c: (a, b, c)
+    )
     proposal.flow = MagicMock()
     proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
 

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -460,6 +460,24 @@ def test_constant_volume_mode(integration_model, tmpdir):
 
 
 @pytest.mark.slow_integration_test
+def test_truncate_log_q(integration_model, tmpdir):
+    """Test sampling with truncate_log_q"""
+    output = str(tmpdir.mkdir("test"))
+    fs = FlowSampler(
+        integration_model,
+        output=output,
+        nlive=500,
+        plot=False,
+        proposal_plots=False,
+        constant_volume_mode=False,
+        latent_prior="flow",
+        truncate_log_q=True,
+    )
+    fs.run(plot=False)
+    assert fs.ns.finalised
+
+
+@pytest.mark.slow_integration_test
 def test_prior_sampling(integration_model, tmpdir):
     """Test prior sampling"""
     output = str(tmpdir.mkdir("prior_sampling"))


### PR DESCRIPTION
Rework how the truncation based of the log-proposal probability (log q) to use the minium value of the training data.

**Motivation**

This could be an alternative to truncating the latent distribution. It should be less prone to over-constraining but may result in inefficient rejection sampling.

**Changes**

- Add methods for sampling from the latent distribution to `FlowModel` and `BaseFlow`
- Refactor  `FlowProposal.radius`
- Add new keyword arguments to `FlowProposal.backwards_pass`
- Rename `worst_q` to `min_log_q` in `FlowProposal.rejection_sample` 

**Breaking changes**

These changes are all to options that were not used by default and we generally recommended avoiding in the past, so I don't think they should impact users.

- This PR removes the current method for truncation that uses the log-probability of the worst point
- This PR removes the `truncate` keyword argument from `FlowProposal`
- This PR renames the `worst_q` keyword argument to `min_log_q` in `FlowProposal.rejection_sample`

**To-Do**

- [ ] ~~Document the method~~
- [x] Fix existing unit tests
- [x] Add new unit tests
- [x] Add a simple integration test