### PR TITLE
Rework how history is stored

### DIFF
--- a/nessai/proposal/base.py
+++ b/nessai/proposal/base.py
@@ -5,6 +5,7 @@ Base object for all proposal classes.
 from abc import ABC, abstractmethod
 import datetime
 import logging
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class Proposal(ABC):
         self.training_count = 0
         self.population_acceptance = None
         self.population_time = datetime.timedelta()
-        self.r = None
+        self.r = np.nan
         self.samples = []
         self.indices = []
         self._checked_population = True

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1695,7 +1695,7 @@ class FlowProposal(RejectionProposal):
         self.populated_count = 0
         self.population_acceptance = None
         self._poolsize_scale = 1.0
-        self.r = None
+        self.r = np.nan
         self.alt_dist = None
         self._checked_population = True
         self.acceptance = []

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -1488,6 +1488,7 @@ class FlowProposal(RejectionProposal):
                 log_u = np.log(np.random.rand(len(log_weights)))
                 accept = (log_weights - log_constant) > log_u
             logger.debug("Total number of samples: %s", samples.size)
+            n_accepted = np.sum(accept)
             self.x = samples[accept][:N]
         else:
             self.x = samples[:N]

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -275,7 +275,12 @@ class BaseNestedSampler(ABC):
         """
         now = datetime.datetime.now()
         if not periodic:
-            self.history["checkpoint_iterations"] += [self.iteration]
+            if self.history:
+                self.history["checkpoint_iterations"] += [self.iteration]
+            else:
+                logger.warning(
+                    "Could not log checkpoint iteration in the history"
+                )
         elif force:
             pass
         else:

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -103,7 +103,6 @@ class BaseNestedSampler(ABC):
         self.sampling_time = datetime.timedelta()
         self.sampling_start_time = datetime.datetime.now()
         self.iteration = 0
-        self.checkpoint_iterations = []
         self.finalised = False
         self.resumed = False
 
@@ -112,6 +111,7 @@ class BaseNestedSampler(ABC):
         self.configure_periodic_logging(logging_interval, log_on_iteration)
 
         self.live_points = None
+        self.history = None
 
     @property
     def current_sampling_time(self):
@@ -232,6 +232,27 @@ class BaseNestedSampler(ABC):
                 self._last_log = now
         self.log_state()
 
+    def initialise_history(self) -> None:
+        """Initialise the dictionary to store history"""
+        if self.history is None:
+            logger.debug("Initialising history dictionary")
+            self.history = dict(
+                likelihood_evaluations=[],
+                sampling_time=[],
+                checkpoint_iterations=[],
+            )
+        else:
+            logger.debug("History dictionary already initialised")
+
+    def update_history(self) -> None:
+        """Update the history dictionary"""
+        self.history["likelihood_evaluations"].append(
+            self.total_likelihood_evaluations
+        )
+        self.history["sampling_time"].append(
+            self.current_sampling_time.total_seconds()
+        )
+
     def checkpoint(
         self,
         periodic: bool = False,
@@ -254,7 +275,7 @@ class BaseNestedSampler(ABC):
         """
         now = datetime.datetime.now()
         if not periodic:
-            self.checkpoint_iterations += [self.iteration]
+            self.history["checkpoint_iterations"] += [self.iteration]
         elif force:
             pass
         else:
@@ -361,6 +382,7 @@ class BaseNestedSampler(ABC):
         d[
             "likelihood_evaluation_time"
         ] = self.likelihood_evaluation_time.total_seconds()
+        d["history"] = self.history
         if hasattr(self.model, "truth"):
             d["truth"] = self.model.truth
         return d

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -497,29 +497,30 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def initialise_history(self) -> None:
         """Initialise the dictionary to store history"""
         if self.history is None:
