### PR TITLE
Add option to save log_q

### DIFF
--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -7,10 +7,13 @@ import numpy as np
 import pytest
 
 
-def test_init(ins, model):
+@pytest.mark.parametrize("save_log_q", [False, True])
+def test_init(ins, model, save_log_q):
     ins.add_fields = MagicMock()
-    INS.__init__(ins, model)
+    INS.__init__(ins, model, save_log_q=save_log_q, draw_iid_live=True)
     ins.add_fields.assert_called_once()
+    assert ins.training_samples.save_log_q is save_log_q
+    assert ins.iid_samples.save_log_q is save_log_q
 
 
 def test_add_fields():

--- a/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_ordered_samples.py
@@ -310,3 +310,18 @@ def test_computed_evidence_ratio(ordered_samples, samples, threshold):
         mock_log_evidence.call_args_list[0][0][0], samples[above_threshold]
     )
     assert out == (log_z - log_z_total)
+
+
+@pytest.mark.parametrize("save_log_q", [False, True])
+def test_getstate(ordered_samples, save_log_q):
+    samples = np.random.randn(20, 4)
+    log_q = np.random.randn(2, 20)
+    ordered_samples.save_log_q = save_log_q
+    ordered_samples.log_q = log_q
+    ordered_samples.samples = samples
+    state = OrderedSamples.__getstate__(ordered_samples)
+    assert state["samples"] is samples
+    if save_log_q:
+        assert state["log_q"] is log_q
+    else:
+        assert state["log_q"] is None

--- a/tests/test_sampling/test_ins_sampling.py
+++ b/tests/test_sampling/test_ins_sampling.py
@@ -9,7 +9,8 @@ import pytest
 
 @pytest.mark.slow_integration_test
 @pytest.mark.flaky(reruns=3)
-def test_ins_resume(tmp_path, model, flow_config):
+@pytest.mark.parametrize("save_log_q", [False, True])
+def test_ins_resume(tmp_path, model, flow_config, save_log_q):
     """Assert the INS sampler resumes correctly"""
     output = tmp_path / "test_ins_resume"
     fp = FlowSampler(
@@ -22,6 +23,7 @@ def test_ins_resume(tmp_path, model, flow_config):
         flow_config=flow_config,
         importance_nested_sampler=True,
         max_iteration=2,
+        save_log_q=save_log_q,
     )
     fp.run()
 


### PR DESCRIPTION
After removing `log_q` from the checkpoint files, resuming the importance nested sampler can be very slow. This PR adds an option to save `log_q` instead of removing it. This makes the resume files much larger but makes resuming faster.