### PR TITLE
Revert #350

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Nessai: Nested Sampling with Artificial Intelligence"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -94,6 +94,7 @@ exclude_lines = [
 [tool.black]
 line-length = 79
 target-version = [
+    "py38",
     "py39",
     "py310",
     "py311",
@@ -103,3 +104,4 @@ target-version = [
 extend-ignore = [
     "E203",
 ]
+


### PR DESCRIPTION
Given maintaining support for 3.8 doesn't requite additional development work, I think we should continue to support for now, so I'm reverting https://github.com/mj-will/nessai/pull/350