### PR TITLE
Address slowdown in bilby analyses with v0.10.0

### DIFF
--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -174,7 +174,7 @@ def batch_evaluate_function(
     return out
 
 
-def check_vectorised_function(func, x, dtype=None):
+def check_vectorised_function(func, x, dtype=None, atol=1e-15, rtol=1e-15):
     """Check if a function is vectorised given a set of inputs.
 
     Parameters
@@ -186,6 +186,10 @@ def check_vectorised_function(func, x, dtype=None):
     dtype :  Optional[Union[str, numpy.dtype]]
         Dtype to cast the results to. If not specified, the default dtype
         for livepoints is used.
+    rtol : float
+        Relative tolerance, see numpy documentation for :code:`allclose`.
+    atol : float
+        Abosoulte tolerance, see numpy documentation for :code:`allclose`.
 
     Returns
     -------
@@ -205,7 +209,7 @@ def check_vectorised_function(func, x, dtype=None):
         logger.debug("Assuming function is not vectorised")
         return False
     else:
-        if np.array_equal(target, batch):
+        if np.allclose(target, batch, atol=atol, rtol=rtol):
             logger.debug("Function is vectorised")
             return True
         else:


### PR DESCRIPTION
Address the issue mentioned in https://github.com/mj-will/nessai/issues/342.

The cause of the slowdown was the new function `check_vectorised_function` which was too strict for the priors in bilby and as a result, the prior was being treated as not being vectorised. The immediate fix is to add a small tolerance to the check using `np.allclose`. We may want to revisit this in future, as it's not clear to me that using `1e-15` is sufficient. I'll test this and report back before merging this.

I plan to merge this into the release branch, update the changelog and then make a new release. I'll then merge this change into main.

**To-Do**

- [x] Run bilby_pipe analysis with this fix