### PR TITLE
Remove max threads

### DIFF
--- a/docs/parallelisation.rst
+++ b/docs/parallelisation.rst
@@ -45,7 +45,7 @@ Using ``ray``
 Other pools
 -----------
 
-When a pool object is passed to :code:`nessai` it tries to determine how many processes the pool contains and (if the likelihood is vectorised) uses this information to determine the chunk size when evaluating the likelihood. If it can not determine this, then likelihood vectorisation will be disabled. This can be avoided by specifying :code:`n_pool` and :code:`max_threads` when initialising the sampler.
+When a pool object is passed to :code:`nessai` it tries to determine how many processes the pool contains and (if the likelihood is vectorised) uses this information to determine the chunk size when evaluating the likelihood. If it can not determine this, then likelihood vectorisation will be disabled. This can be avoided by specifying :code:`n_pool` when initialising the sampler.
 
 ***********************
 PyTorch parallelisation

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -48,8 +48,6 @@ class FlowSampler:
     pytorch_threads : int
         Maximum number of threads to use for torch. If ``None`` torch uses all
         available threads.
-    max_threads : int
-        Deprecated and will be removed in a future release.
     signal_handling : bool
         Enable or disable signal handling.
     exit_code : int, optional
@@ -97,7 +95,6 @@ class FlowSampler:
         signal_handling=True,
         exit_code=130,
         pytorch_threads=1,
-        max_threads=None,
         close_pool=True,
         eps=None,
         torch_dtype=None,
@@ -110,7 +107,6 @@ class FlowSampler:
     ):
 
         configure_threads(
-            max_threads=max_threads,
             pytorch_threads=pytorch_threads,
         )
 

--- a/nessai/utils/threading.py
+++ b/nessai/utils/threading.py
@@ -3,14 +3,13 @@
 Utilities related to managing threads used by nessai.
 """
 import logging
-import warnings
 
 import torch
 
 logger = logging.getLogger(__name__)
 
 
-def configure_threads(pytorch_threads=None, max_threads=None):
+def configure_threads(pytorch_threads=None):
     """Configure the number of threads available.
 
     This is necessary when using PyTorch on the CPU as by default it will use
@@ -26,17 +25,7 @@ def configure_threads(pytorch_threads=None, max_threads=None):
     pytorch_threads: int, optional
         Maximum number of threads for PyTorch on CPU. If None, pytorch will
         use all available threads.
-    max_threads: int, optional
-        Ignored. Deprecated starting nessai 0.7.0.
     """
-    if max_threads:
-        msg = (
-            "`max_threads` is deprecated and will be removed in a future "
-            "release. Use `pytorch_threads` to set the number of threads for "
-            "pytorch and `n_pool` to set the number of cores for "
-            "paralellisation."
-        )
-        warnings.warn(msg, FutureWarning)
     if pytorch_threads:
         logger.debug(
             f"Setting maximum number of PyTorch threads to {pytorch_threads}"

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -2,15 +2,7 @@
 """
 Tests for modules/functions that are soon to be deprecated.
 """
-from nessai.utils import configure_threads
 import pytest
-
-
-def test_max_threads_warning():
-    """Assert a future warning is raised if max threads is specified"""
-    with pytest.warns(FutureWarning) as record:
-        configure_threads(max_threads=1)
-    assert "`max_threads` is deprecated" in str(record[0].message)
 
 
 def test_nested_sampler_deprecation():

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -151,7 +151,6 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
 
     mock_threads.assert_called_once_with(
         pytorch_threads=pytorch_threads,
-        max_threads=None,
     )
 
     mock.assert_called_once_with(
@@ -371,7 +370,6 @@ def test_init_resume(tmp_path, test_old, error):
 
     mock_threads.assert_called_once_with(
         pytorch_threads=pytorch_threads,
-        max_threads=None,
     )
 
     mock_resume.assert_called_with(


### PR DESCRIPTION
Remove the deprecated `max_threads` argument from `FlowSampler` and `configure_threads`