-            logger.debug("Initialising history dictionary")
-            self.history = dict(
-                min_logL=[],
-                max_logL=[],
-                logL_threshold=[],
-                logX=[],
-                gradients=[],
-                median_logL=[],
-                leakage_live_points=[],
-                leakage_new_points=[],
-                logZ=[],
-                n_live=[],
-                n_added=[],
-                n_removed=[],
-                n_post=[],
-                live_points_ess=[],
-                pool_entropy=[],
-                samples_entropy=[],
-                proposal_entropy=[],
-                likelihood_evaluations=[],
-                stopping_criteria={
-                    k: [] for k in self.stopping_criterion_aliases.keys()
-                },
+            super().initialise_history()
+            self.history.update(
+                dict(
+                    min_logL=[],
+                    max_logL=[],
+                    logL_threshold=[],
+                    logX=[],
+                    gradients=[],
+                    median_logL=[],
+                    leakage_live_points=[],
+                    leakage_new_points=[],
+                    logZ=[],
+                    n_live=[],
+                    n_added=[],
+                    n_removed=[],
+                    n_post=[],
+                    live_points_ess=[],
+                    pool_entropy=[],
+                    samples_entropy=[],
+                    proposal_entropy=[],
+                    stopping_criteria={
+                        k: [] for k in self.stopping_criterion_aliases.keys()
+                    },
+                )
             )
         else:
             logger.debug("History dictionary already initialised")
@@ -1520,7 +1521,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         its = np.arange(self.iteration)
 
         for a in ax:
-            a.vlines(self.checkpoint_iterations, 0, 1, color="C2")
+            a.vlines(self.history["checkpoint_iterations"], 0, 1, color="C2")
 
         # Counter for each plot
         m = 0
@@ -1876,7 +1877,6 @@ class ImportanceNestedSampler(BaseNestedSampler):
     def get_result_dictionary(self):
         """Get a dictionary contain the main results from the sampler."""
         d = super().get_result_dictionary()
-        d["history"] = self.history
         d["initial_samples"] = self.samples
         d["initial_log_evidence"] = self.log_evidence
         d["initial_log_evidence_error"] = self.log_evidence_error

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -500,8 +500,8 @@ class ImportanceNestedSampler(BaseNestedSampler):
             super().initialise_history()
             self.history.update(
                 dict(
-                    min_logL=[],
-                    max_logL=[],
+                    min_log_likelihood=[],
+                    max_log_likelihood=[],
                     logL_threshold=[],
                     logX=[],
                     gradients=[],
@@ -527,8 +527,12 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
     def update_history(self) -> None:
         """Update the history dictionary"""
-        self.history["min_logL"].append(np.min(self.live_points["logL"]))
-        self.history["max_logL"].append(np.max(self.live_points["logL"]))
+        self.history["min_log_likelihood"].append(
+            np.min(self.live_points["logL"])
+        )
+        self.history["max_log_likelihood"].append(
+            np.max(self.live_points["logL"])
+        )
         self.history["median_logL"].append(np.median(self.live_points["logL"]))
         self.history["logL_threshold"].append(self.logL_threshold)
         self.history["logX"].append(self.logX)
@@ -1339,7 +1343,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         )
         max_samples = int(max_samples_ratio * self.nested_samples.size)
 
-        max_logL = np.max(self.nested_samples["logL"])
+        max_log_likelihood = np.max(self.nested_samples["logL"])
 
         logger.debug(f"Expected efficiency: {eff:.3f}")
         if not any([n_post, n_draw]):
@@ -1439,9 +1443,9 @@ class ImportanceNestedSampler(BaseNestedSampler):
                 it_samples
             )
 
-            if np.any(it_samples["logL"] > max_logL):
+            if np.any(it_samples["logL"] > max_log_likelihood):
                 logger.warning(
-                    f"Max logL increased from {max_logL:.3f} to "
+                    f"Max logL increased from {max_log_likelihood:.3f} to "
                     f"{it_samples['logL'].max():.3f}"
                 )
 
@@ -1528,12 +1532,12 @@ class ImportanceNestedSampler(BaseNestedSampler):
 
         ax[m].plot(
             its,
-            self.history["min_logL"],
+            self.history["min_log_likelihood"],
             label="Min. Log L",
         )
         ax[m].plot(
             its,
-            self.history["max_logL"],
+            self.history["max_log_likelihood"],
             label="Max. Log L",
         )
         ax[m].plot(

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -552,8 +552,8 @@ class NestedSampler(BaseNestedSampler):
             self.history.update(
                 dict(
                     iterations=[],
-                    min_likelihood=[],
-                    max_likelihood=[],
+                    min_log_likelihood=[],
+                    max_log_likelihood=[],
                     logZ=[],
                     dlogZ=[],
                     mean_acceptance=[],
@@ -568,8 +568,8 @@ class NestedSampler(BaseNestedSampler):
     def update_history(self):
         super().update_history()
         self.history["iterations"].append(self.iteration)
-        self.history["min_likelihood"].append(self.logLmin)
-        self.history["max_likelihood"].append(self.logLmax)
+        self.history["min_log_likelihood"].append(self.logLmin)
+        self.history["max_log_likelihood"].append(self.logLmax)
         self.history["logZ"].append(self.state.logZ)
         self.history["dlogZ"].append(self.condition)
         self.history["mean_acceptance"].append(self.mean_acceptance)
@@ -992,8 +992,8 @@ class NestedSampler(BaseNestedSampler):
         for a in ax:
             a.axvline(self.iteration, c="#ff9900", ls="-.")
 
-        ax[0].plot(it, self.history["min_likelihood"], label="Min log L")
-        ax[0].plot(it, self.history["max_likelihood"], label="Max log L")
+        ax[0].plot(it, self.history["min_log_likelihood"], label="Min log L")
+        ax[0].plot(it, self.history["max_log_likelihood"], label="Max log L")
         ax[0].set_ylabel(r"$\log L$")
         ax[0].legend(frameon=False)
 

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -310,7 +310,7 @@ class NestedSampler(BaseNestedSampler):
     @property
     def last_updated(self):
         """Last time the normalising flow was retrained"""
-        if self.history["training_iterations"]:
+        if self.history and self.history["training_iterations"]:
             return self.history["training_iterations"][-1]
         else:
             return 0

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -223,7 +223,6 @@ class NestedSampler(BaseNestedSampler):
         self.checkpoint_on_training = checkpoint_on_training
         self.iteration = 0
         self.acceptance_history = deque(maxlen=(nlive // 10))
-        self.mean_acceptance_history = []
         self.block_acceptance = 1.0
         self.mean_block_acceptance = 1.0
         self.block_iteration = 0
@@ -256,18 +255,6 @@ class NestedSampler(BaseNestedSampler):
 
         # Resume flags
         self.completed_training = True
-
-        # History
-        self.likelihood_evaluations = []
-        self.training_iterations = []
-        self.min_likelihood = []
-        self.max_likelihood = []
-        self.logZ_history = []
-        self.dlogZ_history = []
-        self.population_acceptance = []
-        self.population_radii = []
-        self.population_iterations = []
-        self.checkpoint_iterations = []
 
         self.acceptance_threshold = acceptance_threshold
 
@@ -323,8 +310,8 @@ class NestedSampler(BaseNestedSampler):
     @property
     def last_updated(self):
         """Last time the normalising flow was retrained"""
-        if self.training_iterations:
-            return self.training_iterations[-1]
+        if self.history["training_iterations"]:
+            return self.history["training_iterations"][-1]
         else:
             return 0
 
@@ -559,6 +546,34 @@ class NestedSampler(BaseNestedSampler):
             self.reset_weights = self.reset_flow
             self.reset_permutations = self.reset_flow
 
+    def initialise_history(self):
+        if not self.history:
+            super().initialise_history()
+            self.history.update(
+                dict(
+                    iterations=[],
+                    min_likelihood=[],
+                    max_likelihood=[],
+                    logZ=[],
+                    dlogZ=[],
+                    mean_acceptance=[],
+                    training_iterations=[],
+                    population_acceptance=[],
+                    population_radii=[],
+                    population_iterations=[],
+                    rolling_p=[],
+                )
+            )
+
+    def update_history(self):
+        super().update_history()
+        self.history["iterations"].append(self.iteration)
+        self.history["min_likelihood"].append(self.logLmin)
+        self.history["max_likelihood"].append(self.logLmax)
+        self.history["logZ"].append(self.state.logZ)
+        self.history["dlogZ"].append(self.condition)
+        self.history["mean_acceptance"].append(self.mean_acceptance)
+
     def log_state(self):
         """Log the current state of the sampler"""
         logger.info(
@@ -589,7 +604,7 @@ class NestedSampler(BaseNestedSampler):
                     f"it: {self.iteration:5d}: "
                     f"Rolling KS test: D={D:.4}, p-value={p:.4}"
                 )
-                self.rolling_p.append(p)
+                self.history["rolling_p"].append(p)
             else:
                 logger.info(f"Final KS test: D={D:.4}, p-value={p:.4}")
                 self.final_p_value = p
@@ -781,6 +796,8 @@ class NestedSampler(BaseNestedSampler):
         if self.condition > self.tolerance:
             self.finalised = False
 
+        self.initialise_history()
+
         if all(flags):
             self.initialised = True
 
@@ -920,7 +937,7 @@ class NestedSampler(BaseNestedSampler):
             st = datetime.datetime.now()
             self.proposal.train(training_data)
             self.training_time += datetime.datetime.now() - st
-            self.training_iterations.append(self.iteration)
+            self.history["training_iterations"].append(self.iteration)
 
             self.block_iteration = 0
             self.block_acceptance = 0.0
@@ -966,18 +983,17 @@ class NestedSampler(BaseNestedSampler):
 
         fig, ax = plt.subplots(7, 1, sharex=True, figsize=(12, 12))
         ax = ax.ravel()
-        it = (np.arange(len(self.min_likelihood))) * (self.nlive // 10)
-        it[-1] = self.iteration
+        it = np.array(self.history["iterations"])
 
-        for i in self.checkpoint_iterations:
+        for i in self.history["checkpoint_iterations"]:
             for a in ax:
                 a.axvline(i, ls=":", color="#66ccff")
 
         for a in ax:
             a.axvline(self.iteration, c="#ff9900", ls="-.")
 
-        ax[0].plot(it, self.min_likelihood, label="Min log L")
-        ax[0].plot(it, self.max_likelihood, label="Max log L")
+        ax[0].plot(it, self.history["min_likelihood"], label="Min log L")
+        ax[0].plot(it, self.history["max_likelihood"], label="Max log L")
         ax[0].set_ylabel(r"$\log L$")
         ax[0].legend(frameon=False)
 
@@ -1004,7 +1020,9 @@ class NestedSampler(BaseNestedSampler):
                 handles + handles_tw, labels + labels_tw, frameon=False
             )
 
-        ax[2].plot(it, self.likelihood_evaluations, label="Evaluations")
+        ax[2].plot(
+            it, self.history["likelihood_evaluations"], label="Evaluations"
+        )
         ax[2].set_ylabel("Likelihood\n evaluations")
         ax[2].set_yscale("log")
 
@@ -1015,7 +1033,7 @@ class NestedSampler(BaseNestedSampler):
         ax_dz = plt.twinx(ax[3])
         ax_dz.plot(
             it,
-            self.dlogZ_history,
+            self.history["dlogZ"],
             label="dlogZ",
             c="C1",
             ls=config.plotting.line_styles[1],
@@ -1026,10 +1044,10 @@ class NestedSampler(BaseNestedSampler):
         handles_dz, labels_dz = ax_dz.get_legend_handles_labels()
         ax[3].legend(handles + handles_dz, labels + labels_dz, frameon=False)
 
-        ax[4].plot(it, self.mean_acceptance_history, label="Proposal")
+        ax[4].plot(it, self.history["mean_acceptance"], label="Proposal")
         ax[4].plot(
-            self.population_iterations,
-            self.population_acceptance,
+            self.history["population_iterations"],
+            self.history["population_acceptance"],
             label="Population",
         )
         ax[4].set_ylabel("Acceptance")
@@ -1037,8 +1055,8 @@ class NestedSampler(BaseNestedSampler):
 
         ax_r = plt.twinx(ax[4])
         ax_r.plot(
-            self.population_iterations,
-            self.population_radii,
+            self.history["population_iterations"],
+            self.history["population_radii"],
             label="Radius",
             color="C2",
             ls=config.plotting.line_styles[2],
@@ -1048,19 +1066,21 @@ class NestedSampler(BaseNestedSampler):
         ax[4].legend(handles + handles_r, labels + labels_r, frameon=False)
         ax[4].set_yscale("log")
         ax[4].set_ylim(top=1.1)
-        dtrain = np.array(self.training_iterations[1:]) - np.array(
-            self.training_iterations[:-1]
+        dtrain = np.array(self.history["training_iterations"][1:]) - np.array(
+            self.history["training_iterations"][:-1]
         )
-        ax[5].plot(self.training_iterations[1:], dtrain)
-        if self.training_iterations:
+        ax[5].plot(self.history["training_iterations"][1:], dtrain)
+        if self.history["training_iterations"]:
             ax[5].axvline(
-                self.training_iterations[0], ls="-", color="lightgrey"
+                self.history["training_iterations"][0],
+                ls="-",
+                color="lightgrey",
             )
         ax[5].set_ylabel(r"$\Delta$ train")
 
-        if len(self.rolling_p):
-            it = (np.arange(len(self.rolling_p)) + 1) * self.nlive
-            ax[6].plot(it, self.rolling_p, "o", label="p-value")
+        if len(self.history["rolling_p"]):
+            it = (np.arange(len(self.history["rolling_p"])) + 1) * self.nlive
+            ax[6].plot(it, self.history["rolling_p"], "o", label="p-value")
         ax[6].set_ylabel("p-value")
         ax[6].set_ylim([-0.1, 1.1])
 
@@ -1146,22 +1166,15 @@ class NestedSampler(BaseNestedSampler):
         # Check if acceptance is not None, this indicates the proposal
         # was populated
         if not self.proposal._checked_population:
-            self.population_acceptance.append(
+            self.history["population_acceptance"].append(
                 self.proposal.population_acceptance
             )
-            self.population_radii.append(self.proposal.r)
-            self.population_iterations.append(self.iteration)
+            self.history["population_radii"].append(self.proposal.r)
+            self.history["population_iterations"].append(self.iteration)
             self.proposal._checked_population = True
 
         if not (self.iteration % (self.nlive // 10)) or force:
-            self.likelihood_evaluations.append(
-                self.model.likelihood_evaluations
-            )
-            self.min_likelihood.append(self.logLmin)
-            self.max_likelihood.append(self.logLmax)
-            self.logZ_history.append(self.state.logZ)
-            self.dlogZ_history.append(self.condition)
-            self.mean_acceptance_history.append(self.mean_acceptance)
+            self.update_history()
 
         if not (self.iteration % self.nlive) or force:
             if not force:
@@ -1313,23 +1326,6 @@ class NestedSampler(BaseNestedSampler):
     def get_result_dictionary(self):
         """Return a dictionary that contains results"""
         d = super().get_result_dictionary()
-        iterations = np.arange(len(self.min_likelihood)) * (self.nlive // 10)
-        iterations[-1] = self.iteration
-        d["history"] = dict(
-            iterations=iterations,
-            min_likelihood=self.min_likelihood,
-            max_likelihood=self.max_likelihood,
-            likelihood_evaluations=self.likelihood_evaluations,
-            logZ=self.logZ_history,
-            dlogZ=self.dlogZ_history,
-            mean_acceptance=self.mean_acceptance_history,
-            rolling_p=self.rolling_p,
-            population=dict(
-                iterations=self.population_iterations,
-                acceptance=self.population_acceptance,
-            ),
-            training_iterations=self.training_iterations,
-        )
         d["insertion_indices"] = self.insertion_indices
         d["final_p_value"] = self.final_p_value
         d["final_ks_statistic"] = self.final_ks_statistic

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -1025,8 +1025,24 @@ class NestedSampler(BaseNestedSampler):
         )
         ax[2].set_ylabel("Likelihood\n evaluations")
         ax[2].set_yscale("log")
+        ax[2].legend()
 
-        ax[3].plot(it, self.logZ_history, label="logZ")
+        ax_time = plt.twinx(ax[2])
+        ax_time.plot(
+            it,
+            np.array(self.history["sampling_time"]) / 60,
+            ls=config.plotting.line_styles[1],
+            color="C1",
+            label="Time",
+        )
+        ax_time.set_ylabel("Sampling \ntime [min]")
+        handles, labels = ax[2].get_legend_handles_labels()
+        handles_time, labels_time = ax_time.get_legend_handles_labels()
+        ax[2].legend(
+            handles + handles_time, labels + labels_time, frameon=False
+        )
+
+        ax[3].plot(it, self.history["logZ"], label="logZ")
         ax[3].set_ylabel(r"$\log Z$")
         ax[3].legend(frameon=False)
 

--- a/tests/test_gw/test_gw_reparameterisations.py
+++ b/tests/test_gw/test_gw_reparameterisations.py
@@ -213,5 +213,5 @@ def test_delta_phase_inverse_invertible():
         x_in, x_prime_f.copy(), log_j_f.copy()
     )
     assert_structured_arrays_equal(x_prime_i, x_prime_f)
-    assert_structured_arrays_equal(x_i, x, rtol=1e-15)
+    assert_structured_arrays_equal(x_i, x, rtol=1e-10)
     np.testing.assert_array_equal(log_j_i, log_j_f)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test methods related to initialising and resuming the proposal method"""
+import numpy as np
 import os
 import pytest
 from unittest.mock import patch, MagicMock
@@ -217,7 +218,7 @@ def test_reset(proposal):
     assert proposal.samples is None
     assert proposal.populated is False
     assert proposal.populated_count == 0
-    assert proposal.r is None
+    assert proposal.r is np.nan
     assert proposal.alt_dist is None
     assert proposal._checked_population
 

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -265,13 +265,17 @@ def test_periodically_log_state_iteration(sampler, interval):
 
 
 @pytest.mark.parametrize("periodic", [False, True])
-def test_checkpoint_iteration(sampler, wait, periodic):
+@pytest.mark.parametrize("no_history", [False, True])
+def test_checkpoint_iteration(sampler, wait, periodic, no_history):
     """Test checkpointing method on iterations.
 
     Make sure a file is produced and that the sampling time is updated.
     Also checks to make sure that the iteration is recorded when periodic=False
     """
-    sampler.history = dict(checkpoint_iterations=[10])
+    if no_history:
+        sampler.history = None
+    else:
+        sampler.history = dict(checkpoint_iterations=[10])
     sampler.checkpoint_on_iteration = True
     sampler.checkpoint_interval = 10
     sampler.checkpoint_callback = None
@@ -294,10 +298,16 @@ def test_checkpoint_iteration(sampler, wait, periodic):
     assert sampler.sampling_time.total_seconds() > 0.0
 
     if periodic:
-        assert sampler.history["checkpoint_iterations"] == [10]
+        if not no_history:
+            assert sampler.history["checkpoint_iterations"] == [10]
+        else:
+            assert sampler.history is None
         assert sampler._last_checkpoint == 20
     else:
-        assert sampler.history["checkpoint_iterations"] == [10, 20]
+        if not no_history:
+            assert sampler.history["checkpoint_iterations"] == [10, 20]
+        else:
+            assert sampler.history is None
 
 
 def test_checkpoint_time(sampler, wait):

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -78,6 +78,7 @@ def test_init(sampler, checkpoint_on_iteration):
     assert sampler.live_points is None
     assert sampler.iteration == 0
     assert sampler.finalised is False
+    assert sampler.history is None
 
 
 def test_likelihood_evaluation_time(sampler):
@@ -270,7 +271,7 @@ def test_checkpoint_iteration(sampler, wait, periodic):
     Make sure a file is produced and that the sampling time is updated.
     Also checks to make sure that the iteration is recorded when periodic=False
     """
-    sampler.checkpoint_iterations = [10]
+    sampler.history = dict(checkpoint_iterations=[10])
     sampler.checkpoint_on_iteration = True
     sampler.checkpoint_interval = 10
     sampler.checkpoint_callback = None
@@ -293,10 +294,10 @@ def test_checkpoint_iteration(sampler, wait, periodic):
     assert sampler.sampling_time.total_seconds() > 0.0
 
     if periodic:
-        assert sampler.checkpoint_iterations == [10]
+        assert sampler.history["checkpoint_iterations"] == [10]
         assert sampler._last_checkpoint == 20
     else:
-        assert sampler.checkpoint_iterations == [10, 20]
+        assert sampler.history["checkpoint_iterations"] == [10, 20]
 
 
 def test_checkpoint_time(sampler, wait):
@@ -374,7 +375,7 @@ def test_checkpoint_callback(sampler):
 
     callback = MagicMock()
 
-    sampler.checkpoint_iterations = [10]
+    sampler.history = dict(checkpoint_iterations=[10])
     sampler.checkpoint_on_iteration = True
     sampler.checkpoint_interval = 10
     sampler.checkpoint_callback = callback
@@ -443,6 +444,7 @@ def test_get_result_dictionary(sampler):
     sampler.likelihood_evaluation_time = datetime.timedelta(seconds=2)
     sampler.model.truth = 1.0
     sampler.model.likelihood_evaluations = 10
+    sampler.history = None
 
     d = BaseNestedSampler.get_result_dictionary(sampler)
 
@@ -451,6 +453,7 @@ def test_get_result_dictionary(sampler):
     assert d["total_likelihood_evaluations"] == 10
     assert d["likelihood_evaluation_time"] == 2
     assert d["truth"] == 1.0
+    assert "history" in d
 
 
 def test_getstate(sampler):

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -464,3 +464,27 @@ def test_getstate(sampler):
     assert "model" not in d
     assert d["_previous_likelihood_evaluations"] == 10
     assert d["_previous_likelihood_evaluation_time"] == 4
+
+
+def test_initialise_history(sampler):
+    sampler.history = None
+    BaseNestedSampler.initialise_history(sampler)
+    assert isinstance(sampler.history, dict)
+    assert "sampling_time" in sampler.history
+    assert "likelihood_evaluations" in sampler.history
+
+
+def test_initialise_history_skip(sampler, caplog):
+    caplog.set_level("DEBUG")
+    sampler.history = {}
+    BaseNestedSampler.initialise_history(sampler)
+    assert "already initialised" in str(caplog.text)
+
+
+def test_update_history(sampler):
+    sampler.total_likelihood_evaluations = 20
+    sampler.current_sampling_time = datetime.timedelta(seconds=2)
+    sampler.history = dict(likelihood_evaluations=[10], sampling_time=[1])
+    BaseNestedSampler.update_history(sampler)
+    assert sampler.history["likelihood_evaluations"] == [10, 20]
+    assert sampler.history["sampling_time"] == [1, 2]

--- a/tests/test_samplers/test_importance_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_importance_nested_sampler/conftest.py
@@ -72,8 +72,8 @@ def history(n_it):
     keys = [
         "logX",
         "logZ",
-        "min_logL",
-        "max_logL",
+        "min_log_likelihood",
+        "max_log_likelihood",
         "median_logL",
         "likelihood_evaluations",
         "n_post",

--- a/tests/test_samplers/test_importance_nested_sampler/test_plots.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_plots.py
@@ -14,7 +14,7 @@ def auto_close_figures():
 def test_plot_state(ins, history, n_it):
     ins.iteration = n_it
     ins.history = history
-    ins.checkpoint_iterations = [3, 4]
+    ins.history["checkpoint_iterations"] = [3, 4]
     ins.importance = dict(
         total=np.arange(-1, n_it),
         evidence=np.arange(-1, n_it),

--- a/tests/test_samplers/test_nested_sampler/test_flow_proposal.py
+++ b/tests/test_samplers/test_nested_sampler/test_flow_proposal.py
@@ -268,7 +268,7 @@ def test_train_proposal(sampler, wait):
     sampler.cooldown = 20
     sampler.memory = False
     sampler.training_time = datetime.timedelta()
-    sampler.training_iterations = []
+    sampler.history = dict(training_iterations=[])
     sampler.live_points = np.arange(10)
     sampler.checkpoint_on_training = True
     sampler.block_iteration = 10
@@ -280,7 +280,7 @@ def test_train_proposal(sampler, wait):
     sampler.proposal.train.assert_called_once()
     sampler.checkpoint.assert_called_once_with(periodic=True)
 
-    assert sampler.training_iterations == [100]
+    assert sampler.history["training_iterations"] == [100]
     assert sampler.training_time.total_seconds() > 0
     assert sampler.completed_training is True
     assert sampler.block_iteration == 0
@@ -298,7 +298,7 @@ def test_train_proposal_memory(sampler, wait):
     sampler.cooldown = 20
     sampler.memory = 2
     sampler.training_time = datetime.timedelta()
-    sampler.training_iterations = []
+    sampler.history = dict(training_iterations=[])
     sampler.nested_samples = np.arange(5)
     sampler.live_points = np.arange(5, 10)
     sampler.checkpoint_on_training = True
@@ -315,7 +315,7 @@ def test_train_proposal_memory(sampler, wait):
         sampler.proposal.train.call_args[0], np.array([[5, 6, 7, 8, 9, 3, 4]])
     )
 
-    assert sampler.training_iterations == [100]
+    assert sampler.history["training_iterations"] == [100]
     assert sampler.training_time.total_seconds() > 0
     assert sampler.completed_training is True
     assert sampler.block_iteration == 0

--- a/tests/test_samplers/test_nested_sampler/test_live_points.py
+++ b/tests/test_samplers/test_nested_sampler/test_live_points.py
@@ -72,7 +72,7 @@ def test_populate_live_points_none_returned(sampler):
 def test_insertion_indices(mock_fn, rolling, sampler):
     """Test computing the distribution of insertion indices"""
     sampler.iteration = 100
-    sampler.rolling_p = []
+    sampler.history = dict(rolling_p=[])
     sampler.final_p_value = None
     sampler.final_ks_statistic = None
     sampler.insertion_indices = np.random.randint(
@@ -82,7 +82,7 @@ def test_insertion_indices(mock_fn, rolling, sampler):
     NestedSampler.check_insertion_indices(sampler, rolling=rolling)
 
     if rolling:
-        assert len(sampler.rolling_p) == 1
+        assert len(sampler.history["rolling_p"]) == 1
         np.testing.assert_array_equal(
             mock_fn.call_args_list[0][0][0],
             sampler.insertion_indices[-sampler.nlive :],

--- a/tests/test_samplers/test_nested_sampler/test_manage_state.py
+++ b/tests/test_samplers/test_nested_sampler/test_manage_state.py
@@ -14,17 +14,18 @@ from nessai.samplers.nestedsampler import NestedSampler
 def sampler(sampler):
     """A sampler mock configured to work with update state"""
     # Stored stats
-    sampler.population_acceptance = [0.5]
-    sampler.population_radii = [1.0]
-    sampler.population_iterations = [0]
-    sampler.population_acceptance = [0.5]
-
-    sampler.likelihood_evaluations = [10]
-    sampler.min_likelihood = [0.0]
-    sampler.max_likelihood = [100.0]
-    sampler.logZ_history = [-100.0]
-    sampler.dlogZ_history = [100.0]
-    sampler.mean_acceptance_history = [0.5]
+    sampler.history = dict(
+        iterations=[10],
+        population_radii=[1.0],
+        population_iterations=[0],
+        population_acceptance=[0.5],
+        likelihood_evaluations=[10],
+        min_likelihood=[0.0],
+        max_likelihood=[100.0],
+        logZ=[-100.0],
+        dlogZ=[100.0],
+        mean_acceptance=[0.5],
+    )
     # Attributed used to update stats
     sampler.model = MagicMock()
     sampler.model.likelihood_evaluations = 100
@@ -96,6 +97,28 @@ def test_check_state_train(sampler, force, train):
         sampler.train_proposal.assert_not_called()
 
 
+def test_update_history(sampler):
+    """Test updating the history dictionary"""
+
+    sampler.iteration = 15
+
+    with patch(
+        "nessai.samplers.nestedsampler.BaseNestedSampler.update_history"
+    ) as mock:
+        NestedSampler.update_history(sampler)
+
+    mock.assert_called_once()
+
+    assert sampler.history["population_acceptance"] == [0.5]
+    assert sampler.history["min_likelihood"] == [0.0, 0.0]
+    assert sampler.history["max_likelihood"] == [100.0, 150.0]
+    assert sampler.history["logZ"] == [-100.0, -50.0]
+    assert sampler.history["dlogZ"] == [100.0, 50.0]
+    assert sampler.history["mean_acceptance"] == [0.5, 0.5]
+    assert sampler.history["iterations"] == [10, 15]
+    sampler.checkpoint.assert_not_called()
+
+
 @patch("nessai.samplers.nestedsampler.NestedSampler.checkpoint")
 def test_update_state_checked_acceptance(mock, sampler):
     """Test the behaviour of update state if `_checked_population` is False.
@@ -106,15 +129,17 @@ def test_update_state_checked_acceptance(mock, sampler):
     sampler.iteration = 11
     sampler.proposal._checked_population = False
     sampler.checkpointing = False
+    sampler.update_history = MagicMock()
 
     NestedSampler.update_state(sampler)
 
-    assert sampler.population_acceptance == [0.5, 0.4]
-    assert sampler.population_radii == [1.0, 2.0]
-    assert sampler.population_iterations == [0, 11]
+    sampler.update_history.assert_not_called()
+
+    assert sampler.history["population_acceptance"] == [0.5, 0.4]
+    assert sampler.history["population_radii"] == [1.0, 2.0]
+    assert sampler.history["population_iterations"] == [0, 11]
     assert sampler.proposal._checked_population is True
-    assert sampler.likelihood_evaluations == [10]
-    assert not mock.called
+    mock.assert_not_called()
 
 
 def test_update_state_history(sampler):
@@ -126,17 +151,14 @@ def test_update_state_history(sampler):
     sampler.iteration = 10
     sampler.proposal._checked_population = True
     sampler.checkpointing = False
+    sampler.update_history = MagicMock()
 
     NestedSampler.update_state(sampler)
 
-    assert sampler.population_acceptance == [0.5]
-    assert sampler.likelihood_evaluations == [10, 100]
-    assert sampler.min_likelihood == [0.0, 0.0]
-    assert sampler.max_likelihood == [100.0, 150.0]
-    assert sampler.logZ_history == [-100.0, -50.0]
-    assert sampler.dlogZ_history == [100.0, 50.0]
-    assert sampler.mean_acceptance_history == [0.5, 0.5]
-    assert not sampler.checkpoint.called
+    sampler.update_history.assert_called_once()
+
+    assert sampler.history["population_acceptance"] == [0.5]
+    sampler.checkpoint.assert_not_called()
 
     assert sampler.proposal.ns_acceptance == 0.5
 
@@ -159,14 +181,15 @@ def test_update_state_every_nlive(mock_plot, plot, sampler):
     sampler.output = os.getcwd()
     sampler.insertion_indices = range(2 * sampler.nlive)
     sampler.checkpointing = False
+    sampler.update_history = MagicMock()
 
     NestedSampler.update_state(sampler)
 
+    sampler.update_history.assert_called()
     sampler.check_insertion_indices.assert_called_once()
     assert sampler.block_iteration == 0
     assert sampler.block_acceptance == 0.0
-    assert sampler.likelihood_evaluations == [10, 100]
-    assert sampler.population_acceptance == [0.5]
+    assert sampler.history["population_acceptance"] == [0.5]
 
     if plot:
         sampler.plot_state.assert_called_once_with(
@@ -182,9 +205,9 @@ def test_update_state_every_nlive(mock_plot, plot, sampler):
             ),
         )
     else:
-        assert not sampler.plot_state.called
-        assert not sampler.plot_trace.called
-        assert not mock_plot.called
+        sampler.plot_state.assert_not_called()
+        sampler.plot_trace.assert_not_called()
+        mock_plot.assert_not_called()
 
 
 @patch("nessai.samplers.nestedsampler.plot_indices")
@@ -202,18 +225,19 @@ def test_update_state_force(mock_plot, sampler):
     sampler.output = os.getcwd()
     sampler.uninformed_sampling = False
     sampler.checkpointing = False
+    sampler.update_history = MagicMock()
 
     NestedSampler.update_state(sampler, force=True)
 
-    assert not mock_plot.called
-    assert not sampler.called
+    sampler.update_history.assert_called_once()
+
+    mock_plot.assert_not_called()
     sampler.plot_trace.assert_called_once()
     sampler.plot_state.assert_called_once_with(
         filename=os.path.join(os.getcwd(), "state.png")
     )
 
-    assert sampler.max_likelihood == [100.0, 150.0]
-    assert sampler.population_acceptance == [0.5]
+    assert sampler.history["population_acceptance"] == [0.5]
     assert sampler.block_acceptance == 0.5
     assert sampler.block_iteration == 5
 
@@ -240,8 +264,13 @@ def test_get_result_dictionary(sampler):
     """Assert the correct dictionary is returned"""
     from datetime import timedelta
 
-    base_result = dict(seed=1234)
-
+    base_result = dict(
+        seed=1234,
+        history=dict(
+            likelihood_evaluations=[10],
+            sampling_time=[2],
+        ),
+    )
     sampler.nlive = 1
     sampler.iteration = 3
     sampler.min_likelihood = [-3, -2, 1]

--- a/tests/test_samplers/test_nested_sampler/test_manage_state.py
+++ b/tests/test_samplers/test_nested_sampler/test_manage_state.py
@@ -20,8 +20,8 @@ def sampler(sampler):
         population_iterations=[0],
         population_acceptance=[0.5],
         likelihood_evaluations=[10],
-        min_likelihood=[0.0],
-        max_likelihood=[100.0],
+        min_log_likelihood=[0.0],
+        max_log_likelihood=[100.0],
         logZ=[-100.0],
         dlogZ=[100.0],
         mean_acceptance=[0.5],
@@ -110,8 +110,8 @@ def test_update_history(sampler):
     mock.assert_called_once()
 
     assert sampler.history["population_acceptance"] == [0.5]
-    assert sampler.history["min_likelihood"] == [0.0, 0.0]
-    assert sampler.history["max_likelihood"] == [100.0, 150.0]
+    assert sampler.history["min_log_likelihood"] == [0.0, 0.0]
+    assert sampler.history["max_log_likelihood"] == [100.0, 150.0]
     assert sampler.history["logZ"] == [-100.0, -50.0]
     assert sampler.history["dlogZ"] == [100.0, 50.0]
     assert sampler.history["mean_acceptance"] == [0.5, 0.5]
@@ -273,8 +273,8 @@ def test_get_result_dictionary(sampler):
     )
     sampler.nlive = 1
     sampler.iteration = 3
-    sampler.min_likelihood = [-3, -2, 1]
-    sampler.max_likelihood = [1, 2, 3]
+    sampler.min_log_likelihood = [-3, -2, 1]
+    sampler.max_log_likelihood = [1, 2, 3]
     sampler.likelihood_evaluations = 3
     sampler.logZ_history = [1, 2, 3]
     sampler.mean_acceptance_history = [1, 2, 3]

--- a/tests/test_samplers/test_nested_sampler/test_ns_plotting.py
+++ b/tests/test_samplers/test_nested_sampler/test_ns_plotting.py
@@ -14,24 +14,28 @@ from nessai.samplers.nestedsampler import NestedSampler
 def test_plot_state(sampler, tmpdir, filename, track_gradients):
     """Test making the state plot"""
     x = np.arange(10)
-    sampler.min_likelihood = x
-    sampler.max_likelihood = x
     sampler.iteration = 1003
-    sampler.training_iterations = [256, 711]
     sampler.train_on_empty = False
-    sampler.population_iterations = [256, 500, 711, 800]
-    sampler.population_acceptance = 4 * [0.5]
-    sampler.population_radii = 4 * [1.0]
-    sampler.checkpoint_iterations = [600]
-    sampler.likelihood_evaluations = x
+    sampler.history = dict(
+        iterations=np.arange(10),
+        min_likelihood=x,
+        max_likelihood=x,
+        logZ=x,
+        dlogZ=x,
+        likelihood_evaluations=x,
+        sampling_time=x,
+        training_iterations=[256, 711],
+        population_iterations=[256, 500, 711, 800],
+        population_acceptance=4 * [0.5],
+        population_radii=4 * [1.0],
+        checkpoint_iterations=[600],
+        mean_acceptance=1 / x,
+        rolling_p=np.arange(4),
+    )
     sampler.state = MagicMock()
     sampler.state.log_vols = np.linspace(0, -10, 1050)
     sampler.state.track_gradients = track_gradients
     sampler.state.gradients = np.arange(1050)
-    sampler.logZ_history = x
-    sampler.dlogZ_history = x
-    sampler.mean_acceptance_history = x
-    sampler.rolling_p = np.arange(4)
 
     if filename is not None:
         sampler.output = tmpdir.mkdir("test_plot_state")
@@ -103,7 +107,7 @@ def test_plot_trace(
 @pytest.mark.parametrize("filename", [None, "trace.png"])
 @patch("nessai.samplers.nestedsampler.plot_indices", return_value="fig")
 def test_plot_insertion_indices(mock_plot, sampler, filename):
-    """Test plotting the insetion indices"""
+    """Test plotting the insertion indices"""
     nlive = 10
     indices = list(range(20))
     sampler.nlive = nlive

--- a/tests/test_samplers/test_nested_sampler/test_ns_plotting.py
+++ b/tests/test_samplers/test_nested_sampler/test_ns_plotting.py
@@ -18,8 +18,8 @@ def test_plot_state(sampler, tmpdir, filename, track_gradients):
     sampler.train_on_empty = False
     sampler.history = dict(
         iterations=np.arange(10),
-        min_likelihood=x,
-        max_likelihood=x,
+        min_log_likelihood=x,
+        max_log_likelihood=x,
         logZ=x,
         dlogZ=x,
         likelihood_evaluations=x,

--- a/tests/test_samplers/test_nested_sampler/test_properties.py
+++ b/tests/test_samplers/test_nested_sampler/test_properties.py
@@ -71,13 +71,19 @@ def test_current_sampling_time_finalised(sampler):
 
 def test_last_updated(sampler):
     """Assert last training iteration is returned"""
-    sampler.training_iterations = [10, 20]
+    sampler.history = dict(training_iterations=[10, 20])
     assert NestedSampler.last_updated.__get__(sampler) == 20
 
 
 def test_last_updated_no_training(sampler):
     """Assert None is return if the flow has not been trained"""
-    sampler.training_iterations = []
+    sampler.history = dict(training_iterations=[])
+    assert NestedSampler.last_updated.__get__(sampler) == 0
+
+
+def test_last_updated_no_history(sampler):
+    """Assert None is return if the flow has not been trained"""
+    sampler.history = None
     assert NestedSampler.last_updated.__get__(sampler) == 0
 
 


### PR DESCRIPTION
This PR reworks how the history (run statistics etc) are stored in the samplers so they all use a dictionary. The main change is to the standard sampler, since the importance nested sampler already made use of this.

This should only impact users that are accessing attributes directly from the sampler class. I will mostly likely break resuming from runs with older versions.

I also took this change to add the sampling time to the state plot for the standard sampler.