### PR TITLE
ENH: Add fractional evidence stopping criterion

### DIFF
--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -289,6 +289,16 @@ class _INSIntegralState(_BaseNSIntegralState):
         return self.compute_uncertainty(log_evidence=True)
 
     @property
+    def evidence(self) -> float:
+        """The current evidence"""
+        return np.exp(self.log_evidence)
+
+    @property
+    def evidence_error(self) -> float:
+        """The evidence error"""
+        return self.compute_uncertainty(log_evidence=False)
+
+    @property
     def log_evidence_live_points(self) -> float:
         """Log-evidence in the live points."""
         if self._weights_lp is None:

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -334,6 +334,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         ess=[
             "ess",
         ],
+        fractional_error=["fractional_error"],
     )
     """Dictionary of available stopping criteria and their aliases."""
 
@@ -1418,6 +1419,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         self.ratio_ns = self.state.compute_evidence_ratio(ns_only=True)
         self.ess = self.state.effective_n_posterior_samples
         self.Z_err = np.exp(self.log_evidence_error)
+        self.fractional_error = self.state.evidence_error / self.state.evidence
         cond = [getattr(self, sc) for sc in self.stopping_criterion]
 
         logger.info(

--- a/tests/test_evidence/test_ins_evidence.py
+++ b/tests/test_evidence/test_ins_evidence.py
@@ -57,6 +57,18 @@ def test_log_evidence_error(state):
     state.compute_uncertainty.assert_called_once_with(log_evidence=True)
 
 
+def test_evidence(state):
+    state.log_evidence = 0.0
+    assert INSState.evidence.__get__(state) == 1.0
+
+
+def test_evidence_error(state):
+    out = 0.1
+    state.compute_uncertainty = MagicMock(return_value=out)
+    assert INSState.evidence_error.__get__(state) == out
+    state.compute_uncertainty.assert_called_once_with(log_evidence=False)
+
+
 def test_log_evidence_live_points(state):
     """Check the correct value is returned"""
     state._weights_lp = np.log(np.array([1, 2, 3]))

--- a/tests/test_samplers/test_importance_nested_sampler/test_stopping_criteria.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_stopping_criteria.py
@@ -1,5 +1,6 @@
 from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
 import pytest
+from unittest.mock import MagicMock
 
 
 @pytest.mark.parametrize(
@@ -20,3 +21,13 @@ def test_reached_tolerance(ins, criterion, tolerance, stop_any, reached):
     ins.tolerance = tolerance
     ins._stop_any = stop_any
     assert INS.reached_tolerance.__get__(ins) is reached
+
+
+def test_compute_stopping_criterion_fractional_error(ins):
+    ins.stopping_criterion = ["fractional_error"]
+    ins.iteration = 0
+    ins.tolerance = 0.0
+    ins.state = MagicMock()
+    ins.state.evidence = 1.0
+    ins.state.evidence_error = 0.1
+    assert INS.compute_stopping_criterion(ins) == [0.1]


### PR DESCRIPTION
@johnveitch based on the conversation we had, I thought I'd add the `fractional_error` as a stopping criterion. 

I've not changed any defaults but I've verified this does indeed run and for the example, stops with a reasonable ESS:

![image](https://github.com/mj-will/nessai/assets/25609742/b008453d-b59f-4117-a958-23b4acaeca9b)
