### PR TITLE
Mark INS resume test as flaky

### DIFF
--- a/tests/test_sampling/test_ins_sampling.py
+++ b/tests/test_sampling/test_ins_sampling.py
@@ -7,6 +7,7 @@ import pytest
 
 
 @pytest.mark.slow_integration_test
+@pytest.mark.flaky(reruns=3)
 def test_ins_resume(tmp_path, model, flow_config):
     """Assert the INS sampler resumes correctly"""
     output = tmp_path / "test_ins_resume"


### PR DESCRIPTION
This test sometimes fails because the assertion for `log_q` uses random samples, so I've marked it as flaky