### PR TITLE
Rework importance nested sampler

### DIFF
--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -383,3 +383,21 @@ class _INSIntegralState(_BaseNSIntegralState):
             return float(np.abs(u / Z_hat))
         else:
             return u
+
+
+def log_evidence_from_ins_samples(samples: np.ndarray) -> float:
+    """Compute the log-evidence for a given set of samples from the importance
+    nested sampler.
+
+    Parameters
+    ----------
+    samples : numpy.ndarray
+        Array of samples from the importance nested samples. Must have the logW
+        field.
+
+    Returns
+    -------
+    float
+        The log-evidence
+    """
+    return logsumexp(samples["logL"] + samples["logW"]) - np.log(len(samples))

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -375,7 +375,11 @@ class FlowSampler:
         self.ns.initialise()
         self.logZ, self._nested_samples = self.ns.nested_sampling_loop()
         self.logZ_error = self.ns.state.log_evidence_error
-        logger.info((f"Total sampling time: {self.ns.sampling_time}"))
+        logger.info(f"Total sampling time: {self.ns.sampling_time}")
+        logger.info(
+            "Total likelihood evaluations: "
+            f"{self.ns.total_likelihood_evaluations}"
+        )
 
         logger.info("Starting post processing")
         logger.info("Computing posterior samples")
@@ -425,7 +429,7 @@ class FlowSampler:
         plot_posterior=True,
         save=True,
         posterior_sampling_method=None,
-        redraw_samples=True,
+        redraw_samples=False,
         n_posterior_samples=None,
         compute_initial_posterior=False,
         close_pool=None,
@@ -471,9 +475,15 @@ class FlowSampler:
         if posterior_sampling_method is None:
             posterior_sampling_method = "importance_sampling"
 
-        self.logZ, self._nested_samples = self.ns.nested_sampling_loop()
+        self.ns.nested_sampling_loop()
+        self._nested_samples = self.ns.samples
+        self.logZ = self.ns.state.log_evidence
         self.logZ_error = self.ns.state.log_evidence_error
-        logger.info((f"Total sampling time: {self.ns.sampling_time}"))
+        logger.info(f"Total sampling time: {self.ns.sampling_time}")
+        logger.info(
+            "Total likelihood evaluations: "
+            f"{self.ns.total_likelihood_evaluations}"
+        )
 
         logger.info("Starting post processing")
 
@@ -490,7 +500,7 @@ class FlowSampler:
         logger.info("Computing posterior samples")
 
         if compute_initial_posterior or not redraw_samples:
