### PR TITLE
Add checkpointing callbacks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,3 +67,11 @@ autoapi_type = "python"
 autoapi_dirs = ["../nessai/"]
 autoapi_add_toctree_entry = False
 autoapi_options = ["members", "show-inheritance", "show-module-summary"]
+
+# -- RST config --------------------------------------------------------------
+# Inline python highlighting, base on https://stackoverflow.com/a/68931907
+rst_prolog = """
+.. role:: python(code)
+    :language: python
+    :class: highlight
+"""

--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,2 @@
+[restructuredtext parser]
+syntax_highlight = short

--- a/docs/further-details.rst
+++ b/docs/further-details.rst
@@ -61,6 +61,90 @@ Using analytic priors
 To use this setting, the user must re-define ``new_point`` when defining the model as described in :doc:`running the sampler<running-the-sampler>`. This method must return samples as live points, see :ref:`using live points<Using live points>`. Once the method is redefined, set :code:`analytic_priors=True` when calling :py:class:`~nessai.flowsampler.FlowSampler`.
 
 
+Checkpointing and resuming
+==========================
+
+Both the standard and importance nested samplers support checkpointing and
+resuming. By default, the samplers periodically checkpoint to pickle file based
+on the time elapsed since the last checkpoint. This behaviour can be configured
+via various keyword arguments.
+
+
+Configuration
+-------------
+
+The following options are available in all the sampler classes:
+
+* :python:`checkpointing: bool`: Boolean to toggle checkpointing. If false, the sampler will not periodically checkpoint but will checkpoint at the end of sampling.
+* :python:`checkpoint_on_iteration: bool`: Boolean to enable checkpointing based on the number of iterations rather than the elapsed time.
+* :python:`checkpoint_interval: int`: The interval between checkpointing, the units depend on the value of :python:`checkpoint_interval`; if it false, is value the interval is specified in seconds; if it is true, the interval is specified in iterations.
+* :python:`checkpoint_callback: Callable`: Callback function to be used instead of the default function. See `Checkpoint callbacks`_ for more details.
+
+The following options are available when creating an instance of
+:py:class:`~nessai.flowsampler.FlowSampler`:
+
+* :python:`resume: bool`: Boolean to entirely enable or disable resuming irrespective of if there is a file or data to resume from.
+* :python:`resume_file: str`: Name of the resume file.
+* :python:`resume_data: Any`: Data to resume the sampler from instead of a resume file. The data will be passed to the :python:`resume_from_pickled_sampler` of the relevant class.
+
+
+Resuming a sampling run
+-----------------------
+
+A sampling run can be resumed from either an existing resume file, which is
+loaded automatically, or by specifying pickled data to resume from.
+We recommended using the resume files, which are produced automatically, for
+most applications.
+
+The recommended method for resuming a run is by calling :py:class:`~nessai.flowsampler.FlowSampler` with
+the same arguments that were originally used to start run; ensuring
+:python:`resume=True` and :python:`resume_file` matches the name of the
+:code:`.pkl` file in the output directory (the default is
+:code:`nested_sampler_resume.pkl`).
+
+.. note::
+
+    Depending on how the sampling was interrupted, some progress may be lost and
+    the sampling may resume from an earlier iteration.
+
+Alternatively, you can specify the :python:`resume_data` argument which takes
+priority over the resume file.
+This will be passed to the :python:`resume_from_pickled_sampler` of the
+corresponding sampler class.
+
+
+Checkpoint callbacks
+--------------------
+
+Checkpoint callbacks allow the user to specify a custom function to use for
+checkpointing the sampler.
+This allows, for example, for the sampler to checkpoint an existing file rather.
+
+The checkpoint callback function will be called in the :code:`checkpoint` method
+with the class instance as the only argument, i.e.
+:python:`checkpoint_callback(self)`.
+
+All the sampler classes define custom :py:meth:`~nessai.samplers.base.BaseNestedSampler.__getstate__` methods that are
+compatible with pickle and can be used to obtain a pickled representation of
+the state of the sampler. Below is an example of a valid callback
+
+.. code-block:: python
+
+    import pickle
+    filename = "checkpoint.pkl"
+
+    def checkpoint_callback(state):
+        with open(filename, "wb") as f:
+            pickle.dump(state, f)
+
+This could then passed as a keyword argument when running or resuming a sampler
+via :py:class:`~nessai.flowsampler.FlowSampler`.
+
+.. warning::
+    The checkpoint callback is not included in the output of :python:`__getstate__`
+    and must be specified when resuming the sampler via :py:class:`~nessai.flowsampler.FlowSampler`.
+
+
 Detailed explanation of outputs
 ===============================
 

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -53,7 +53,7 @@ class FlowSampler:
     signal_handling : bool
         Enable or disable signal handling.
     exit_code : int, optional
