### PR TITLE
Explicity support Python 3.12

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ gw = [
 ]
 dev = [
     "pre-commit",
-    "ray[default]; sys_platform != 'win32' or (sys_platform == 'win32' and python_version < '3.12')",
+    "ray[default]; sys_platform != 'win32' and python_version < '3.12'",
     "corner",
     "black>=24.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ gw = [
 ]
 dev = [
     "pre-commit",
-    "ray[default]",
+    "ray[default]; sys_platform != 'win32' or (sys_platform == 'win32' and python_version < '3.12')",
     "corner",
     "black>=24.0",
 ]
@@ -99,6 +99,7 @@ target-version = [
     "py39",
     "py310",
     "py311",
+    "py312",
 ]
 
 [tool.flake8]

--- a/tests/test_flows/test_base_flow.py
+++ b/tests/test_flows/test_base_flow.py
@@ -28,9 +28,7 @@ def test_base_flow_abstract_methods():
     """Assert an error is raised if the methods are not implemented."""
     with pytest.raises(TypeError) as excinfo:
         BaseFlow()
-    assert "instantiate abstract class BaseFlow with abstract method" in str(
-        excinfo.value
-    )
+    assert "instantiate abstract class BaseFlow" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -830,7 +830,7 @@ def test_run_ins_redraw(flow_sampler):
         compute_initial_posterior=True,
     )
 
-    assert ns.draw_posterior_samples.has_calls(
+    ns.draw_posterior_samples.assert_has_calls(
         [
             call(
                 sampling_method="importance_sampling", use_final_samples=False

--- a/tests/test_gw/test_distance_converters.py
+++ b/tests/test_gw/test_distance_converters.py
@@ -56,10 +56,7 @@ def test_converter_error():
     """Assert an error is raised if the methods are not implemented"""
     with pytest.raises(TypeError) as excinfo:
         DistanceConverter()
-    assert (
-        "abstract methods from_uniform_parameter, to_uniform_parameter"
-        in str(excinfo.value)
-    )
+    assert "abstract methods" in str(excinfo.value)
 
 
 def test_converter_to_uniform_parameter_error(base_converter):

--- a/tests/test_proposal/test_base_proposal.py
+++ b/tests/test_proposal/test_base_proposal.py
@@ -37,7 +37,7 @@ def test_init_with_draw():
     model = Mock()
     with pytest.raises(TypeError) as excinfo:
         Proposal(model)
-    assert "class Proposal with abstract method" in str(excinfo.value)
+    assert "class Proposal with" in str(excinfo.value)
 
 
 def test_initialised(proposal):


### PR DESCRIPTION
The code currently works for Python 3.12 but isn't tested, this PR adds 3.12 to the test suite