-            logger.debug("Computing initial posterior samples")
+            logger.debug("Computing posterior samples")
             self.initial_posterior_samples = self.ns.draw_posterior_samples(
                 sampling_method=posterior_sampling_method,
                 use_final_samples=False,

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -477,8 +477,8 @@ class FlowSampler:
 
         self.ns.nested_sampling_loop()
         self._nested_samples = self.ns.samples
-        self.logZ = self.ns.state.log_evidence
-        self.logZ_error = self.ns.state.log_evidence_error
+        self.logZ = self.ns.log_evidence
+        self.logZ_error = self.ns.log_evidence_error
         logger.info(f"Total sampling time: {self.ns.sampling_time}")
         logger.info(
             "Total likelihood evaluations: "
@@ -491,10 +491,11 @@ class FlowSampler:
             logger.info("Redrawing samples")
             self.initial_logZ = self.logZ
             self.initial_logZ_error = self.logZ_error
-            self.logZ, self._final_samples = self.ns.draw_final_samples(
+            _, self._final_samples = self.ns.draw_final_samples(
                 n_post=n_posterior_samples,
                 **kwargs,
             )
+            self.logZ = self.ns.final_log_evidence
             self.logZ_error = self.ns.final_log_evidence_error
 
         logger.info("Computing posterior samples")

--- a/nessai/posterior.py
+++ b/nessai/posterior.py
@@ -142,6 +142,8 @@ def draw_posterior_samples(
                 "Number of samples cannot be specified for rejection sampling"
             )
         log_w = log_w - np.max(log_w)
+        n_expected = np.exp(logsumexp(log_w))
+        logger.info(f"Expect {n_expected} samples from rejection sampling")
         log_u = np.log(np.random.rand(nested_samples.size))
         indices = np.where(log_w > log_u)[0]
         samples = nested_samples[indices]

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -661,9 +661,8 @@ class ImportanceFlowProposal(Proposal):
 
     def draw_from_prior(self, n: int) -> Tuple[np.ndarray, np.ndarray]:
         """Draw from the prior"""
-        cube_samples = np.random.rand(n, self.model.dims)
-        prime_samples, log_j = self.to_prime(cube_samples)
-        samples = self.inverse_rescale(prime_samples)[0]
+        samples = self.model.sample_unit_hypercube(n)
+        prime_samples, log_j = self.rescale(samples)
         log_Q, log_q = self.compute_log_Q(prime_samples, log_j=log_j)
         samples["logQ"] = log_Q
         samples["logW"] = -log_Q

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -26,7 +26,7 @@ from ..utils.rescaling import (
     logit,
     sigmoid,
 )
-from ..utils.structures import get_subset_arrays, isfinite_struct
+from ..utils.structures import get_subset_arrays
 
 
 logger = logging.getLogger(__name__)
@@ -191,7 +191,7 @@ class ImportanceFlowProposal(Proposal):
             The relative tolerance.
         """
         logger.debug("Verifying rescaling")
-        x_in = self.model.new_point(n)
+        x_in = self.model.sample_unit_hypercube(n)
 
         x_prime, log_j = self.rescale(x_in)
         x_re, log_j_inv = self.inverse_rescale(x_prime)
@@ -268,9 +268,8 @@ class ImportanceFlowProposal(Proposal):
 
         Returns an unstructured array.
         """
-        x_hypercube = self.model.to_unit_hypercube(x)
-        x_array = live_points_to_array(x_hypercube, self.model.names)
-        x_prime, log_j = self.to_prime(x_array)
+        x = live_points_to_array(x, self.model.names)
+        x_prime, log_j = self.to_prime(x)
         return x_prime, log_j
 
     def inverse_rescale(self, x_prime: np.ndarray) -> np.ndarray:
@@ -278,11 +277,10 @@ class ImportanceFlowProposal(Proposal):
 
         Returns a structured array.
         """
-        x_array, log_j = self.from_prime(x_prime)
+        x, log_j = self.from_prime(x_prime)
         if self.clip:
-            x_array = np.clip(x_array, 0.0, 1.0)
-        x_hypercube = numpy_array_to_live_points(x_array, self.model.names)
-        x = self.model.from_unit_hypercube(x_hypercube)
+            x = np.clip(x, 0.0, 1.0)
+        x = numpy_array_to_live_points(x, self.model.names)
         return x, log_j
 
     def train(
@@ -510,8 +508,7 @@ class ImportanceFlowProposal(Proposal):
             x_check, log_j = self.rescale(x)
             # Probably don't need all these checks.
             acc = (
-                self.model.in_bounds(x)
-                & isfinite_struct(x, names=self.model.names)
+                self.model.in_unit_hypercube(x)
                 & np.isfinite(x_check).all(axis=1)
                 & np.isfinite(x_prime).all(axis=1)
                 & np.isfinite(log_j)
@@ -528,7 +525,9 @@ class ImportanceFlowProposal(Proposal):
             x["logQ"], log_q_all = self.compute_log_Q(
                 x_prime, log_q_current=None, n=n_weight, log_j=log_j
             )
-            x["logP"] = self.model.batch_evaluate_log_prior(x)
+            x["logP"] = self.model.batch_evaluate_log_prior(
+                x, unit_hypercube=True
+            )
             x["logW"] = -x["logQ"]
             accept = (
                 np.isfinite(x["logP"])
@@ -737,8 +736,7 @@ class ImportanceFlowProposal(Proposal):
         x_check, log_j = self.rescale(samples)
         # Probably don't need all these checks.
         finite = (
-            self.model.in_bounds(samples)
-            & isfinite_struct(samples, names=self.model.names)
+            self.model.in_unit_hypercube(samples)
             & np.isfinite(x_check).all(axis=1)
             & np.isfinite(prime_samples).all(axis=1)
             & np.isfinite(log_j)
@@ -765,7 +763,9 @@ class ImportanceFlowProposal(Proposal):
         )
         logger.debug(f"Mean log_q for each each flow: {log_q.mean(axis=0)}")
 
-        samples["logP"] = self.model.batch_evaluate_log_prior(samples)
+        samples["logP"] = self.model.batch_evaluate_log_prior(
+            samples, unit_hypercube=True
+        )
         samples, log_q = get_subset_arrays(
             np.isfinite(samples["logP"]), samples, log_q
         )

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -587,10 +587,12 @@ class ImportanceFlowProposal(Proposal):
     def compute_meta_proposal_samples(self, samples: np.ndarray) -> np.ndarray:
         """Compute the meta proposal Q for a set of samples.
 
-        Includes the transform to the unit hypercube.
+        Includes any rescaling that has been configured.
 
         Returns
         -------
+        log_meta_proposal : numpy.ndarray
+            Array of meta-proposal log probabilities (log Q)
         log_q : numpy.ndarray
             Array of log q for each flow.
         """
@@ -604,10 +606,7 @@ class ImportanceFlowProposal(Proposal):
                 "existing samples!"
             )
         x, log_j = self.rescale(samples)
-        log_Q, log_q = self.compute_log_Q(x, log_j=log_j)
-        samples["logQ"] = log_Q
-        samples["logW"] = -samples["logQ"]
-        return log_q
+        return self.compute_log_Q(x, log_j=log_j)
 
     def _log_prior(self, x: np.ndarray) -> np.ndarray:
         """Helper function that returns the prior in the unit hyper-cube."""

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1012,7 +1012,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def adjust_final_samples(self, n_batches=5):
         """Adjust the final samples"""
         orig_n_total = len(self.samples_unit)
-        its, counts = np.unique(self.samples["it"], return_counts=True)
+        its, counts = np.unique(self.samples_unit["it"], return_counts=True)
         assert counts.sum() == orig_n_total
         weights = counts / orig_n_total
         original_unnorm_weight = counts.copy()

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1021,7 +1021,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             and self.max_samples
             and ((samples.size - n) + self.nlive) > self.max_samples
         ):
-            n = max(self.max_samples, samples.size) - self.nlive
+            n = samples.size - self.max_samples + self.nlive
             logger.warning(
                 "Next level would have more than max samples, "
                 f"removing {n} samples"

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1128,7 +1128,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
             self.log_dZ = np.inf
         self.ratio = self.state.compute_evidence_ratio(ns_only=False)
         self.ratio_ns = self.state.compute_evidence_ratio(ns_only=True)
-        self.kl = self.kl_divergence(self.samples_unit)
         self.ess = self.state.effective_n_posterior_samples
         self.Z_err = np.exp(self.log_evidence_error)
         cond = [getattr(self, sc) for sc in self.stopping_criterion]
@@ -1741,7 +1740,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         Union[matplotlib.figure.Figure, None]
             Returns the figure if a filename name is not given.
         """
-        n_subplots = 5
+        n_subplots = 4
 
         fig, ax = plt.subplots(n_subplots, 1, sharex=True, figsize=(15, 15))
         ax = ax.ravel()
@@ -1791,10 +1790,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
         ax[m].set_ylabel("Differential\n entropy")
         ax[m].legend()
 
-        m += 1
-
-        ax[m].plot(its, self.history["stopping_criteria"]["kl"])
-        ax[m].set_ylabel("KL(Q||posterior)")
         m += 1
 
         ax[-1].set_xlabel("Iteration")

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -715,6 +715,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             raise ValueError("`min_samples` must be less than `nlive`")
         if self.min_remove > self.nlive:
             raise ValueError("`min_remove` must be less than `nlive`")
+        logger.debug("Sampler configuration is valid")
         return True
 
     def populate_live_points(self) -> None:

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1021,7 +1021,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             and self.max_samples
             and ((samples.size - n) + self.nlive) > self.max_samples
         ):
-            n = self.nlive
+            n = max(self.max_samples, samples.size) - self.nlive
             logger.warning(
                 "Next level would have more than max samples, "
                 f"removing {n} samples"

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -900,11 +900,15 @@ class ImportanceNestedSampler(BaseNestedSampler):
         new_samples, log_q = self.draw_n_samples(n)
         new_samples["it"] = self.iteration
         if self.draw_iid_live:
+            split_index = new_samples.size // 2
             new_samples, iid_samples = (
-                new_samples[: n // 2],
-                new_samples[n // 2 :],
+                new_samples[:split_index],
+                new_samples[split_index:],
             )
-            log_q, iid_log_q = log_q[: n // 2, ...], log_q[n // 2 :, ...]
+            log_q, iid_log_q = (
+                log_q[:split_index, ...],
+                log_q[split_index:, ...],
+            )
             self.iid_samples.log_q = self.proposal.update_log_q(
                 self.iid_samples.samples, self.iid_samples.log_q
             )

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -792,8 +792,14 @@ class ImportanceNestedSampler(BaseNestedSampler):
         st = datetime.datetime.now()
 
         # Implicitly includes all samples
-        n_train = np.argmax(
-            self.training_samples.samples["logL"] >= self.logL_threshold
+        # Ensure at least min_samples are used for training
+        # This reduces the likelihood threshold but avoids issues with training
+        # with e.g. 1 point.
+        n_train = min(
+            np.argmax(
+                self.training_samples.samples["logL"] >= self.logL_threshold
+            ),
+            self.training_samples.samples.size - self.min_samples,
         )
         self.current_training_samples = self.training_samples.samples[
             n_train:
@@ -977,6 +983,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
         else:
             self.history["n_removed"].append(n)
         logger.debug(f"Removing {n} points")
+        print(n)
+        print(self.training_samples.live_points.size)
+        print(self.iid_samples.live_points.size)
         self.training_samples.remove_samples(n)
         if self.draw_iid_live:
             self.iid_samples.remove_samples(n)

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -983,9 +983,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
         else:
             self.history["n_removed"].append(n)
         logger.debug(f"Removing {n} points")
-        print(n)
-        print(self.training_samples.live_points.size)
-        print(self.iid_samples.live_points.size)
         self.training_samples.remove_samples(n)
         if self.draw_iid_live:
             self.iid_samples.remove_samples(n)

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -2076,6 +2076,7 @@ class OrderedSamples:
         self.strict_threshold = strict_threshold
         self.replace_all = replace_all
         self.state = _INSIntegralState()
+        self.log_likelihood_threshold = None
 
     @property
     def live_points(self) -> np.ndarray:

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -134,10 +134,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
         bootstrap: bool = False,
         close_pool: bool = False,
         strict_threshold: bool = False,
-        draw_iid_live: bool = False,
+        draw_iid_live: bool = True,
         **kwargs: Any,
     ):
-
         self.add_fields()
 
         super().__init__(
@@ -169,8 +168,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
         self.importance = dict(total=None, posterior=None, evidence=None)
 
         self.draw_iid_live = draw_iid_live
-        self.iid_samples = np.empty(0, dtype=get_dtype(self.model.names))
-        self.iid_log_q = None
 
         self.n_initial = self.nlive if n_initial is None else n_initial
         self.min_samples = min_samples
@@ -210,10 +207,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         self.ess = 0.0
         self.Z_err = np.inf
 
-        self.state = _INSIntegralState()
-
-        self.final_state = None
-        self.final_samples = None
+        self._final_samples = None
 
         self.proposal = self.get_proposal(**kwargs)
         self.configure_iterations(min_iteration, max_iteration)
@@ -224,10 +218,17 @@ class ImportanceNestedSampler(BaseNestedSampler):
             check_criteria,
         )
 
-        self.samples = np.empty(0, dtype=get_dtype(self.model.names))
-        self.log_q = None
-        self.live_points_indices = None
-        self.nested_samples_indices = np.empty(0, dtype=int)
+        self.training_samples = OrderedSamples(
+            strict_threshold=self.strict_threshold,
+            replace_all=self.replace_all,
+        )
+        if self.draw_iid_live:
+            self.iid_samples = OrderedSamples(
+                strict_threshold=self.strict_threshold,
+                replace_all=self.replace_all,
+            )
+        else:
+            self.iid_samples = None
 
         self.training_time = datetime.timedelta()
         self.draw_samples_time = datetime.timedelta()
@@ -268,6 +269,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
             return None
 
     @property
+    def final_log_posterior_weights(self) -> float:
+        if self.final_state:
+            return self.final_state.log_posterior_weights
+        else:
+            return None
+
+    @property
     def posterior_effective_sample_size(self) -> float:
         """The effective sample size of the posterior distribution.
 
@@ -301,26 +309,64 @@ class ImportanceNestedSampler(BaseNestedSampler):
         return self._current_proposal_entropy
 
     @property
+    def samples(self) -> np.ndarray:
+        if self.draw_iid_live:
+            return self.iid_samples.samples
+        else:
+            return self.training_samples.samples
+
+    @property
+    def log_q(self) -> np.ndarray:
+        if self.draw_iid_live:
+            return self.iid_samples.log_q
+        else:
+            return self.training_samples.log_q
+
+    @property
     def live_points(self) -> np.ndarray:
         """The current set of live points"""
-        if self.live_points_indices is None:
-            return None
+        if self.draw_iid_live:
+            return self.iid_samples.live_points
         else:
-            return self.samples[self.live_points_indices]
+            return self.training_samples.live_points
 
     @live_points.setter
-    def live_points(self, value):
-        if value is not None:
-            raise ValueError("Can only set live points to None!")
-        self.live_points_indices = None
+    def live_points(self, samples) -> None:
+        if samples is not None:
+            raise RuntimeError("Cannot set live points")
 
     @property
     def nested_samples(self) -> np.ndarray:
         """The current set of discarded points"""
-        if self.nested_samples_indices is None:
-            return None
+        if self.draw_iid_live:
+            return self.iid_samples.nested_samples
         else:
-            return self.samples[self.nested_samples_indices]
+            return self.training_samples.nested_samples
+
+    @property
+    def state(self) -> _INSIntegralState:
+        if self.draw_iid_live:
+            return self.iid_samples.state
+        else:
+            return self.training_samples.state
+
+    @property
+    def final_samples(self) -> np.ndarray:
+        if self._final_samples is not None:
+            return self._final_samples.samples
+        elif self.iid_samples is not None:
+            return self.iid_samples.samples
+        else:
+            return None
+
+    @property
+    def final_state(self) -> _INSIntegralState:
+        if self._final_samples is not None:
+            return self._final_samples.state
+        elif self.iid_samples is not None:
+            return self.iid_samples.state
+        else:
+            return None
 
     @property
     def reached_tolerance(self) -> bool:
@@ -426,22 +472,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
             raise ValueError("`min_remove` must be less than `nlive`")
         return True
 
-    def sort_points(self, x: np.ndarray, *args) -> np.ndarray:
-        """Correctly sort new live points.
-
-        Parameters
-        ----------
-        x
-            Array to sort
-        args
-            Any extra iterables to sort in the same way as x.
-        """
-        idx = np.argsort(x, order="logL")
-        if len(args):
-            return get_subset_arrays(idx, x, *args)
-        else:
-            return x[idx]
-
     def populate_live_points(self) -> None:
         """Draw the initial live points from the prior.
 
@@ -482,18 +512,20 @@ class ImportanceNestedSampler(BaseNestedSampler):
         # Since log_Q is computed in the unit-cube
         live_points["logQ"] = np.zeros(live_points.size)
         live_points["logW"] = -live_points["logQ"]
+        log_q = np.zeros([live_points.size, 1])
 
         if self.draw_iid_live:
             live_points, iid_samples = (
                 live_points[: self.n_initial],
                 live_points[self.n_initial :],
             )
-            self.iid_samples = self.sort_points(iid_samples)
-            self.iid_log_q = np.zeros([self.iid_samples.size, 1])
+            log_q, iid_log_q = (
+                log_q[: self.n_initial, ...],
+                log_q[self.n_initial :, ...],
+            )
+            self.iid_samples.add_initial_samples(iid_samples, iid_log_q)
 
-        self.samples = self.sort_points(live_points)
-        self.live_points_indices = np.arange(live_points.size, dtype=int)
-        self.log_q = np.zeros([self.samples.size, 1])
+        self.training_samples.add_initial_samples(live_points, log_q)
 
     def initialise(self) -> None:
         """Initialise the nested sampler.
@@ -722,6 +754,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
         )
 
         self.logL_threshold = self.live_points[n]["logL"].copy()
+        self.training_samples.update_log_likelihood_threshold(
+            self.logL_threshold
+        )
+        if self.iid_samples:
+            self.iid_samples.update_log_likelihood_threshold(
+                self.logL_threshold
+            )
         logger.info(f"Log-likelihood threshold: {self.logL_threshold}")
         return n
 
@@ -730,31 +769,38 @@ class ImportanceNestedSampler(BaseNestedSampler):
         st = datetime.datetime.now()
 
         # Implicitly includes all samples
-        n_train = np.argmax(self.samples["logL"] >= self.logL_threshold)
-        self.training_samples = self.samples[n_train:].copy()
-        self.training_log_q = self.log_q[n_train:, :].copy()
+        n_train = np.argmax(
+            self.training_samples.samples["logL"] >= self.logL_threshold
+        )
+        self.current_training_samples = self.training_samples.samples[
+            n_train:
+        ].copy()
+        self.current_training_log_q = self.training_samples.log_q[
+            n_train:, :
+        ].copy()
 
         logger.info(
-            f"Training next proposal with {len(self.training_samples)} samples"
+            "Training next proposal with "
+            f"{len(self.current_training_samples)} samples"
         )
 
         logger.debug("Updating the contour")
         logger.debug(
             "Training data ESS: "
-            f"{effective_sample_size(self.training_samples['logW'])}"
+            f"{effective_sample_size(self.current_training_samples['logW'])}"
         )
 
         if self.replace_all:
-            weights = -np.exp(self.training_log_q[:, -1])
+            weights = -np.exp(self.current_training_log_q[:, -1])
         elif self.weighted_kl:
-            log_w = self.training_samples["logW"].copy()
+            log_w = self.current_training_samples["logW"].copy()
             log_w -= logsumexp(log_w)
             weights = np.exp(log_w)
         else:
             weights = None
 
         self.proposal.train(
-            self.training_samples,
+            self.current_training_samples,
             plot=self.plot_training_data,
             weights=weights,
         )
@@ -815,82 +861,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
         else:
             return (samples["logL"] < self.logL_threshold).sum() / samples.size
 
-    def compute_importance(self, G: float = 0.5):
-        """Compute the importance
-
-        Parameters
-        ----------
-        G :
-            relative importance of the posterior versus the evidence. G=1 is
-            only the posterior and G=0 is only the evidence,
-
-        Returns
-        -------
-        dict
-            Dictionary containing the total, posterior and evidence importance
-            as a function of iteration.
-        """
-        log_imp_post = np.empty(self.log_q.shape[1])
-        log_imp_z = np.empty(self.log_q.shape[1])
-        for i, it in enumerate(range(-1, self.log_q.shape[-1] - 1)):
-            sidx = np.where(self.samples["it"] == it)[0]
-            zidx = np.where(self.samples["it"] >= it)[0]
-            log_imp_post[i] = logsumexp(
-                self.samples["logL"][sidx] + self.samples["logW"][sidx]
-            ) - np.log(len(sidx))
-            log_imp_z[i] = logsumexp(
-                self.samples["logL"][zidx] + self.samples["logW"][zidx]
-            ) - np.log(len(zidx))
-        imp_z = np.exp(log_imp_z - logsumexp(log_imp_z))
-        imp_post = np.exp(log_imp_post - logsumexp(log_imp_post))
-        imp = (1 - G) * imp_z + G * imp_post
-        return {"total": imp, "posterior": imp_post, "evidence": imp_z}
-
-    def add_samples(self, samples: np.ndarray, log_q: np.ndarray) -> None:
-        """Add samples the existing samples
-
-        Samples MUST be sorted by logL.
-        """
-        # Insert samples into existing samples
-        indices = np.searchsorted(self.samples["logL"], samples["logL"])
-        self.samples = np.insert(self.samples, indices, samples)
-        self.log_q = np.insert(self.log_q, indices, log_q, axis=0)
-
-        if self.strict_threshold:
-            n = np.argmax(self.samples["logL"] >= self.logL_threshold)
-            indices = np.arange(len(self.samples))
-            self.nested_samples_indices = indices[:n]
-            self.live_points_indices = indices[n:]
-        else:
-            # Indices after insertion are indices + n before
-            new_indices = indices + np.arange(len(indices))
-
-            # Indices of all previous samples
-            old_indices = get_inverse_indices(self.samples.size, new_indices)
-
-            if len(old_indices) != (self.samples.size - samples.size):
-                raise RuntimeError("Mismatch in updated_indices!")
-
-            # Updated indices of nested samples
-            self.nested_samples_indices = old_indices[
-                self.nested_samples_indices
-            ]
-
-            if self.live_points_indices is None:
-                self.live_points_indices = new_indices
-            else:
-                self.live_points_indices = old_indices[
-                    self.live_points_indices
-                ]
-                insert_indices = np.searchsorted(
-                    self.live_points_indices, new_indices
-                )
-                self.live_points_indices = np.insert(
-                    self.live_points_indices,
-                    insert_indices,
-                    new_indices,
-                )
-
     def add_and_update_points(self, n: int):
         """Add new points to the current set of live points.
 
@@ -910,9 +880,20 @@ class ImportanceNestedSampler(BaseNestedSampler):
                 new_samples[: n // 2],
                 new_samples[n // 2 :],
             )
-            log_q, iid_log_q = log_q[: n // 2], log_q[n // 2 :]
-            idd_samples, iid_log_q = self.sort_points(iid_samples, iid_log_q)
-        new_samples, log_q = self.sort_points(new_samples, log_q)
+            log_q, iid_log_q = log_q[: n // 2, ...], log_q[n // 2 :, ...]
+            self.iid_samples.log_q = self.proposal.update_log_q(
+                self.iid_samples.samples, self.iid_samples.log_q
+            )
+            self.iid_samples.samples[
+                "logQ"
+            ] = self.proposal.compute_meta_proposal_from_log_q(
+                self.iid_samples.log_q
+            )
+            self.iid_samples.samples["logW"] = -self.iid_samples.samples[
+                "logQ"
+            ]
+            self.iid_samples.add_samples(iid_samples, iid_log_q)
+
         self._current_proposal_entropy = differential_entropy(-log_q[:, -1])
 
         logger.debug(
@@ -921,72 +902,37 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         if self.plot and self.plot_pool:
             plot_1d_comparison(
-                self.training_samples,
+                self.current_training_samples,
                 new_samples,
                 filename=os.path.join(
                     self.output, "levels", f"pool_{self.iteration}.png"
                 ),
             )
 
-        self.log_q = self.proposal.update_log_q(self.samples, self.log_q)
-
-        self.samples["logQ"] = self.proposal.compute_meta_proposal_from_log_q(
-            self.log_q
+        self.training_samples.log_q = self.proposal.update_log_q(
+            self.training_samples.samples, self.training_samples.log_q
         )
-        self.samples["logW"] = -self.samples["logQ"]
-        if self.draw_iid_live:
-            self.iid_log_q = self.proposal.update_log_q(
-                self.iid_samples, self.iid_log_q
-            )
-            self.iid_samples[
-                "logQ"
-            ] = self.proposal.compute_meta_proposal_from_log_q(self.iid_log_q)
-            self.iid_samples["logW"] = -self.iid_samples["logQ"]
-            self.add_iid_samples(iid_samples, iid_log_q)
+
+        self.training_samples.samples[
+            "logQ"
+        ] = self.proposal.compute_meta_proposal_from_log_q(
+            self.training_samples.log_q
+        )
+        self.training_samples.samples["logW"] = -self.training_samples.samples[
+            "logQ"
+        ]
+
+        self.training_samples.add_samples(new_samples, log_q)
 
         self.history["n_added"].append(new_samples.size)
 
-        self.add_samples(new_samples, log_q)
-
-        live_points = self.live_points
-        self.history["n_live"].append(live_points.size)
-        self.live_points_ess = effective_sample_size(live_points["logW"])
+        self.history["n_live"].append(self.live_points.size)
+        self.live_points_ess = effective_sample_size(self.live_points["logW"])
         self.history["leakage_live_points"].append(
-            self.compute_leakage(live_points)
+            self.compute_leakage(self.live_points)
         )
         logger.debug(f"Current live points ESS: {self.live_points_ess:.2f}")
         self.add_and_update_samples_time += datetime.datetime.now() - st
-
-    def add_iid_samples(self, iid_samples, iid_log_q):
-        logger.info("Drawing i.i.d samples")
-
-        # Insert samples into existing samples
-        indices = np.searchsorted(
-            self.iid_samples["logL"], iid_samples["logL"]
-        )
-        self.iid_samples = np.insert(self.iid_samples, indices, iid_samples)
-        self.iid_log_q = np.insert(self.iid_log_q, indices, iid_log_q, axis=0)
-        log_w = self.iid_samples["logL"] + self.iid_samples["logW"]
-        logZ = logsumexp(log_w) - np.log(len(self.iid_samples))
-        logger.info(f"i.i.d logZ = {logZ}")
-        above = self.iid_samples["logL"] >= self.logL_threshold
-        logZ_above = logsumexp(log_w[above]) - np.log(above.sum())
-        self.iid_ratio = logZ_above - logZ
-        logger.info(f"i.i.d ratio: {self.iid_ratio}")
-        self.iid_state = _INSIntegralState()
-        self.iid_state.update_evidence(self.iid_samples)
-        logger.info(
-            f"i.i.d ESS: {self.iid_state.effective_n_posterior_samples}"
-        )
-
-    def add_to_nested_samples(self, indices: np.ndarray) -> None:
-        """Add an array of samples to the nested samples."""
-        sort_indices = np.searchsorted(self.nested_samples_indices, indices)
-        self.nested_samples_indices = np.insert(
-            self.nested_samples_indices,
-            sort_indices,
-            indices,
-        )
 
     def remove_samples(self, n: int) -> None:
         """Remove samples from the current set of live points.
@@ -1001,20 +947,16 @@ class ImportanceNestedSampler(BaseNestedSampler):
         else:
             self.history["n_removed"].append(n)
         logger.debug(f"Removing {n} points")
-
-        if self.replace_all:
-            self.add_to_nested_samples(self.live_points_indices)
-            self.live_points_indices = None
-        else:
-            self.add_to_nested_samples(self.live_points_indices[:n])
-            self.live_points_indices = np.delete(
-                self.live_points_indices, np.s_[:n]
-            )
+        self.training_samples.remove_samples(n)
+        if self.draw_iid_live:
+            self.iid_samples.remove_samples(n)
 
     def adjust_final_samples(self, n_batches=5):
         """Adjust the final samples"""
-        orig_n_total = self.samples.size
-        its, counts = np.unique(self.samples["it"], return_counts=True)
+        orig_n_total = self.training_samples.size
+        its, counts = np.unique(
+            self.training_samples["it"], return_counts=True
+        )
         assert counts.sum() == orig_n_total
         weights = counts / orig_n_total
         original_unnorm_weight = counts.copy()
@@ -1024,9 +966,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
         logger.debug(f"Final weights: {weights}")
         logger.debug(f"Final its: {list(self.proposal.n_requested.keys())}")
 
-        sort_idx = np.argsort(self.samples, order="it")
-        samples = self.samples[sort_idx].copy()
-        log_q = self.log_q[sort_idx].copy()
+        sort_idx = np.argsort(self.training_samples.samples, order="it")
+        samples = self.training_samples[sort_idx].copy()
+        log_q = self.training_log_q[sort_idx].copy()
         n_total = samples.size
 
         # This changes the proposal because the number of samples changes
@@ -1111,27 +1053,23 @@ class ImportanceNestedSampler(BaseNestedSampler):
         if self._train_final_flow:
             self.train_final_flow()
 
-        self.add_to_nested_samples(self.live_points_indices)
-        self.live_points = None
-        self.state.update_evidence(self.samples)
+        self.training_samples.finalise()
+        if self.draw_iid_live:
+            self.iid_samples.finalise()
 
         if self.bootstrap:
             self.adjust_final_samples()
 
-        if self.draw_iid_live:
-            self.final_samples = self.iid_samples
-            self.final_state = self.iid_state
-            final_kl = self.kl_divergence(self.final_samples)
-            state = self.final_state
-        else:
-            final_kl = self.kl_divergence(self.samples)
-            state = self.state
+        final_kl = self.kl_divergence(self.samples)
+
         logger.info(
-            f"Final log Z: {state.logZ:.3f} "
-            f"+/- {state.compute_uncertainty():.3f}"
+            f"Final log Z: {self.state.logZ:.3f} "
+            f"+/- {self.state.compute_uncertainty():.3f}"
         )
         logger.info(f"Final KL divergence: {final_kl:.3f}")
-        logger.info(f"Final ESS: {state.effective_n_posterior_samples:.3f}")
+        logger.info(
+            f"Final ESS: {self.state.effective_n_posterior_samples:.3f}"
+        )
         self.finalised = True
         self.checkpoint(periodic=True, force=True)
         self.produce_plots()
@@ -1205,6 +1143,18 @@ class ImportanceNestedSampler(BaseNestedSampler):
             f"logL max: {self.live_points['logL'].max():.3f}"
         )
 
+    def update_evidence(self):
+        self.training_samples.update_evidence()
+        if self.draw_iid_live:
+            self.iid_samples.update_evidence()
+
+    def compute_importance(self, **kwargs):
+        if self.draw_iid_live:
+            importance = self.iid_samples.compute_importance(**kwargs)
+        else:
+            importance = self.training_samples.compute_importance(**kwargs)
+        return importance
+
     def nested_sampling_loop(self):
         """Main nested sampling loop."""
         if self.finalised:
@@ -1239,7 +1189,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
                 n_add = n_remove
             self.add_and_update_points(n_add)
 
-            self.importance = self.compute_importance(G=0.5)
+            self.importance = self.compute_importance(importance_ratio=0.5)
 
             self.state.update_evidence(self.nested_samples, self.live_points)
             self.criterion = self.compute_stopping_criterion()
@@ -1266,7 +1216,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             f"Add and update samples time: {self.add_and_update_samples_time}"
         )
         logger.info(f"Log-likelihood time: {self.likelihood_evaluation_time}")
-        return self.log_evidence, self.nested_samples
+        return self.log_evidence, self.samples
 
     def draw_posterior_samples(
         self,
@@ -1394,21 +1344,23 @@ class ImportanceNestedSampler(BaseNestedSampler):
             raise RuntimeError("Specify either `n_post` or `n_draw`")
         start_time = datetime.datetime.now()
 
-        if self.final_state:
-            logger.warning("Existing final state will be overridden")
+        if self._final_samples:
+            logger.warning("Existing final samples will be overridden")
+        elif self.iid_samples:
+            logger.warning("Already have i.i.d samples")
 
-        self.final_state = _INSIntegralState()
+        final_samples = OrderedSamples()
 
         eff = (
             self.state.effective_n_posterior_samples / self.nested_samples.size
         )
         max_samples = int(max_samples_ratio * self.nested_samples.size)
 
-        max_log_likelihood = np.max(self.nested_samples["logL"])
+        max_log_likelihood = np.max(self.samples["logL"])
 
         logger.debug(f"Expected efficiency: {eff:.3f}")
         if not any([n_post, n_draw]):
-            n_draw = self.nested_samples.size
+            n_draw = self.samples.size
 
         if n_post:
             n_draw = int(n_post / eff)
@@ -1520,8 +1472,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
             samples["logQ"] = log_Q
             samples["logW"] = -log_Q
 
-            self.final_state.update_evidence(samples)
-            ess = self.final_state.effective_n_posterior_samples
+            final_samples.state.update_evidence(samples)
+            ess = final_samples.state.effective_n_posterior_samples
             logger.debug(f"Sample count: {samples.size}")
             logger.debug(f"Current ESS: {ess}")
             it += 1
@@ -1532,11 +1484,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         logger.info(f"Drew {samples.size} final samples")
         logger.info(
-            f"Final log-evidence: {self.final_state.logZ:.3f} "
-            f"+/- {self.final_state.compute_uncertainty():.3f}"
+            f"Final log-evidence: {final_samples.state.log_evidence:.3f} "
+            f"+/- {final_samples.state.log_evidence_error:.3f}"
         )
         logger.info(f"Final ESS: {ess:.1f}")
-        self.final_samples = samples
+        final_samples.samples = samples
+        final_samples.log_q = log_q
+        self._final_samples = final_samples
         self.draw_final_samples_time += datetime.datetime.now() - start_time
         return self.final_state.logZ, samples
 
@@ -1942,14 +1896,20 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def get_result_dictionary(self):
         """Get a dictionary contain the main results from the sampler."""
         d = super().get_result_dictionary()
-        d["initial_samples"] = self.samples
-        d["initial_log_evidence"] = self.log_evidence
-        d["initial_log_evidence_error"] = self.log_evidence_error
+        d["history"] = self.history
+        d["training_samples"] = self.training_samples.samples
+        d["training_log_evidence"] = self.training_samples.state.log_evidence
+        d[
+            "training_log_evidence_error"
+        ] = self.training_samples.state.log_evidence_error
+        d[
+            "training_log_posterior_weights"
+        ] = self.training_samples.state.log_posterior_weights
         # Will all be None if the final samples haven't been drawn
         d["bootstrap_log_evidence"] = self.bootstrap_log_evidence
         d["bootstrap_log_evidence_error"] = self.bootstrap_log_evidence_error
         d["samples"] = self.final_samples
-        d["log_posterior_weights"] = self.state.log_posterior_weights
+        d["log_posterior_weights"] = self.final_log_posterior_weights
         d["log_evidence"] = self.final_log_evidence
         d["log_evidence_error"] = self.final_log_evidence_error
 
@@ -1997,9 +1957,16 @@ class ImportanceNestedSampler(BaseNestedSampler):
             flow_config = {}
         obj.proposal.resume(model, flow_config, weights_path=weights_path)
 
-        if obj.log_q is None:
-            logger.debug("Recomputing log_q")
-            obj.log_q = obj.proposal.compute_meta_proposal_samples(obj.samples)
+        logger.debug("Recomputing log_q")
+        obj.training_samples.log_q = (
+            obj.proposal.compute_meta_proposal_samples(
+                obj.training_samples.samples
+            )
+        )
+        if obj.iid_samples:
+            obj.iid_samples.log_q = obj.proposal.compute_meta_proposal_samples(
+                obj.iid_samples.samples
+            )
 
         logger.info(f"Resuming sampler at iteration {obj.iteration}")
         logger.info(f"Current number of samples: {len(obj.nested_samples)}")
@@ -2011,7 +1978,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
     def __getstate__(self):
         d = self.__dict__
-        exclude = {"model", "proposal", "log_q", "checkpoint_callback"}
+        exclude = {
+            "model",
+            "proposal",
+            "checkpoint_callback",
+            "training_samples",
+            "iid_samples",
+        }
         state = {k: d[k] for k in d.keys() - exclude}
         if d.get("model") is not None:
             state["_previous_likelihood_evaluations"] = d[
@@ -2024,8 +1997,194 @@ class ImportanceNestedSampler(BaseNestedSampler):
             state["_previous_likelihood_evaluations"] = 0
             state["_previous_likelihood_evaluation_time"] = 0
         state["log_q"] = None
-        return state, self.proposal
+        return state, self.proposal, self.training_samples, self.iid_samples
 
     def __setstate__(self, state):
         self.__dict__.update(state[0])
         self.proposal = state[1]
+        self.training_samples = state[2]
+        self.iid_samples = state[3]
+
+
+class OrderedSamples:
+    """Samples ordered by log-likelihood."""
+
+    def __init__(
+        self,
+        strict_threshold: bool = False,
+        replace_all: bool = False,
+    ) -> None:
+        self.samples = None
+        self.log_q = None
+        self.live_points_indices = None
+        self.nested_samples_indices = np.empty(0, dtype=int)
+        self.strict_threshold = strict_threshold
+        self.replace_all = replace_all
+        self.state = _INSIntegralState()
+
+    @property
+    def live_points(self) -> np.ndarray:
+        """The current set of live points"""
+        if self.live_points_indices is None:
+            return None
+        else:
+            return self.samples[self.live_points_indices]
+
+    @live_points.setter
+    def live_points(self, value):
+        if value is not None:
+            raise ValueError("Can only set live points to None!")
+        self.live_points_indices = None
+
+    @property
+    def nested_samples(self) -> np.ndarray:
+        """The current set of discarded points"""
+        if self.nested_samples_indices is None:
+            return None
+        else:
+            return self.samples[self.nested_samples_indices]
+
+    def update_log_likelihood_threshold(self, threshold: float) -> None:
+        self.log_likelihood_threshold = threshold
+
+    def sort_samples(self, samples: np.ndarray, *args) -> np.ndarray:
+        """Correctly sort new live points.
+
+        Parameters
+        ----------
+        x
+            Array to sort
+        args
+            Any extra iterables to sort in the same way as x.
+        """
+        idx = np.argsort(samples, order="logL")
+        if len(args):
+            return get_subset_arrays(idx, samples, *args)
+        else:
+            return samples[idx]
+
+    def add_initial_samples(
+        self, samples: np.ndarray, log_q: np.ndarray
+    ) -> None:
+        self.samples, self.log_q = self.sort_samples(samples, log_q)
+        self.live_points_indices = np.arange(self.samples.size, dtype=int)
+
+    def add_samples(self, samples: np.ndarray, log_q: np.ndarray) -> None:
+        """Add samples the existing samples"""
+        # Insert samples into existing samples
+        samples, log_q = self.sort_samples(samples, log_q)
+        indices = np.searchsorted(self.samples["logL"], samples["logL"])
+        self.samples = np.insert(self.samples, indices, samples)
+        self.log_q = np.insert(self.log_q, indices, log_q, axis=0)
+
+        if self.strict_threshold:
+            n = np.argmax(
+                self.samples["logL"] >= self.log_likelihood_threshold
+            )
+            indices = np.arange(len(self.samples))
+            self.nested_samples_indices = indices[:n]
+            self.live_points_indices = indices[n:]
+        else:
+            # Indices after insertion are indices + n before
+            new_indices = indices + np.arange(len(indices))
+
+            # Indices of all previous samples
+            old_indices = get_inverse_indices(self.samples.size, new_indices)
+
+            if len(old_indices) != (self.samples.size - samples.size):
+                raise RuntimeError("Mismatch in updated_indices!")
+
+            # Updated indices of nested samples
+            self.nested_samples_indices = old_indices[
+                self.nested_samples_indices
+            ]
+
+            if self.live_points_indices is None:
+                self.live_points_indices = new_indices
+            else:
+                self.live_points_indices = old_indices[
+                    self.live_points_indices
+                ]
+                insert_indices = np.searchsorted(
+                    self.live_points_indices, new_indices
+                )
+                self.live_points_indices = np.insert(
+                    self.live_points_indices,
+                    insert_indices,
+                    new_indices,
+                )
+
+    def add_to_nested_samples(self, indices: np.ndarray) -> None:
+        """Add an array of samples to the nested samples."""
+        sort_indices = np.searchsorted(self.nested_samples_indices, indices)
+        self.nested_samples_indices = np.insert(
+            self.nested_samples_indices,
+            sort_indices,
+            indices,
+        )
+
+    def remove_samples(self, n: int) -> None:
+        """Remove samples from the current set of live points.
+
+        Parameters
+        ----------
+        n : int
+            The number of samples to remove.
+        """
+        if self.replace_all:
+            self.add_to_nested_samples(self.live_points_indices)
+            self.live_points_indices = None
+        else:
+            self.add_to_nested_samples(self.live_points_indices[:n])
+            self.live_points_indices = np.delete(
+                self.live_points_indices, np.s_[:n]
+            )
+
+    def update_evidence(self) -> None:
+        self.state.update_evidence(
+            nested_samples=self.nested_samples,
+            live_points=self.live_points,
+        )
+
+    def finalise(self) -> None:
+        self.add_to_nested_samples(self.live_points_indices)
+        self.live_points = None
+        self.state.update_evidence(self.samples)
+
+    def compute_importance(self, importance_ratio: float = 0.5):
+        """Compute the importance
+
+        Parameters
+        ----------
+        importance_factor :
+            Relative importance of the posterior versus the evidence. 1 is
+            only the posterior and 0 is only the evidence.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the total, posterior and evidence importance
+            as a function of iteration.
+        """
+        log_imp_post = np.empty(self.log_q.shape[1])
+        log_imp_z = np.empty(self.log_q.shape[1])
+        for i, it in enumerate(range(-1, self.log_q.shape[-1] - 1)):
+            sidx = np.where(self.samples["it"] == it)[0]
+            zidx = np.where(self.samples["it"] >= it)[0]
+            log_imp_post[i] = logsumexp(
+                self.samples["logL"][sidx] + self.samples["logW"][sidx]
+            ) - np.log(len(sidx))
+            log_imp_z[i] = logsumexp(
+                self.samples["logL"][zidx] + self.samples["logW"][zidx]
+            ) - np.log(len(zidx))
+        imp_z = np.exp(log_imp_z - logsumexp(log_imp_z))
+        imp_post = np.exp(log_imp_post - logsumexp(log_imp_post))
+        imp = (1 - importance_ratio) * imp_z + importance_ratio * imp_post
+        return {"total": imp, "posterior": imp_post, "evidence": imp_z}
+
+    def __getstate__(self):
+        d = self.__dict__
+        exclude = {"log_q"}
+        state = {k: d[k] for k in d.keys() - exclude}
+        state["log_q"] = None
+        return state

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1211,6 +1211,22 @@ class ImportanceNestedSampler(BaseNestedSampler):
                     break
             else:
                 n_remove = self.n_update
+                if (self.live_points_unit.size - n_remove) < self.min_samples:
+                    n_remove = self.live_points_unit.size - self.min_samples
+                logger.info(
+                    f"Removing {n_remove} samples from "
+                    f"{self.live_points_unit.size}"
+                )
+                self.logL_threshold = self.live_points_unit[n_remove][
+                    "logL"
+                ].copy()
+                self.training_samples.update_log_likelihood_threshold(
+                    self.logL_threshold
+                )
+                if self.iid_samples:
+                    self.iid_samples.update_log_likelihood_threshold(
+                        self.logL_threshold
+                    )
             self.remove_samples(n_remove)
 
             self.add_new_proposal()

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -22,7 +22,6 @@ from ..plot import nessai_style, plot_1d_comparison
 from ..livepoint import (
     add_extra_parameters_to_live_points,
     get_dtype,
-    numpy_array_to_live_points,
 )
 from ..utils.hist import auto_bins
 from ..utils.information import differential_entropy
@@ -301,7 +300,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         where :math:`W(x) = \\pi(x)/Q(x)`.
         """
-        return differential_entropy(self.samples["logW"])
+        return differential_entropy(self.samples_unit["logW"])
 
     @property
     def current_proposal_entropy(self) -> float:
@@ -309,11 +308,15 @@ class ImportanceNestedSampler(BaseNestedSampler):
         return self._current_proposal_entropy
 
     @property
-    def samples(self) -> np.ndarray:
+    def samples_unit(self) -> np.ndarray:
         if self.draw_iid_live:
             return self.iid_samples.samples
         else:
             return self.training_samples.samples
+
+    @property
+    def samples(self) -> np.ndarray:
+        return self.model.from_unit_hypercube(self.samples_unit)
 
     @property
     def log_q(self) -> np.ndarray:
@@ -323,12 +326,21 @@ class ImportanceNestedSampler(BaseNestedSampler):
             return self.training_samples.log_q
 
     @property
-    def live_points(self) -> np.ndarray:
+    def live_points_unit(self) -> np.ndarray:
         """The current set of live points"""
         if self.draw_iid_live:
             return self.iid_samples.live_points
         else:
             return self.training_samples.live_points
+
+    @live_points_unit.setter
+    def live_points_unit(self, samples) -> None:
+        if samples is not None:
+            raise RuntimeError("Cannot set live points")
+
+    @property
+    def live_points(self) -> np.ndarray:
+        return self.model.from_unit_hypercube(self.live_points_unit)
 
     @live_points.setter
     def live_points(self, samples) -> None:
@@ -336,12 +348,16 @@ class ImportanceNestedSampler(BaseNestedSampler):
             raise RuntimeError("Cannot set live points")
 
     @property
-    def nested_samples(self) -> np.ndarray:
+    def nested_samples_unit(self) -> np.ndarray:
         """The current set of discarded points"""
         if self.draw_iid_live:
             return self.iid_samples.nested_samples
         else:
             return self.training_samples.nested_samples
+
+    @property
+    def nested_samples(self) -> np.ndarray:
+        return self.model.from_unit_hypercube(self.nested_samples_unit)
 
     @property
     def state(self) -> _INSIntegralState:
@@ -351,13 +367,17 @@ class ImportanceNestedSampler(BaseNestedSampler):
             return self.training_samples.state
 
     @property
-    def final_samples(self) -> np.ndarray:
+    def final_samples_unit(self) -> np.ndarray:
         if self._final_samples is not None:
             return self._final_samples.samples
         elif self.iid_samples is not None:
             return self.iid_samples.samples
         else:
             return None
+
+    @property
+    def final_samples(self) -> np.ndarray:
+        return self.model.from_unit_hypercube(self.final_samples_unit)
 
     @property
     def final_state(self) -> _INSIntegralState:
@@ -486,13 +506,10 @@ class ImportanceNestedSampler(BaseNestedSampler):
         n = 0
         logger.debug(f"Drawing {self.n_initial} initial points")
         while n < target:
-            points = self.model.from_unit_hypercube(
-                numpy_array_to_live_points(
-                    np.random.rand(target, self.model.dims),
-                    self.model.names,
-                )
+            points = self.model.sample_unit_hypercube(target)
+            points["logP"] = self.model.batch_evaluate_log_prior(
+                points, unit_hypercube=True
             )
-            points["logP"] = self.model.batch_evaluate_log_prior(points)
             accept = np.isfinite(points["logP"])
             n_it = accept.sum()
             m = min(n_it, target - n)
@@ -500,7 +517,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             n += m
 
         live_points["logL"] = self.model.batch_evaluate_log_likelihood(
-            live_points
+            live_points, unit_hypercube=True
         )
         if not np.isfinite(live_points["logL"]).all():
             logger.warning("Found infinite values in the log-likelihood")
@@ -534,7 +551,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """
         if self.initialised:
             logger.warning("Nested sampler has already initialised!")
-        if self.live_points is None:
+        if self.live_points_unit is None:
             self.populate_live_points()
 
         self.initialise_history()
@@ -575,12 +592,14 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def update_history(self) -> None:
         """Update the history dictionary"""
         self.history["min_log_likelihood"].append(
-            np.min(self.live_points["logL"])
+            np.min(self.live_points_unit["logL"])
         )
         self.history["max_log_likelihood"].append(
-            np.max(self.live_points["logL"])
+            np.max(self.live_points_unit["logL"])
         )
-        self.history["median_logL"].append(np.median(self.live_points["logL"]))
+        self.history["median_logL"].append(
+            np.median(self.live_points_unit["logL"])
+        )
         self.history["logL_threshold"].append(self.logL_threshold)
         self.history["logX"].append(self.logX)
         self.history["gradients"].append(self.gradient)
@@ -618,11 +637,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
             The number of live points to discard.
         """
         logger.debug(f"Determining {q:.3f} quantile")
-        a = self.live_points["logL"]
+        a = self.live_points_unit["logL"]
         if include_likelihood:
-            log_weights = self.live_points["logW"] + self.live_points["logL"]
+            log_weights = (
+                self.live_points_unit["logW"] + self.live_points_unit["logL"]
+            )
         else:
-            log_weights = self.live_points["logW"].copy()
+            log_weights = self.live_points_unit["logW"].copy()
         cutoff = weighted_quantile(
             a, q, log_weights=log_weights, values_sorted=True
         )
@@ -653,9 +674,11 @@ class ImportanceNestedSampler(BaseNestedSampler):
             log-weights.
         """
         if include_likelihood:
-            log_weights = self.live_points["logW"] + self.live_points["logL"]
+            log_weights = (
+                self.live_points_unit["logW"] + self.live_points_unit["logL"]
+            )
         else:
-            log_weights = self.live_points["logW"]
+            log_weights = self.live_points_unit["logW"]
         if use_log_weights:
             p = log_weights
         else:
@@ -672,7 +695,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             os.makedirs(output, exist_ok=True)
             self.plot_level_cdf(
                 cdf,
-                threshold=self.live_points["logL"][n],
+                threshold=self.live_points_unit["logL"][n],
                 q=q,
                 filename=os.path.join(output, "cdf.png"),
             )
@@ -703,7 +726,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             specified.
         """
         fig = plt.figure()
-        plt.plot(self.live_points["logL"], cdf)
+        plt.plot(self.live_points_unit["logL"], cdf)
         plt.xlabel("Log-likelihood")
         plt.title("CDF")
         plt.axhline(q, c="C1")
@@ -737,23 +760,23 @@ class ImportanceNestedSampler(BaseNestedSampler):
                 return 0
             else:
                 n = 1
-        if (self.live_points.size - n) < self.min_samples:
+        if (self.live_points_unit.size - n) < self.min_samples:
             logger.warning(
-                f"Cannot remove {n} from {self.live_points.size}, "
+                f"Cannot remove {n} from {self.live_points_unit.size}, "
                 f"min_samples={self.min_samples}"
             )
-            n = max(0, self.live_points.size - self.min_samples)
+            n = max(0, self.live_points_unit.size - self.min_samples)
         elif n < self.min_remove:
             logger.warning(
                 f"Cannot remove less than {self.min_remove} samples"
             )
             n = self.min_remove
         logger.info(
-            f"Removing {n}/{self.live_points.size} samples to train next "
+            f"Removing {n}/{self.live_points_unit.size} samples to train next "
             "proposal"
         )
 
-        self.logL_threshold = self.live_points[n]["logL"].copy()
+        self.logL_threshold = self.live_points_unit[n]["logL"].copy()
         self.training_samples.update_log_likelihood_threshold(
             self.logL_threshold
         )
@@ -816,7 +839,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
         new_points, log_q = self.proposal.draw(n)
         logger.debug("Evaluating likelihood for new points")
         new_points["logL"] = self.model.batch_evaluate_log_likelihood(
-            new_points
+            new_points,
+            unit_hypercube=True,
         )
         logger.debug(
             "Min. log-likelihood of new samples: "
@@ -926,10 +950,12 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         self.history["n_added"].append(new_samples.size)
 
-        self.history["n_live"].append(self.live_points.size)
-        self.live_points_ess = effective_sample_size(self.live_points["logW"])
+        self.history["n_live"].append(self.live_points_unit.size)
+        self.live_points_ess = effective_sample_size(
+            self.live_points_unit["logW"]
+        )
         self.history["leakage_live_points"].append(
-            self.compute_leakage(self.live_points)
+            self.compute_leakage(self.live_points_unit)
         )
         logger.debug(f"Current live points ESS: {self.live_points_ess:.2f}")
         self.add_and_update_samples_time += datetime.datetime.now() - st
@@ -943,7 +969,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             The number of samples to remove.
         """
         if self.replace_all:
-            self.history["n_removed"].append(self.live_points.size)
+            self.history["n_removed"].append(self.live_points_unit.size)
         else:
             self.history["n_removed"].append(n)
         logger.debug(f"Removing {n} points")
@@ -1000,7 +1026,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
                     new_samples["it"] = it
                     new_samples[
                         "logL"
-                    ] = self.model.batch_evaluate_log_likelihood(new_samples)
+                    ] = self.model.batch_evaluate_log_likelihood(
+                        new_samples, unit_hypercube=True
+                    )
                     new_loc = np.searchsorted(samples["it"], new_samples["it"])
                     samples = np.insert(samples, new_loc, new_samples)
                     log_q = np.insert(log_q, new_loc, new_log_q, axis=0)
@@ -1060,7 +1088,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         if self.bootstrap:
             self.adjust_final_samples()
 
-        final_kl = self.kl_divergence(self.samples)
+        final_kl = self.kl_divergence(self.samples_unit)
 
         logger.info(
             f"Final log Z: {self.state.logZ:.3f} "
@@ -1083,7 +1111,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         log_q = self.update_live_points(new_samples, log_q)
         self.update_nested_samples()
         self.add_to_nested_samples(new_samples)
-        self.state.update_evidence(self.nested_samples)
+        self.state.update_evidence(self.nested_samples_unit)
 
     def compute_stopping_criterion(self) -> List[float]:
         """Compute the stopping criterion.
@@ -1096,7 +1124,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             self.log_dZ = np.inf
         self.ratio = self.state.compute_evidence_ratio(ns_only=False)
         self.ratio_ns = self.state.compute_evidence_ratio(ns_only=True)
-        self.kl = self.kl_divergence(self.samples)
+        self.kl = self.kl_divergence(self.samples_unit)
         self.ess = self.state.effective_n_posterior_samples
         self.Z_err = np.exp(self.log_evidence_error)
         cond = [getattr(self, sc) for sc in self.stopping_criterion]
@@ -1122,10 +1150,10 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
     def _compute_gradient(self) -> None:
         self.logX_pre = self.logX
-        self.logX = logsumexp(self.live_points["logW"])
+        self.logX = logsumexp(self.live_points_unit["logW"])
         self.logL_pre = self.logL
         self.logL = logsumexp(
-            self.live_points["logL"] - self.live_points["logQ"]
+            self.live_points_unit["logL"] - self.live_points_unit["logQ"]
         )
         self.dlogX = self.logX - self.logX_pre
         self.dlogL = self.logL - self.logL_pre
@@ -1138,9 +1166,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
             f"log Z: {self.state.logZ:.3f} +/- "
             f"{self.state.compute_uncertainty():.3f} "
             f"ESS: {self.ess:.1f} "
-            f"logL min: {self.live_points['logL'].min():.3f} "
-            f"logL median: {np.nanmedian(self.live_points['logL']):.3f} "
-            f"logL max: {self.live_points['logL'].max():.3f}"
+            f"logL min: {self.live_points_unit['logL'].min():.3f} "
+            f"logL median: {np.nanmedian(self.live_points_unit['logL']):.3f} "
+            f"logL max: {self.live_points_unit['logL'].max():.3f}"
         )
 
     def update_evidence(self):
@@ -1159,7 +1187,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """Main nested sampling loop."""
         if self.finalised:
             logger.warning("Sampler has already finished sampling! Aborting")
-            return self.log_evidence, self.nested_samples
+            return self.log_evidence, self.nested_samples_unit
         self.initialise()
         logger.info("Starting the nested sampling loop")
 
@@ -1191,7 +1219,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
             self.importance = self.compute_importance(importance_ratio=0.5)
 
-            self.state.update_evidence(self.nested_samples, self.live_points)
+            self.state.update_evidence(
+                self.nested_samples_unit, self.live_points_unit
+            )
             self.criterion = self.compute_stopping_criterion()
 
             self.log_state()
@@ -1226,11 +1256,11 @@ class ImportanceNestedSampler(BaseNestedSampler):
     ) -> np.ndarray:
         """Draw posterior samples from the current nested samples."""
 
-        if use_final_samples and self.final_samples is not None:
+        if use_final_samples and self.final_samples_unit is not None:
             samples = self.final_samples
             log_w = self.final_state.log_posterior_weights
         else:
-            samples = self.nested_samples
+            samples = self.samples
             log_w = self.state.log_posterior_weights
 
         posterior_samples, indices = draw_posterior_samples(
@@ -1269,7 +1299,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def draw_more_nested_samples(self, n: int) -> np.ndarray:
         """Draw more nested samples from g"""
         samples = self.proposal.draw_from_flows(n)
-        samples["logL"] = self.model.batch_evaluate_log_likelihood(samples)
+        samples["logL"] = self.model.batch_evaluate_log_likelihood(
+            samples, unit_hypercube=True
+        )
         state = _INSIntegralState()
         state.update_evidence(samples)
         logger.info(
@@ -1352,15 +1384,16 @@ class ImportanceNestedSampler(BaseNestedSampler):
         final_samples = OrderedSamples()
 
         eff = (
-            self.state.effective_n_posterior_samples / self.nested_samples.size
+            self.state.effective_n_posterior_samples
+            / self.nested_samples_unit.size
         )
-        max_samples = int(max_samples_ratio * self.nested_samples.size)
+        max_samples = int(max_samples_ratio * self.nested_samples_unit.size)
 
-        max_log_likelihood = np.max(self.samples["logL"])
+        max_logL = np.max(self.samples_unit["logL"])
 
         logger.debug(f"Expected efficiency: {eff:.3f}")
         if not any([n_post, n_draw]):
-            n_draw = self.samples.size
+            n_draw = self.samples_unit.size
 
         if n_post:
             n_draw = int(n_post / eff)
@@ -1394,7 +1427,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
                 if optimise_kwargs is None:
                     optimise_kwargs = {}
                 weights = optimise_meta_proposal_weights(
-                    self.nested_samples,
+                    self.nested_samples_unit,
                     self._log_q_ns,
                     initial_weights=weights,
                     **optimise_kwargs,
@@ -1453,7 +1486,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
             counts += new_counts
 
             it_samples["logL"] = self.model.batch_evaluate_log_likelihood(
-                it_samples
+                it_samples,
+                unit_hypercube=True,
             )
 
             if np.any(it_samples["logL"] > max_log_likelihood):
@@ -1501,7 +1535,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         weights = np.exp(self.state.log_posterior_weights)
         weights /= weights.sum()
-        samples, log_j = self.proposal.rescale(self.nested_samples)
+        samples, log_j = self.proposal.rescale(self.nested_samples_unit)
         flow = FlowModel(
             output=os.path.join(self.output, "levels", "final_level", ""),
             config=self.proposal.flow_config,
@@ -1509,11 +1543,15 @@ class ImportanceNestedSampler(BaseNestedSampler):
         flow.initialise()
         flow.train(samples, weights=weights)
 
-        x_p_out, log_prob = flow.sample_and_log_prob(self.nested_samples.size)
+        x_p_out, log_prob = flow.sample_and_log_prob(
+            self.nested_samples_unit.size
+        )
         x_out, log_j_out = self.proposal.inverse_rescale(x_p_out)
         x_out["logQ"] = log_prob - log_j_out
         x_out["logW"] = -x_out["logQ"]
-        x_out["logL"] = self.model.batch_evaluate_log_likelihood(x_out)
+        x_out["logL"] = self.model.batch_evaluate_log_likelihood(
+            x_out, unit_hypercube=True
+        )
 
         state = _INSIntegralState(normalised=False)
         state.log_meta_constant = 0.0
@@ -1777,7 +1815,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             specified.
         """
 
-        parameters = list(self.samples.dtype.names)
+        parameters = list(self.samples_unit.dtype.names)
         for p in ["logW"]:
             parameters.remove(p)
         n = len(parameters)
@@ -1786,17 +1824,17 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         if enable_colours:
             colour_kwargs = dict(
-                c=self.samples["it"],
+                c=self.samples_unit["it"],
                 vmin=-1,
-                vmax=self.samples["it"].max(),
+                vmax=self.samples_unit["it"].max(),
             )
         else:
             colour_kwargs = {}
 
         for ax, p in zip(axs, parameters):
             ax.scatter(
-                self.samples["logW"],
-                self.samples[p],
+                self.samples_unit["logW"],
+                self.samples_unit[p],
                 s=1.0,
                 **colour_kwargs,
             )
@@ -1830,16 +1868,16 @@ class ImportanceNestedSampler(BaseNestedSampler):
         max_bins
             The maximum number of bins allowed.
         """
-        its = np.unique(self.samples["it"])
+        its = np.unique(self.samples_unit["it"])
         colours = plt.get_cmap(cmap)(np.linspace(0, 1, len(its)))
-        vmax = np.max(self.samples["logL"])
+        vmax = np.max(self.samples_unit["logL"])
         vmin = np.ma.masked_invalid(
-            self.samples["logL"][self.samples["it"] == its[-1]]
+            self.samples_unit["logL"][self.samples_unit["it"] == its[-1]]
         ).min()
 
         fig, axs = plt.subplots(1, 2)
         for it, c in zip(its, colours):
-            data = self.samples["logL"][self.samples["it"] == it]
+            data = self.samples_unit["logL"][self.samples_unit["it"] == it]
             data = data[np.isfinite(data)]
             if not len(data):
                 continue
@@ -1897,7 +1935,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """Get a dictionary contain the main results from the sampler."""
         d = super().get_result_dictionary()
         d["history"] = self.history
-        d["training_samples"] = self.training_samples.samples
+        d["training_samples"] = self.model.from_unit_hypercube(
+            self.training_samples.samples
+        )
         d["training_log_evidence"] = self.training_samples.state.log_evidence
         d[
             "training_log_evidence_error"

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -775,7 +775,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         Draws live points, initialises the proposal.
         """
         if self.initialised:
-            logger.warning("Nested sampler has already initialised!")
+            logger.warning("Nested sampler has already been initialised!")
         if self.live_points_unit is None:
             self.populate_live_points()
 

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -134,6 +134,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         bootstrap: bool = False,
         close_pool: bool = False,
         strict_threshold: bool = False,
+        draw_iid_live: bool = False,
         **kwargs: Any,
     ):
 
@@ -166,6 +167,10 @@ class ImportanceNestedSampler(BaseNestedSampler):
         self._stop_any = None
         self._current_proposal_entropy = None
         self.importance = dict(total=None, posterior=None, evidence=None)
+
+        self.draw_iid_live = draw_iid_live
+        self.iid_samples = np.empty(0, dtype=get_dtype(self.model.names))
+        self.iid_log_q = None
 
         self.n_initial = self.nlive if n_initial is None else n_initial
         self.min_samples = min_samples
@@ -443,29 +448,30 @@ class ImportanceNestedSampler(BaseNestedSampler):
         The live points are automatically sorted and assigned the iteration
         number -1.
         """
-        live_points = np.empty(
-            self.n_initial, dtype=get_dtype(self.model.names)
-        )
+        if self.draw_iid_live:
+            target = int(2 * self.n_initial)
+        else:
+            target = self.n_initial
+        live_points = np.empty(target, dtype=get_dtype(self.model.names))
         n = 0
         logger.debug(f"Drawing {self.n_initial} initial points")
-        while n < self.n_initial:
+        while n < target:
             points = self.model.from_unit_hypercube(
                 numpy_array_to_live_points(
-                    np.random.rand(self.n_initial, self.model.dims),
+                    np.random.rand(target, self.model.dims),
                     self.model.names,
                 )
             )
             points["logP"] = self.model.batch_evaluate_log_prior(points)
             accept = np.isfinite(points["logP"])
             n_it = accept.sum()
-            m = min(n_it, self.n_initial - n)
+            m = min(n_it, target - n)
             live_points[n : (n + m)] = points[accept][:m]
             n += m
 
         live_points["logL"] = self.model.batch_evaluate_log_likelihood(
             live_points
         )
-
         if not np.isfinite(live_points["logL"]).all():
             logger.warning("Found infinite values in the log-likelihood")
 
@@ -476,9 +482,18 @@ class ImportanceNestedSampler(BaseNestedSampler):
         # Since log_Q is computed in the unit-cube
         live_points["logQ"] = np.zeros(live_points.size)
         live_points["logW"] = -live_points["logQ"]
+
+        if self.draw_iid_live:
+            live_points, iid_samples = (
+                live_points[: self.n_initial],
+                live_points[self.n_initial :],
+            )
+            self.iid_samples = self.sort_points(iid_samples)
+            self.iid_log_q = np.zeros([self.iid_samples.size, 1])
+
         self.samples = self.sort_points(live_points)
         self.live_points_indices = np.arange(live_points.size, dtype=int)
-        self.log_q = np.zeros([live_points.size, 1])
+        self.log_q = np.zeros([self.samples.size, 1])
 
     def initialise(self) -> None:
         """Initialise the nested sampler.
@@ -886,10 +901,19 @@ class ImportanceNestedSampler(BaseNestedSampler):
         """
         st = datetime.datetime.now()
         logger.debug(f"Adding {n} points")
+        if self.draw_iid_live:
+            n *= 2
         new_samples, log_q = self.draw_n_samples(n)
+        new_samples["it"] = self.iteration
+        if self.draw_iid_live:
+            new_samples, iid_samples = (
+                new_samples[: n // 2],
+                new_samples[n // 2 :],
+            )
+            log_q, iid_log_q = log_q[: n // 2], log_q[n // 2 :]
+            idd_samples, iid_log_q = self.sort_points(iid_samples, iid_log_q)
         new_samples, log_q = self.sort_points(new_samples, log_q)
         self._current_proposal_entropy = differential_entropy(-log_q[:, -1])
-        new_samples["it"] = self.iteration
 
         logger.debug(
             "New samples ESS: " f"{effective_sample_size(new_samples['logW'])}"
@@ -905,10 +929,20 @@ class ImportanceNestedSampler(BaseNestedSampler):
             )
 
         self.log_q = self.proposal.update_log_q(self.samples, self.log_q)
+
         self.samples["logQ"] = self.proposal.compute_meta_proposal_from_log_q(
             self.log_q
         )
         self.samples["logW"] = -self.samples["logQ"]
+        if self.draw_iid_live:
+            self.iid_log_q = self.proposal.update_log_q(
+                self.iid_samples, self.iid_log_q
+            )
+            self.iid_samples[
+                "logQ"
+            ] = self.proposal.compute_meta_proposal_from_log_q(self.iid_log_q)
+            self.iid_samples["logW"] = -self.iid_samples["logQ"]
+            self.add_iid_samples(iid_samples, iid_log_q)
 
         self.history["n_added"].append(new_samples.size)
 
@@ -922,6 +956,28 @@ class ImportanceNestedSampler(BaseNestedSampler):
         )
         logger.debug(f"Current live points ESS: {self.live_points_ess:.2f}")
         self.add_and_update_samples_time += datetime.datetime.now() - st
+
+    def add_iid_samples(self, iid_samples, iid_log_q):
+        logger.info("Drawing i.i.d samples")
+
+        # Insert samples into existing samples
+        indices = np.searchsorted(
+            self.iid_samples["logL"], iid_samples["logL"]
+        )
+        self.iid_samples = np.insert(self.iid_samples, indices, iid_samples)
+        self.iid_log_q = np.insert(self.iid_log_q, indices, iid_log_q, axis=0)
+        log_w = self.iid_samples["logL"] + self.iid_samples["logW"]
+        logZ = logsumexp(log_w) - np.log(len(self.iid_samples))
+        logger.info(f"i.i.d logZ = {logZ}")
+        above = self.iid_samples["logL"] >= self.logL_threshold
+        logZ_above = logsumexp(log_w[above]) - np.log(above.sum())
+        self.iid_ratio = logZ_above - logZ
+        logger.info(f"i.i.d ratio: {self.iid_ratio}")
+        self.iid_state = _INSIntegralState()
+        self.iid_state.update_evidence(self.iid_samples)
+        logger.info(
+            f"i.i.d ESS: {self.iid_state.effective_n_posterior_samples}"
+        )
 
     def add_to_nested_samples(self, indices: np.ndarray) -> None:
         """Add an array of samples to the nested samples."""
@@ -1062,15 +1118,20 @@ class ImportanceNestedSampler(BaseNestedSampler):
         if self.bootstrap:
             self.adjust_final_samples()
 
-        final_kl = self.kl_divergence(self.samples)
+        if self.draw_iid_live:
+            self.final_samples = self.iid_samples
+            self.final_state = self.iid_state
+            final_kl = self.kl_divergence(self.final_samples)
+            state = self.final_state
+        else:
+            final_kl = self.kl_divergence(self.samples)
+            state = self.state
         logger.info(
-            f"Final log Z: {self.state.logZ:.3f} "
-            f"+/- {self.state.compute_uncertainty():.3f}"
+            f"Final log Z: {state.logZ:.3f} "
+            f"+/- {state.compute_uncertainty():.3f}"
         )
         logger.info(f"Final KL divergence: {final_kl:.3f}")
-        logger.info(
-            f"Final ESS: {self.state.effective_n_posterior_samples:.3f}"
-        )
+        logger.info(f"Final ESS: {state.effective_n_posterior_samples:.3f}")
         self.finalised = True
         self.checkpoint(periodic=True, force=True)
         self.produce_plots()

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -1655,7 +1655,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         )
         max_samples = int(max_samples_ratio * self.nested_samples_unit.size)
 
-        max_logL = np.max(self.samples_unit["logL"])
+        max_log_likelihood = np.max(self.samples_unit["logL"])
 
         logger.debug(f"Expected efficiency: {eff:.3f}")
         if not any([n_post, n_draw]):

--- a/tests/test_evidence/test_ins_evidence.py
+++ b/tests/test_evidence/test_ins_evidence.py
@@ -142,4 +142,4 @@ def test_log_evidence_ins_samples():
 
     out = log_evidence_from_ins_samples(samples)
 
-    np.testing.assert_equal(out, expected)
+    np.testing.assert_almost_equal(out, expected, decimal=12)

--- a/tests/test_evidence/test_ins_evidence.py
+++ b/tests/test_evidence/test_ins_evidence.py
@@ -5,7 +5,10 @@ import numpy as np
 import pytest
 from scipy.special import logsumexp
 
-from nessai.evidence import _INSIntegralState as INSState
+from nessai.evidence import (
+    _INSIntegralState as INSState,
+    log_evidence_from_ins_samples,
+)
 
 
 @pytest.fixture
@@ -125,3 +128,18 @@ def test_compute_uncertainty_log(state):
     out = INSState.compute_uncertainty(state, log_evidence=False)
     # Check errors are equivalent
     np.testing.assert_almost_equal(out_ln, out / np.exp(state.logZ))
+
+
+def test_log_evidence_ins_samples():
+    n = 10
+    log_l = np.log(np.random.rand(n))
+    log_w = np.log(np.random.rand(n))
+    samples = np.array(
+        [*zip(log_l, log_w)], dtype=[("logL", "f8"), ("logW", "f8")]
+    )
+
+    expected = np.log(np.mean(np.exp(log_l + log_w)))
+
+    out = log_evidence_from_ins_samples(samples)
+
+    np.testing.assert_equal(out, expected)

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -772,7 +772,7 @@ def test_run_ins(flow_sampler, close_pool):
     post = np.array([1, 2])
     ns = MagicMock()
     ns.nested_sampling_loop = MagicMock()
-    ns.nested_samples = nested_samples
+    ns.samples = nested_samples
     ns.log_evidence = logZ
     ns.log_evidence_error = logZ_err
     ns.draw_posterior_samples = MagicMock(return_value=post)
@@ -811,7 +811,7 @@ def test_run_ins_redraw(flow_sampler):
     final_post = np.array([4, 5])
     ns = MagicMock()
     ns.nested_sampling_loop = MagicMock()
-    ns.nested_samples = nested_samples
+    ns.samples = nested_samples
     ns.log_evidence = logZ
     ns.log_evidence_error = logZ_err
     ns.final_log_evidence = final_logZ

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -1100,13 +1100,15 @@ def test_resume_from_data_integration(
 
     kwargs = {}
     if ins:
-        kwargs["min_samples"] = 1
+        kwargs["min_samples"] = 4
+        kwargs["max_iteration"] = 2
+    else:
+        kwargs["max_iteration"] = 10
 
     fs = FlowSampler(
         integration_model,
         nlive=10,
         output=output,
-        max_iteration=5,
         checkpointing=False,
         resume_file=None,
         importance_nested_sampler=ins,
@@ -1121,7 +1123,6 @@ def test_resume_from_data_integration(
         integration_model,
         nlive=10,
         output=output,
-        max_iteration=5,
         checkpointing=False,
         resume_data=resume_data,
         resume_file=None,

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -158,7 +158,7 @@ def test_get_state(proposal, populated, mask):
 @pytest.mark.parametrize("reparameterisation", [False, True])
 @pytest.mark.parametrize("init", [False, True])
 @pytest.mark.parametrize(
-    "latent_prior", ["truncated_gaussian", "uniform", "gaussian"]
+    "latent_prior", ["truncated_gaussian", "uniform_nball", "gaussian"]
 )
 def test_resume_pickle(model, tmpdir, reparameterisation, init, latent_prior):
     """Test pickling and resuming the proposal.
@@ -226,7 +226,7 @@ def test_reset(proposal):
 @pytest.mark.timeout(60)
 @pytest.mark.integration_test
 @pytest.mark.parametrize(
-    "latent_prior", ["truncated_gaussian", "uniform", "gaussian"]
+    "latent_prior", ["truncated_gaussian", "uniform_nball", "gaussian"]
 )
 def test_reset_integration(tmpdir, model, latent_prior):
     """Test reset method iteration with other methods"""
@@ -242,7 +242,7 @@ def test_reset_integration(tmpdir, model, latent_prior):
         )
     )
     output = str(tmpdir.mkdir("reset_integration"))
-    poolsize = 1
+    poolsize = 2
     drawsize = 100
     if latent_prior != "truncated_gaussian":
         constant_volume_mode = False

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -242,7 +242,7 @@ def test_reset_integration(tmpdir, model, latent_prior):
         )
     )
     output = str(tmpdir.mkdir("reset_integration"))
-    poolsize = 2
+    poolsize = 1
     drawsize = 100
     if latent_prior != "truncated_gaussian":
         constant_volume_mode = False

--- a/tests/test_proposal/test_importance/test_prob.py
+++ b/tests/test_proposal/test_importance/test_prob.py
@@ -176,11 +176,10 @@ def test_compute_meta_proposal_samples(ifp, x, x_prime, log_j):
     ifp.rescale = MagicMock(return_value=(x_prime, log_j))
     ifp.compute_log_Q = MagicMock(return_value=(log_Q, log_q))
 
-    log_q_out = IFP.compute_meta_proposal_samples(ifp, x)
+    log_Q_out, log_q_out = IFP.compute_meta_proposal_samples(ifp, x)
 
     ifp.rescale.assert_called_once_with(x)
     ifp.compute_log_Q.assert_called_once_with(x_prime, log_j=log_j)
 
-    np.testing.assert_array_equal(x["logQ"], log_Q)
-    np.testing.assert_array_equal(x["logW"], -log_Q)
+    np.testing.assert_array_equal(log_Q_out, log_Q)
     np.testing.assert_array_equal(log_q_out, log_q)

--- a/tests/test_proposal/test_importance/test_sampling.py
+++ b/tests/test_proposal/test_importance/test_sampling.py
@@ -13,15 +13,13 @@ import pytest
 @pytest.mark.usefixtures("ins_parameters")
 def test_draw_from_prior(ifp, x, n):
     """Test drawing from the prior"""
-    dims = 2
     n_proposals = 4
     x_prime = np.random.randn(n, 2)
     log_j = np.random.rand(n)
     log_Q = np.random.randn(n)
     log_q = np.random.randn(n_proposals, n)
-    ifp.model.dims = dims
-    ifp.to_prime = MagicMock(return_value=(x_prime, log_j))
-    ifp.inverse_rescale = MagicMock(return_value=(x, None))
+    ifp.model.sample_unit_hypercube = MagicMock(return_value=x)
+    ifp.rescale = MagicMock(return_value=(x_prime, log_j))
     ifp.compute_log_Q = MagicMock(return_value=(log_Q, log_q))
 
     x_out, log_q_out = IFP.draw_from_prior(ifp, n)
@@ -51,10 +49,9 @@ def test_draw_from_flows(ifp, model, n, test_counts):
 
     def inverse_rescale(x):
         x = numpy_array_to_live_points(x, model.names)
-        return model.from_unit_hypercube(x), np.zeros(x.size)
+        return x, np.zeros(x.size)
 
     def rescale(x):
-        x = model.to_unit_hypercube(x)
         x = live_points_to_array(x, model.names)
         return x, np.zeros(x.shape[0])
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -33,7 +33,7 @@ def test_configure_max_iterations(ins, it, expected):
 
 def test_initialise(ins):
     ins.initialised = False
-    ins.live_points = None
+    ins.live_points_unit = None
     ins.populate_live_points = MagicMock()
     ins.proposal = MagicMock()
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -48,3 +48,30 @@ def test_initialise_history(ins):
     ins.history = None
     INS.initialise_history(ins)
     assert ins.history is not None
+
+
+def test_check_configuration_min_samples(ins):
+    ins.min_samples = 100
+    ins.nlive = 10
+    ins.min_remove = 1
+    with pytest.raises(
+        ValueError, match="`min_samples` must be less than `nlive`"
+    ):
+        INS.check_configuration(ins)
+
+
+def test_check_configuration_min_remove(ins):
+    ins.min_samples = 50
+    ins.nlive = 100
+    ins.min_remove = 200
+    with pytest.raises(
+        ValueError, match="`min_remove` must be less than `nlive`"
+    ):
+        INS.check_configuration(ins)
+
+
+def check_configuration_okay(ins):
+    ins.min_samples = 50
+    ins.nlive = 100
+    ins.min_remove = 1
+    assert INS.check_configuration(ins) is True

--- a/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
@@ -40,6 +40,16 @@ def test_live_points_none(ordered_samples, samples):
     assert OrderedSamples.live_points.__get__(ordered_samples) is None
 
 
+def test_live_points_setter_error(ordered_samples):
+    with pytest.raises(ValueError, match=r"Can only set live points to None"):
+        OrderedSamples.live_points.__set__(ordered_samples, 1.0)
+
+
+def test_live_points_setter(ordered_samples):
+    OrderedSamples.live_points.__set__(ordered_samples, None)
+    assert ordered_samples.live_points_indices is None
+
+
 def test_nested_samples(ordered_samples, samples):
     indices = [2, 3]
     ordered_samples.nested_samples_indices = indices

--- a/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
@@ -26,10 +26,21 @@ def nested_samples(samples):
     return samples[: samples.size // 2]
 
 
-def test_sort_samples_integration(ordered_samples):
+def test_sort_samples_only(ordered_samples):
     samples = np.array(np.random.randn(10), [("logL", "f8")])
     samples_out = OrderedSamples.sort_samples(ordered_samples, samples)
     assert np.all(np.diff(samples_out["logL"]) > 0)
+
+
+def test_sort_samples_with_log_q(ordered_samples):
+    samples = np.array(np.random.randn(10), [("logL", "f8")])
+    order = np.argsort(samples["logL"])
+    extra = np.arange(samples.size)
+    sorted_samples, sorted_extra = OrderedSamples.sort_samples(
+        ordered_samples, samples, extra
+    )
+    assert_structured_arrays_equal(sorted_samples, samples[order])
+    np.testing.assert_array_equal(sorted_extra, extra[order])
 
 
 def test_add_initial_samples(ordered_samples, samples, log_q):

--- a/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
@@ -1,0 +1,228 @@
+from nessai.samplers.importancesampler import OrderedSamples
+from nessai.evidence import _INSIntegralState
+from nessai.utils.testing import assert_structured_arrays_equal
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, create_autospec
+
+
+@pytest.fixture()
+def ordered_samples():
+    return create_autospec(OrderedSamples)
+
+
+@pytest.fixture()
+def samples(samples):
+    return np.sort(samples, order="logL")
+
+
+@pytest.fixture()
+def live_points(samples):
+    return samples[samples.size // 2 :]
+
+
+@pytest.fixture()
+def nested_samples(samples):
+    return samples[: samples.size // 2]
+
+
+def test_sort_samples_integration(ordered_samples):
+    samples = np.array(np.random.randn(10), [("logL", "f8")])
+    samples_out = OrderedSamples.sort_samples(ordered_samples, samples)
+    assert np.all(np.diff(samples_out["logL"]) > 0)
+
+
+def test_add_initial_samples(ordered_samples, samples, log_q):
+    ordered_samples.sort_samples = MagicMock(return_value=(samples, log_q))
+    OrderedSamples.add_initial_samples(ordered_samples, samples, log_q)
+    ordered_samples.sort_samples.assert_called_once_with(samples, log_q)
+    assert ordered_samples.samples is samples
+    assert ordered_samples.log_q is log_q
+    assert len(ordered_samples.live_points_indices) == len(samples)
+    assert np.all(np.diff(ordered_samples.live_points_indices) > 0)
+    np.testing.assert_array_equal(
+        ordered_samples.live_points_indices, np.arange(samples.size)
+    )
+
+
+@pytest.mark.parametrize("has_live_points", [True, False])
+def test_add_samples_soft(ordered_samples, samples, log_q, has_live_points):
+    n = int(0.8 * samples.size)
+    ordered_samples.strict_threshold = False
+
+    if has_live_points:
+        n_ns = int(0.8 * n)
+        ns_indices = np.sort(np.random.choice(n, size=n_ns, replace=False))
+        live_indices = np.sort(list(set(np.arange(n)) - set(ns_indices)))
+    else:
+        n_ns = n
+        ns_indices = np.arange(n_ns)
+        live_indices = None
+
+    sort_idx = np.argsort(samples[:n], order="logL")
+    ordered_samples.samples = samples[:n][sort_idx]
+    ordered_samples.log_q = log_q[:n][sort_idx]
+    ordered_samples.nested_samples_indices = ns_indices
+    ordered_samples.live_points_indices = live_indices
+
+    new_samples = samples[n:]
+    new_log_q = log_q[n:]
+
+    idx = np.argsort(new_samples, order="logL")
+    new_samples_ordered = new_samples[idx]
+    new_log_q_ordered = new_log_q[idx]
+
+    ordered_samples.sort_samples = MagicMock(
+        return_value=(new_samples_ordered, new_log_q_ordered)
+    )
+
+    OrderedSamples.add_samples(ordered_samples, new_samples, new_log_q)
+
+    ordered_samples.sort_samples.assert_called_once_with(
+        new_samples, new_log_q
+    )
+    assert len(ordered_samples.live_points_indices) == (
+        n - n_ns + new_samples.size
+    )
+    assert np.all(np.diff(ordered_samples.samples["logL"]) >= 0)
+    assert np.all(
+        np.diff(
+            ordered_samples.samples[ordered_samples.live_points_indices][
+                "logL"
+            ]
+        )
+        >= 0
+    )
+    assert np.all(
+        np.diff(
+            ordered_samples.samples[ordered_samples.nested_samples_indices][
+                "logL"
+            ]
+        )
+        >= 0
+    )
+
+
+def test_add_samples(ordered_samples, samples, log_q):
+    ordered_samples.strict_threshold = True
+
+    idx = np.argsort(samples, order="logL")
+    expected = samples[idx].copy()
+    expected_log_q = log_q[idx].copy()
+
+    perm = np.random.permutation(samples.size)
+    samples = samples[perm]
+    log_q = log_q[perm]
+    n = int(0.8 * samples.size)
+    idx = np.argsort(samples[:n], order="logL")
+    ordered_samples.samples = samples[:n][idx]
+    ordered_samples.log_q = log_q[:n][idx]
+
+    new_samples = samples[n:]
+    new_log_q = log_q[n:]
+
+    idx = np.argsort(new_samples, order="logL")
+    new_samples_ordered = new_samples[idx]
+    new_log_q_ordered = new_log_q[idx]
+    ordered_samples.sort_samples = MagicMock(
+        return_value=(new_samples_ordered, new_log_q_ordered)
+    )
+
+    ordered_samples.log_likelihood_threshold = new_samples_ordered[
+        new_samples_ordered.size // 2
+    ]["logL"].item()
+
+    n_expected = np.sum(
+        expected["logL"] >= ordered_samples.log_likelihood_threshold
+    )
+
+    OrderedSamples.add_samples(ordered_samples, new_samples, new_log_q)
+
+    assert_structured_arrays_equal(ordered_samples.samples, expected)
+    np.testing.assert_array_equal(ordered_samples.log_q, expected_log_q)
+    np.testing.assert_array_equal(
+        ordered_samples.nested_samples_indices,
+        np.arange(samples.size - n_expected),
+    )
+    np.testing.assert_array_equal(
+        ordered_samples.live_points_indices,
+        np.arange(samples.size - n_expected, samples.size),
+    )
+
+
+@pytest.mark.parametrize("replace_all", [False, True])
+def test_remove_samples(ordered_samples, replace_all):
+    n = 10
+    ordered_samples.live_points = np.array(
+        np.arange(n), dtype=[("logL", "f8")]
+    )
+    ordered_samples.live_points_indices = np.arange(n)
+    ordered_samples.log_likelihood_threshold = 5.5
+    ordered_samples.replace_all = replace_all
+    ordered_samples.add_to_nested_samples = MagicMock()
+
+    expected = n if replace_all else 6
+
+    out = OrderedSamples.remove_samples(ordered_samples)
+
+    assert out == expected
+    ordered_samples.add_to_nested_samples.assert_called_once()
+    np.testing.assert_array_equal(
+        ordered_samples.add_to_nested_samples.call_args.args[0],
+        np.arange(expected),
+    )
+    if replace_all:
+        assert ordered_samples.live_points_indices is None
+    else:
+        np.testing.assert_array_equal(
+            ordered_samples.live_points_indices, np.arange(6, n)
+        )
+
+
+def test_add_to_nested_samples(ordered_samples):
+    ns_indices = np.array([0, 1, 2, 4, 5, 8])
+    indices = np.array([3, 6, 7, 9])
+    ordered_samples.nested_samples_indices = ns_indices
+    OrderedSamples.add_to_nested_samples(ordered_samples, indices)
+    np.testing.assert_array_equal(
+        ordered_samples.nested_samples_indices, np.arange(10)
+    )
+
+
+def test_update_evidence(ordered_samples, live_points, nested_samples):
+    ordered_samples.state = create_autospec(_INSIntegralState)
+    ordered_samples.live_points = live_points
+    ordered_samples.nested_samples = nested_samples
+    OrderedSamples.update_evidence(ordered_samples)
+    ordered_samples.state.update_evidence.assert_called_once_with(
+        nested_samples=nested_samples,
+        live_points=live_points,
+    )
+
+
+def test_finalise(ordered_samples, samples):
+    ordered_samples.samples = samples
+    ordered_samples.live_points_indices = np.arange(4)
+
+    def add_to_ns(indices):
+        ordered_samples.live_points_indices = None
+
+    ordered_samples.add_to_nested_samples = MagicMock(side_effect=add_to_ns)
+    ordered_samples.state = create_autospec(_INSIntegralState)
+
+    OrderedSamples.finalise(ordered_samples)
+
+    ordered_samples.state.update_evidence.assert_called_once_with(samples)
+    assert ordered_samples.live_points is None
+    assert ordered_samples.live_points_indices is None
+
+
+@pytest.mark.parametrize("ratio", [0.0, 0.5, 1.0])
+def test_compute_importance(ordered_samples, log_q, samples, ratio):
+    ordered_samples.samples = samples
+    ordered_samples.log_q = log_q
+    out = OrderedSamples.compute_importance(
+        ordered_samples, importance_ratio=ratio
+    )
+    assert len(set(out.keys()) - {"total", "posterior", "evidence"}) == 0
+    assert np.all(np.isfinite(list(out.values())))

--- a/tests/test_samplers/test_importance_nested_sampler/test_plots.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_plots.py
@@ -36,22 +36,22 @@ def test_plot_extra_state(ins, history, n_it):
 
 @pytest.mark.parametrize("enable_colours", [False, True])
 def test_plot_trace(ins, samples, enable_colours):
-    ins.samples = samples
+    ins.samples_unit = samples
     fig = INS.plot_trace(ins, enable_colours=enable_colours)
     assert fig is not None
 
 
 def test_plot_likelihood_levels(ins, samples):
-    ins.samples = samples
+    ins.samples_unit = samples
     fig = INS.plot_likelihood_levels(ins)
     assert fig is not None
 
 
 def test_plot_level_cdf(ins, samples):
-    ins.live_points = samples
     cdf = np.cumsum(samples["logW"])
     fig = INS.plot_level_cdf(
         ins,
+        samples["logL"],
         cdf,
         q=0.5,
         threshold=samples[len(samples) // 2]["logL"],

--- a/tests/test_samplers/test_importance_nested_sampler/test_proposal.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_proposal.py
@@ -2,7 +2,10 @@
 import datetime
 from unittest.mock import MagicMock
 
-from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
+from nessai.samplers.importancesampler import (
+    ImportanceNestedSampler as INS,
+    OrderedSamples,
+)
 from nessai.utils.testing import assert_structured_arrays_equal
 import numpy as np
 import pytest
@@ -19,9 +22,11 @@ def test_add_new_proposal(ins, samples, log_q, weighted_kl):
 
     n = int(0.8 * len(samples))
 
-    ins.samples = np.sort(samples, order="logL")
-    ins.log_q = log_q
-    ins.logL_threshold = ins.samples[n]["logL"]
+    ins.training_samples = MagicMock(spec=OrderedSamples)
+    ins.training_samples.samples = np.sort(samples, order="logL")
+    ins.training_samples.log_q = log_q
+    ins.log_likelihood_threshold = ins.training_samples.samples[n]["logL"]
+    ins.min_samples = 2
 
     ins.replace_all = False
     ins.weighted_kl = weighted_kl
@@ -32,7 +37,8 @@ def test_add_new_proposal(ins, samples, log_q, weighted_kl):
 
     ins.proposal.train.assert_called_once()
     assert_structured_arrays_equal(
-        ins.proposal.train.call_args_list[0][0][0], ins.samples[n:]
+        ins.proposal.train.call_args_list[0][0][0],
+        ins.training_samples.samples[n:],
     )
 
 
@@ -45,14 +51,10 @@ def test_draw_n_samples(ins, samples, log_q, history):
     )
     samples["logL"] = np.nan
     ins.proposal.draw = MagicMock(return_value=(samples, log_q))
-    ins.history = history
-    ins.compute_leakage = MagicMock(return_value=0.1)
 
     out = INS.draw_n_samples(ins, n)
 
     ins.proposal.draw.assert_called_once_with(n)
-
-    assert ins.history["leakage_new_points"][-1] == 0.1
 
     np.testing.assert_array_equal(out[1], log_q)
     assert_structured_arrays_equal(out[0], expected)

--- a/tests/test_samplers/test_importance_nested_sampler/test_result.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_result.py
@@ -31,9 +31,6 @@ def test_get_result_dictionary(ins, history, samples, iid):
     ins.add_and_update_samples_time = datetime.timedelta(seconds=10)
     ins.draw_final_samples_time = datetime.timedelta(seconds=10)
 
-    ins.initial_log_evidence = -1.0
-    ins.initial_log_evidence_error = 0.1
-
     ins.log_evidence = -1.1
     ins.log_evidence_error = 0.3
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_result.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_result.py
@@ -1,14 +1,25 @@
 """Tests related to the results returned by the sampler"""
 import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
-from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
+from nessai.samplers.importancesampler import (
+    ImportanceNestedSampler as INS,
+    OrderedSamples,
+)
 from nessai.evidence import _INSIntegralState
 import numpy as np
 
 
-def test_get_result_dictionary(ins, history, samples):
-    ins.samples = samples.copy()
+def test_get_result_dictionary(ins, history, samples, iid):
+    ins.training_samples.samples = samples.copy()
+    ins.training_samples.state.log_evidence = -1.1
+    ins.training_samples.state.log_evidence_error = 0.2
+    if iid:
+        ins.iid_samples = create_autospec(OrderedSamples)
+        ins.iid_samples.state = create_autospec(_INSIntegralState)
+        ins.iid_samples.samples = samples.copy()
+        ins.iid_samples.state.log_evidence = -0.9
+        ins.iid_samples.state.log_evidence_error = 0.14
     ins.final_samples = samples
     ins.history = history
     ins.state = MagicMock(spec=_INSIntegralState)

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -9,6 +9,41 @@ from nessai.samplers.importancesampler import (
 import numpy as np
 
 
+def test_ordered_samples_property(ins):
+    ins.training_samples = object()
+    ins.draw_iid_live = False
+    assert INS._ordered_samples.__get__(ins) is ins.training_samples
+
+
+def test_ordered_samples_property_iid(ins):
+    ins.iid_samples = object()
+    ins.draw_iid_live = True
+    assert INS._ordered_samples.__get__(ins) is ins.iid_samples
+
+
+def test_live_points_unit_property(ins):
+    ins._ordered_samples = MagicMock(spec=OrderedSamples)
+    assert (
+        INS.live_points_unit.__get__(ins) is ins._ordered_samples.live_points
+    )
+
+
+def test_nested_samples_unit_property(ins):
+    ins._ordered_samples = MagicMock(spec=OrderedSamples)
+    assert (
+        INS.nested_samples_unit.__get__(ins)
+        is ins._ordered_samples.nested_samples
+    )
+
+
+def test_nested_samples_property(ins):
+    ins._ordered_samples = MagicMock(spec=OrderedSamples)
+    assert (
+        INS.nested_samples_unit.__get__(ins)
+        is ins._ordered_samples.nested_samples
+    )
+
+
 def test_populate_live_points_no_iid(ins, model):
     n = 100
     ins.n_initial = n

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -1,160 +1,80 @@
 """Tests related to how samples are handled"""
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 from nessai.livepoint import numpy_array_to_live_points
-from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
-from nessai.utils.testing import assert_structured_arrays_equal
+from nessai.samplers.importancesampler import (
+    ImportanceNestedSampler as INS,
+    OrderedSamples,
+)
 import numpy as np
-import pytest
 
 
-def test_sort_points(ins, samples):
-    order = np.argsort(samples["logL"])
-    extra = np.arange(samples.size)
-    sorted_samples, sorted_extra = INS.sort_points(ins, samples, extra)
-    assert_structured_arrays_equal(sorted_samples, samples[order])
-    np.testing.assert_array_equal(sorted_extra, extra[order])
-
-
-def test_populate_live_points(ins, model):
+def test_populate_live_points_no_iid(ins, model):
     n = 100
     ins.n_initial = n
     ins.model = model
-
-    def fn(x):
-        return np.sort(x, order="logL")
-
-    ins.sort_points = MagicMock(side_effect=fn)
+    ins.draw_iid_live = False
 
     INS.populate_live_points(ins)
 
-    assert len(ins.samples) == n
-    np.testing.assert_array_equal(ins.live_points_indices, np.arange(n))
-    assert np.isfinite(ins.samples["logL"]).all()
-    assert np.isfinite(ins.samples["logW"]).all()
-    assert np.isfinite(ins.samples["logQ"]).all()
-    assert np.isfinite(ins.samples["logP"]).all()
-    assert (ins.samples["it"] == -1).all()
+    ins.training_samples.add_initial_samples.assert_called_once()
+    assert len(ins.training_samples.add_initial_samples.call_args.args[0]) == n
+    assert ins.training_samples.add_initial_samples.call_args.args[
+        1
+    ].shape == (n, 1)
 
 
-def test_add_to_nested_samples(ins):
-    ns_indices = np.array([0, 1, 2, 4, 5, 8])
-    indices = np.array([3, 6, 7, 9])
-    ins.nested_samples_indices = ns_indices
+def test_populate_live_points_iid(ins, model):
+    n = 100
+    ins.n_initial = n
+    ins.model = model
+    ins.draw_iid_live = True
+    ins.iid_samples = create_autospec(OrderedSamples)
 
-    INS.add_to_nested_samples(ins, indices)
+    INS.populate_live_points(ins)
 
-    np.testing.assert_array_equal(ins.nested_samples_indices, np.arange(10))
+    ins.training_samples.add_initial_samples.assert_called_once()
+    assert len(ins.training_samples.add_initial_samples.call_args.args[0]) == n
+    assert ins.training_samples.add_initial_samples.call_args.args[
+        1
+    ].shape == (n, 1)
+    assert np.isfinite(
+        ins.training_samples.add_initial_samples.call_args.args[0]["logL"]
+    ).all()
+    assert np.isfinite(
+        ins.training_samples.add_initial_samples.call_args.args[0]["logP"]
+    ).all()
 
-
-@pytest.mark.parametrize("has_live_points", [True, False])
-def test_add_samples_soft(ins, samples, log_q, has_live_points):
-    n = int(0.8 * samples.size)
-
-    ins.strict_threshold = False
-
-    if has_live_points:
-        n_ns = int(0.8 * n)
-        ns_indices = np.sort(np.random.choice(n, size=n_ns, replace=False))
-        live_indices = np.sort(list(set(np.arange(n)) - set(ns_indices)))
-    else:
-        n_ns = n
-        ns_indices = np.arange(n_ns)
-        live_indices = None
-
-    sort_idx = np.argsort(samples[:n], order="logL")
-    ins.samples = samples[:n][sort_idx]
-    ins.log_q = log_q[:n][sort_idx]
-    ins.nested_samples_indices = ns_indices
-    ins.live_points_indices = live_indices
-
-    sort_idx = np.argsort(samples[n:], order="logL")
-    new_samples = samples[n:][sort_idx]
-    new_log_q = log_q[n:][sort_idx]
-
-    INS.add_samples(ins, new_samples, new_log_q)
-
-    assert len(ins.live_points_indices) == (n - n_ns + new_samples.size)
-
-    assert np.all(np.diff(ins.samples["logL"]) >= 0)
-    assert np.all(np.diff(ins.samples[ins.live_points_indices]["logL"]) >= 0)
-    assert np.all(
-        np.diff(ins.samples[ins.nested_samples_indices]["logL"]) >= 0
+    ins.iid_samples.add_initial_samples.assert_called_once()
+    assert len(ins.iid_samples.add_initial_samples.call_args.args[0]) == n
+    assert ins.iid_samples.add_initial_samples.call_args.args[1].shape == (
+        n,
+        1,
     )
+    assert np.isfinite(
+        ins.iid_samples.add_initial_samples.call_args.args[0]["logL"]
+    ).all()
+    assert np.isfinite(
+        ins.iid_samples.add_initial_samples.call_args.args[0]["logP"]
+    ).all()
 
 
-def test_add_samples(ins, samples, log_q):
-    ins.strict_threshold = True
+def test_remove_samples(ins, iid):
+    ins.history = {}
+    ins.history["n_removed"] = [3]
+    ins.training_samples.remove_samples = MagicMock(return_value=5)
+    ins.draw_iid_live = iid
+    expected = 5
+    if iid:
+        ins.iid_samples = create_autospec(OrderedSamples)
+        ins.iid_samples.remove_samples = MagicMock(return_value=4)
+        expected = 4
 
-    idx = np.argsort(samples, order="logL")
-    expected = samples[idx].copy()
-    expected_log_q = log_q[idx].copy()
+    out = INS.remove_samples(ins)
 
-    perm = np.random.permutation(samples.size)
-    samples = samples[perm]
-    log_q = log_q[perm]
-    n = int(0.8 * samples.size)
-    idx = np.argsort(samples[:n], order="logL")
-    ins.samples = samples[:n][idx]
-    ins.log_q = log_q[:n][idx]
-
-    new_idx = np.argsort(samples[n:], order="logL")
-    new = samples[n:][new_idx]
-    new_log_q = log_q[n:][new_idx]
-
-    ins.logL_threshold = new[new.size // 2]["logL"].item()
-
-    n_expected = np.sum(expected["logL"] >= ins.logL_threshold)
-
-    INS.add_samples(ins, new, new_log_q)
-
-    assert_structured_arrays_equal(ins.samples, expected)
-    np.testing.assert_array_equal(ins.log_q, expected_log_q)
-    np.testing.assert_array_equal(
-        ins.nested_samples_indices, np.arange(samples.size - n_expected)
-    )
-    np.testing.assert_array_equal(
-        ins.live_points_indices,
-        np.arange(samples.size - n_expected, samples.size),
-    )
-
-
-@pytest.mark.parametrize("n", [5, 10])
-def test_remove_samples(ins, n):
-    ins.history = dict(n_removed=[5])
-    ins.replace_all = False
-    ins.add_to_nested_samples = MagicMock()
-
-    live_points_indices = np.random.choice(20, size=15, replace=False)
-    ins.live_points_indices = live_points_indices.copy()
-
-    INS.remove_samples(ins, n)
-
-    assert ins.history["n_removed"] == [5, n]
-    np.testing.assert_array_equal(
-        ins.add_to_nested_samples.call_args[0][0], live_points_indices[:n]
-    )
-    np.testing.assert_array_equal(
-        ins.live_points_indices, live_points_indices[n:]
-    )
-
-
-def test_remove_samples_replace_all(ins):
-    ins.history = dict(n_removed=[5])
-    ins.replace_all = True
-    ins.add_to_nested_samples = MagicMock()
-
-    live_points_indices = np.random.choice(20, size=15, replace=False)
-    ins.live_points_indices = live_points_indices.copy()
-    ins.live_points = np.ones(live_points_indices.size)
-
-    INS.remove_samples(ins, 10)
-
-    assert ins.history["n_removed"] == [5, live_points_indices.size]
-    np.testing.assert_array_equal(
-        ins.add_to_nested_samples.call_args[0][0], live_points_indices
-    )
-    assert ins.live_points_indices is None
+    ins.training_samples.remove_samples.assert_called_once()
+    assert out == expected
+    assert ins.history["n_removed"] == [3, expected]
 
 
 def test_adjust_final_samples(ins, proposal, model, samples, log_q):
@@ -176,7 +96,7 @@ def test_adjust_final_samples(ins, proposal, model, samples, log_q):
     proposal.draw_from_prior = MagicMock(side_effect=draw_from_prior)
     proposal.n_requested = {"-1": 10, "1": 10}
 
-    ins.samples = samples
+    ins.samples_unit = samples
     ins.log_q = log_q
     ins.proposal = proposal
     ins.model = model

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -102,3 +102,34 @@ def test_adjust_final_samples(ins, proposal, model, samples, log_q):
     ins.model = model
 
     INS.adjust_final_samples(ins)
+
+
+def test_compute_importance(ins, iid):
+    importance = {"evidence": 0.4, "posterior": 0.8}
+    ins.training_samples = MagicMock(spec=OrderedSamples)
+    ins.training_samples.compute_importance = MagicMock(
+        return_value=importance
+    )
+    ins.iid_samples = MagicMock(spec=OrderedSamples)
+    ins.iid_samples.compute_importance = MagicMock(return_value=importance)
+    ins.draw_iid_live = iid
+
+    out = INS.compute_importance(ins)
+    assert out is importance
+    if iid:
+        ins.training_samples.compute_importance.assert_not_called()
+        ins.iid_samples.compute_importance.assert_called_once()
+    else:
+        ins.training_samples.compute_importance.assert_called_once()
+        ins.iid_samples.compute_importance.assert_not_called()
+
+
+def test_update_evidence(ins, iid):
+    ins.draw_iid_live = iid
+    ins.training_samples = MagicMock(spec=OrderedSamples)
+    if iid:
+        ins.iid_samples = MagicMock(spec=OrderedSamples)
+    INS.update_evidence(ins)
+    ins.training_samples.update_evidence.assert_called_once()
+    if iid:
+        ins.iid_samples.update_evidence.assert_called_once()

--- a/tests/test_samplers/test_importance_nested_sampler/test_stopping_criteria.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_stopping_criteria.py
@@ -1,0 +1,22 @@
+from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
+import pytest
+
+
+@pytest.mark.parametrize(
+    "criterion, tolerance, stop_any, reached",
+    [
+        ([5.0], [0.0], False, False),
+        ([-1.0], [0.0], False, True),
+        ([5.0, 1.5], [0.0, 1], False, False),
+        ([5.0, 0.5], [0.0, 1], False, False),
+        ([-1.0, 0.5], [0.0, 1], False, True),
+        ([5.0, 1.5], [0.0, 1], True, False),
+        ([5.0, 0.5], [0.0, 1], True, True),
+        ([-1.0, 0.5], [0.0, 1], True, True),
+    ],
+)
+def test_reached_tolerance(ins, criterion, tolerance, stop_any, reached):
+    ins.criterion = criterion
+    ins.tolerance = tolerance
+    ins._stop_any = stop_any
+    assert INS.reached_tolerance.__get__(ins) is reached

--- a/tests/test_samplers/test_importance_nested_sampler/test_threshold.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_threshold.py
@@ -106,8 +106,9 @@ def test_determine_threshold(
     "min_samples, max_samples, n_live, expected",
     [
         [50, 10, 5, 10, 55, 30, 25],
-        [56, 10, 5, 10, 55, 30, 26],
+        [56, 10, 5, 10, 55, 30, 31],
         [50, 20, 5, 10, 100, 30, 20],
+        [1601, 100, 50, 50, 1600, 200, 201],
     ],
 )
 def test_determine_threshold_max_samples(

--- a/tests/test_samplers/test_importance_nested_sampler/test_threshold.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_threshold.py
@@ -2,7 +2,10 @@
 import os
 from unittest.mock import MagicMock
 
-from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
+from nessai.samplers.importancesampler import (
+    ImportanceNestedSampler as INS,
+    OrderedSamples,
+)
 import numpy as np
 import pytest
 
@@ -144,4 +147,20 @@ def test_determine_threshold_max_samples(
     if expected != n_remove:
         assert "Next level would have more than max samples" in str(
             caplog.text
+        )
+
+
+def test_update_log_likelihood_threshold(ins, iid):
+    threshold = 10
+    ins.training_samples = MagicMock(spec=OrderedSamples)
+    if iid:
+        ins.iid_samples = MagicMock(spec=OrderedSamples)
+    INS.update_log_likelihood_threshold(ins, threshold)
+
+    ins.training_samples.update_log_likelihood_threshold.assert_called_once_with(  # noqa
+        threshold
+    )
+    if iid:
+        ins.iid_samples.update_log_likelihood_threshold.assert_called_once_with(  # noqa
+            threshold
         )


### PR DESCRIPTION
This PR reworks the importance nested sampler to enable drawing i.i.d samples on the fly instead of after sampling.

I've introduced an `OrderedSamples` class that handles the samples, since this reduces the amount of duplicate code that is needed. This change also means we no longer need to draw final samples by default.

**Main changes**

- No longer require `to_unit_hypercube` to perform sampling
- Support for drawing i.i.d samples live
- Introduced the `OrderedSamples` class
- Compute `ratio` stopping criterion using the log-likelihood threshold
- Add `in_unit_hypercube` and `samples_unit_hypercube` methods to the `Model` class

**To-Do**

- [x] Update tests