-        Exit code to use when forceably exiting the sampler.
+        Exit code to use when forcibly exiting the sampler.
     close_pool : bool
         If True, the multiprocessing pool will be closed once the run method
         has been called. Disables the option in :code:`NestedSampler` if
@@ -198,7 +198,7 @@ class FlowSampler:
         else:
             logger.warning(
                 "Signal handling is disabled. nessai will not automatically "
-                "checkpoint when exitted."
+                "checkpoint when exited."
             )
 
     def check_resume(self, resume_file, resume_data):
@@ -269,7 +269,7 @@ class FlowSampler:
             model,
             weights_path=weights_path,
             flow_config=flow_config,
-            **kwargs
+            **kwargs,
         )
 
     @property

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -167,6 +167,7 @@ class FlowSampler:
                     model=model,
                     weights_path=weights_path,
                     flow_config=kwargs.get("flow_config"),
+                    checkpoint_callback=kwargs.get("checkpoint_callback"),
                 )
             else:
                 self.ns = self._resume_from_file(
@@ -175,6 +176,7 @@ class FlowSampler:
                     resume_file=resume_file,
                     weights_path=weights_path,
                     flow_config=kwargs.get("flow_config"),
+                    checkpoint_callback=kwargs.get("checkpoint_callback"),
                 )
         else:
             logger.debug("Not resuming sampler")
@@ -218,6 +220,7 @@ class FlowSampler:
         model,
         weights_path,
         flow_config,
+        **kwargs,
     ):
         logger.info(f"Trying to resume sampler from {resume_file}")
         try:
@@ -226,6 +229,7 @@ class FlowSampler:
                 model,
                 weights_path=weights_path,
                 flow_config=flow_config,
+                **kwargs,
             )
         except (FileNotFoundError, RuntimeError) as e:
             logger.error(
@@ -239,6 +243,7 @@ class FlowSampler:
                     model,
                     weights_path=weights_path,
                     flow_config=flow_config,
+                    **kwargs,
                 )
             except RuntimeError as e:
                 logger.error(
@@ -256,6 +261,7 @@ class FlowSampler:
         model,
         weights_path,
         flow_config,
+        **kwargs,
     ):
         logger.info("Trying to resume sampler from `resume_data`")
         return SamplerClass.resume_from_pickled_sampler(
@@ -263,6 +269,7 @@ class FlowSampler:
             model,
             weights_path=weights_path,
             flow_config=flow_config,
+            **kwargs
         )
 
     @property

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1946,7 +1946,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
     def __getstate__(self):
         d = self.__dict__
