### PR TITLE
Fix plot 1d comparison legend bug

### DIFF
--- a/nessai/plot.py
+++ b/nessai/plot.py
@@ -267,17 +267,26 @@ def plot_1d_comparison(
             axs[i].axvline(bounds[f][1], ls=":", alpha=0.5, color="k")
 
     if len(labels) > 1:
-        handles, labels = plt.gca().get_legend_handles_labels()
-        legend_labels = dict(zip(labels, handles))
-        fig.legend(
-            legend_labels.values(),
-            legend_labels.keys(),
-            frameon=False,
-            ncol=len(labels),
-            loc="upper center",
-            bbox_to_anchor=(0, 0.1 / len(parameters), 1, 1),
-            bbox_transform=plt.gcf().transFigure,
-        )
+        # Get the handles
+        # Some axes may have less due to e.g. all NaN values, so loop over them
+        # all until a valid set of handles is found.
+        for ax in axs:
+            handles, _ = ax.get_legend_handles_labels()
+            if len(handles) == len(labels):
+                break
+        if len(handles) == len(labels):
+            legend_labels = dict(zip(labels, handles))
+            fig.legend(
+                legend_labels.values(),
+                legend_labels.keys(),
+                frameon=False,
+                ncol=len(labels),
+                loc="upper center",
+                bbox_to_anchor=(0, 0.1 / len(parameters), 1, 1),
+                bbox_transform=plt.gcf().transFigure,
+            )
+        else:
+            logger.warning("Could not plot legend")
 
     plt.tight_layout()
     if filename is not None:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -257,6 +257,25 @@ def test_plot_1d_comparison_infinite_var_comp(
     assert "No finite points for y, skipping." not in str(caplog.text)
 
 
+def test_plot_1d_comparison_one_valid(live_points, live_points_1, caplog):
+    """Test generating a 1d comparison plot with one invalid"""
+    live_points["logL"] = np.random.rand(live_points.size)
+    live_points_1["logL"] = np.nan
+    plot.plot_1d_comparison(live_points, live_points_1, parameters=["logL"])
+    plt.close()
+    assert "Could not plot legend" in caplog.text
+
+
+def test_plot_1d_comparison_last_invalid(live_points, live_points_1):
+    """Test generating a 1d comparison plot when the last parameter has NANs"""
+    live_points["logL"] = np.random.rand(live_points.size)
+    live_points_1["logL"] = np.nan
+    plot.plot_1d_comparison(
+        live_points, live_points_1, parameters=["x", "logL"]
+    )
+    plt.close()
+
+
 @pytest.mark.parametrize("colours", [None, ["r", "g"]])
 def test_plot_1d_comparison_colours(colours, live_points, live_points_1):
     """Test generating a 1d comparison plot with only one parameter"""


### PR DESCRIPTION
https://github.com/mj-will/nessai/pull/358 uncovered a bug in `plot_1d_comparison` that occurred when the final axis in the subplots only contained a single artist. This leads to the legend being called with `ncol=1` which seems to cause an error in some versions of matplotlib and numpy. I've addressed this by looping over all the axes and using the first axis that has a valid set of legend handles. I also handle the case where there are no valid handles.