-        exclude = {"model", "proposal", "log_q"}
+        exclude = {"model", "proposal", "log_q", "checkpoint_callback"}
         state = {k: d[k] for k in d.keys() - exclude}
         if d.get("model") is not None:
             state["_previous_likelihood_evaluations"] = d[

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -5,7 +5,7 @@ Importance nested sampler.
 import datetime
 import logging
 import os
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -101,6 +101,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         checkpointing: bool = True,
         checkpoint_interval: int = 600,
         checkpoint_on_iteration: bool = False,
+        checkpoint_callback: Optional[Callable] = None,
         save_existing_checkpoint: bool = False,
         logging_interval: int = None,
         log_on_iteration: bool = True,
@@ -146,6 +147,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             checkpointing=checkpointing,
             checkpoint_interval=checkpoint_interval,
             checkpoint_on_iteration=checkpoint_on_iteration,
+            checkpoint_callback=checkpoint_callback,
             logging_interval=logging_interval,
             log_on_iteration=log_on_iteration,
             resume_file=resume_file,
@@ -1900,7 +1902,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
     @classmethod
     def resume_from_pickled_sampler(
-        cls, sampler, model, flow_config=None, weights_path=None
+        cls, sampler, model, flow_config=None, weights_path=None, **kwargs
     ):
         """Resume from a pickled sampler.
 
@@ -1915,6 +1917,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
         weights_path : Optional[dict]
             Path to the weights files that will override the value stored in
             the proposal.
+        kwargs :
+            Keyword arguments passed to the parent class's method.
 
         Returns
         -------
@@ -1922,7 +1926,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """
         cls.add_fields()
         obj = super(ImportanceNestedSampler, cls).resume_from_pickled_sampler(
-            sampler, model
+            sampler, model, **kwargs
         )
         if flow_config is None:
             flow_config = {}

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -162,6 +162,7 @@ class NestedSampler(BaseNestedSampler):
         checkpoint_interval=600,
         checkpoint_on_iteration=False,
         checkpoint_on_training=False,
+        checkpoint_callback=None,
         logging_interval=None,
         log_on_iteration=True,
         resume_file=None,
@@ -202,6 +203,7 @@ class NestedSampler(BaseNestedSampler):
             checkpointing=checkpointing,
             checkpoint_interval=checkpoint_interval,
             checkpoint_on_iteration=checkpoint_on_iteration,
+            checkpoint_callback=checkpoint_callback,
             logging_interval=logging_interval,
             log_on_iteration=log_on_iteration,
             resume_file=resume_file,
@@ -1343,7 +1345,7 @@ class NestedSampler(BaseNestedSampler):
 
     @classmethod
     def resume_from_pickled_sampler(
-        cls, sampler, model, flow_config=None, weights_path=None
+        cls, sampler, model, flow_config=None, weights_path=None, **kwargs
     ):
         """Resume from a pickled sampler.
 
@@ -1358,13 +1360,15 @@ class NestedSampler(BaseNestedSampler):
         weights_path : Optional[str]
             Weights file to use in place of the weights file stored in the
             pickle file.
+        kwargs :
+            Keyword arguments passed to the parent class's method.
 
         Returns
         -------
         Instance of NestedSampler
         """
         obj = super(NestedSampler, cls).resume_from_pickled_sampler(
-            sampler, model
+            sampler, model, **kwargs
         )
         obj._uninformed_proposal.resume(model)
         if flow_config is None:

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -182,6 +182,7 @@ def test_resume_from_resume_data(flow_sampler, model, tmp_path):
         model=model,
         weights_path=None,
         flow_config=None,
+        checkpoint_callback=None,
     )
 
 
@@ -205,6 +206,7 @@ def test_resume_from_resume_file(flow_sampler, model, tmp_path):
         model=model,
         weights_path=None,
         flow_config=None,
+        checkpoint_callback=None,
     )
 
 
@@ -377,6 +379,7 @@ def test_init_resume(tmp_path, test_old, error):
         integration_model,
         flow_config=flow_config,
         weights_path=weights_file,
+        checkpoint_callback=None,
     )
 
     assert fs.ns == "ns"


### PR DESCRIPTION
This PR adds support for a checkpoint callback: a function that is called instead of the default checkpoint function when the sampler tries to checkpoint.

This is motivated by the discussion in https://github.com/gwastro/pycbc/pull/4567


**Usage**


```python

def callback(state):
    # Save the state
    ...

fs = FlowSampler(
    model,
    ...,
    checkpoint_callback=callback,
)
fs.run()

```


**To-Do**

- [x] Documentation