### PR TITLE
ENH: Rework ins weights

### DIFF
--- a/nessai/flowmodel/importance.py
+++ b/nessai/flowmodel/importance.py
@@ -100,7 +100,7 @@ class ImportanceFlowModel(FlowModel):
         log_prob = log_prob.cpu().numpy().astype(np.float64)
         return log_prob
 
-    def log_prob_all(self, x, exclude_last=False):
+    def log_prob_all(self, x):
         """Compute the log probability using all of the stored models."""
         x = (
             torch.from_numpy(x)
@@ -110,12 +110,6 @@ class ImportanceFlowModel(FlowModel):
         if self.models.training:
             self.models.eval()
         n = self.n_models
-        if exclude_last:
-            n -= 1
-        if n <= 0:
-            raise RuntimeError(
-                "Cannot exclude last when flow there is only one flow"
-            )
         log_prob = torch.empty(x.shape[0], n)
         with torch.no_grad():
             for i, m in enumerate(self.models[:n]):

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -97,7 +97,7 @@ class ImportanceFlowProposal(Proposal):
     @property
     def weights_array(self) -> np.ndarray:
         """Array of weights for each proposal"""
-        return np.fromiter(self.weights.values(), dtype=float)
+        return np.fromiter(self._weights.values(), dtype=float)
 
     @property
     def n_proposals(self) -> int:
@@ -422,7 +422,7 @@ class ImportanceFlowProposal(Proposal):
         self,
         n: int,
         flow_number: Optional[int] = None,
-    ) -> np.ndarray:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """Draw n new points.
 
         Parameters
@@ -437,11 +437,11 @@ class ImportanceFlowProposal(Proposal):
         -------
         np.ndarray :
             Array of new points.
+        np.ndarray :
+            Log-proposal probabilities (log_q)
         """
         if flow_number is None:
             flow_number = self.level_count
-        elif flow_number not in self.n_requested:
-            raise RuntimeError("Cannot sample from prior with `draw`")
 
         # Draw a few more samples in case some are not accepted.
         n_draw = int(1.01 * n)
@@ -545,7 +545,9 @@ class ImportanceFlowProposal(Proposal):
             raise RuntimeError(
                 "Cannot update samples unless a level has been constructed!"
             )
-        if np.isnan(self.weights[self.level_count]):
+        if self.level_count not in self.weights or np.isnan(
+            self.weights[self.level_count]
+        ):
             raise RuntimeError(
                 "Must set weights from the new level before updating any "
                 "existing samples!"

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -43,9 +43,9 @@ class ImportanceFlowProposal(Proposal):
         Output directory.
     flow_config : dict
         Configuration for the flow.
-    reparameterization : str
-        Reparameterization to use. If None, only the unit-hypercube
-        reparameterization is used.
+    reparameterisation : str
+        Reparameterisation to use. If None, only the unit-hypercube
+        reparameterisation is used.
     weighted_kl : bool
         If true, use the weights (prior / meta-proposal) when training the
         next flow.
@@ -91,10 +91,12 @@ class ImportanceFlowProposal(Proposal):
 
     @property
     def weights(self) -> dict:
+        """Dictionary containing the weights for each proposal"""
         return self._weights
 
     @property
-    def weights_array(self) -> dict:
+    def weights_array(self) -> np.ndarray:
+        """Array of weights for each proposal"""
         return np.fromiter(self.weights.values(), dtype=float)
 
     @property
@@ -261,7 +263,8 @@ class ImportanceFlowProposal(Proposal):
         x = numpy_array_to_live_points(x, self.model.names)
         return x, log_j
 
-    def update_proposal_weights(self, weights: dict):
+    def update_proposal_weights(self, weights: dict) -> None:
+        """Method to update the proposal weights dictionary."""
         self._weights.update(weights)
 
     def train(

--- a/tests/test_proposal/test_importance/test_config.py
+++ b/tests/test_proposal/test_importance/test_config.py
@@ -15,9 +15,7 @@ def test_init(ifp, model, tmp_path):
     output = tmp_path / "test"
     initial_draws = 1000
     IFP.__init__(ifp, model, output, initial_draws)
-
-    assert ifp.n_draws["initial"] == initial_draws
-    assert ifp.n_requested["initial"] == initial_draws
+    assert ifp._weights[-1] == 1
 
 
 @pytest.mark.usefixtures("ins_parameters")

--- a/tests/test_proposal/test_importance/test_prob.py
+++ b/tests/test_proposal/test_importance/test_prob.py
@@ -23,14 +23,13 @@ def test_log_prior(ifp):
 
 def test_compute_log_Q(ifp, x_prime):
     n_flows = 3
-    ifp.poolsize = np.array([5, 10, 15, 20])
+    ifp.weights_array = np.array([0.25, 0.25, 0.25, 0.25])
     ifp.flow.n_models = n_flows
     ifp.n_proposals = n_flows + 1
 
     log_j = np.log(np.random.rand(len(x_prime)))
 
-    def log_prob_all(x, exclude_last):
-        assert exclude_last is False
+    def log_prob_all(x):
         return np.log(np.random.rand(len(x), n_flows))
 
     ifp.flow.log_prob_all = MagicMock(side_effect=log_prob_all)
@@ -41,44 +40,7 @@ def test_compute_log_Q(ifp, x_prime):
     assert log_q.shape == (len(x_prime), n_flows + 1)
     assert all(log_q[:, 0] == 0)
 
-    weights = ifp.poolsize / ifp.poolsize.sum()
-    expected_log_Q = logsumexp(log_q, b=weights, axis=1)
-    np.testing.assert_array_equal(log_Q, expected_log_Q)
-
-
-def test_compute_log_Q_exclude_last(ifp, x_prime):
-    n_flows = 3
-    n = 30
-    ifp.poolsize = np.array([5, 10, 15, 20])
-    ifp.flow.n_models = n_flows
-    ifp.n_proposals = n_flows + 1
-
-    log_q_current = np.log(np.random.rand(len(x_prime)))
-    log_j = np.log(np.random.rand(len(x_prime)))
-
-    def log_prob_all(x, exclude_last):
-        assert exclude_last is True
-        return np.log(np.random.rand(len(x), n_flows - 1))
-
-    ifp.flow.log_prob_all = MagicMock(side_effect=log_prob_all)
-
-    log_Q, log_q = IFP.compute_log_Q(
-        ifp,
-        x_prime,
-        log_j=log_j,
-        n=n,
-        log_q_current=log_q_current,
-    )
-
-    assert len(log_Q) == len(x_prime)
-    assert log_q.shape == (len(x_prime), n_flows + 1)
-    assert all(log_q[:, 0] == 0)
-    assert all(log_q[:, -1] == (log_q_current + log_j))
-
-    weights = ifp.poolsize.astype(float)
-    weights[-1] = n
-    weights /= np.sum(weights)
-    expected_log_Q = logsumexp(log_q, b=weights, axis=1)
+    expected_log_Q = logsumexp(log_q, b=ifp.weights_array, axis=1)
     np.testing.assert_array_equal(log_Q, expected_log_Q)
 
 
@@ -148,11 +110,12 @@ def test_compute_meta_proposal_from_log_q(ifp):
         pvals=np.ones(n_prop) / float(n_prop),
         size=n,
     )
-    ifp.poolsize = poolsize
+    weights = poolsize / np.sum(poolsize)
+    ifp.weights_array = weights
 
     expected = logsumexp(
         log_q,
-        b=poolsize / np.sum(poolsize),
+        b=weights,
         axis=1,
     )
 
@@ -166,7 +129,7 @@ def test_compute_meta_proposal_from_log_q(ifp):
 def test_compute_meta_proposal_samples(ifp, x, x_prime, log_j):
 
     ifp.level_count = 2
-    ifp.n_draws = {-1: 10, 0: 10, 1: 10, 2: 10}
+    ifp.weights = {-1: 0.25, 0: 0.25, 1: 0.25, 2: 0.25}
 
     x["logQ"] = np.nan
     x["logW"] = np.nan

--- a/tests/test_proposal/test_importance/test_properties.py
+++ b/tests/test_proposal/test_importance/test_properties.py
@@ -2,31 +2,29 @@
 
 from unittest.mock import patch
 from nessai.proposal.importance import ImportanceFlowProposal as IFP
+import numpy as np
 import pytest
 
 
 @pytest.fixture
-def n_draws():
-    return {"-1": 10, "0": 20, "1": 30}
+def weights():
+    return {"-1": 0.2, "0": 0.3, "1": 0.5}
 
 
 @pytest.fixture
-def ifp(ifp, n_draws):
-    ifp.n_draws = n_draws
+def ifp(ifp, weights):
+    ifp._weights = weights
     return ifp
 
 
-def test_total_samples_drawn(ifp):
-    assert IFP.total_samples_drawn.__get__(ifp) == 60
+def test_weights(ifp, weights):
+    assert IFP.weights.__get__(ifp) == weights
 
 
-def test_unnormalised_weights(ifp, n_draws):
-    assert IFP.unnormalised_weights.__get__(ifp) == n_draws
-
-
-def test_poolsize(ifp, n_draws):
-    ifp.unnormalised_weights = n_draws
-    IFP.poolsize.__get__(ifp) == [10, 20, 30]
+def test_weights_array(ifp, weights):
+    np.testing.assert_array_equal(
+        IFP.weights_array.__get__(ifp), np.array(list(weights.values()))
+    )
 
 
 def test_n_proposals(ifp):

--- a/tests/test_proposal/test_importance/test_resume.py
+++ b/tests/test_proposal/test_importance/test_resume.py
@@ -36,14 +36,16 @@ def test_getstate_integration(tmp_path, model):
 
     ifp = IFP(
         model,
-        tmp_path / "test_resume",
-        100,
+        output=tmp_path / "test_resume",
         weighted_kl=False,
     )
     ifp.initialise()
+    weights = {-1: 1.0}
 
-    for _ in range(4):
+    for i in range(4):
         ifp.train(model.new_point(10), max_epochs=2)
+        weights = {j - 1: 1 / (i + 2) for j in range(i + 2)}
+        ifp.update_proposal_weights(weights)
         ifp.draw(10)
 
     out = pickle.dumps(ifp)

--- a/tests/test_samplers/test_importance_nested_sampler/test_proposal.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_proposal.py
@@ -1,14 +1,16 @@
 """Tests for the proposals and meta-proposal"""
 
 import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from nessai.samplers.importancesampler import (
     ImportanceNestedSampler as INS,
     OrderedSamples,
 )
+from nessai.proposal.importance import ImportanceFlowProposal
 from nessai.utils.testing import assert_structured_arrays_equal
 import numpy as np
+import os
 import pytest
 
 
@@ -16,6 +18,25 @@ import pytest
 def ins(ins, proposal):
     ins.proposal = proposal
     return ins
+
+
+def test_get_proposal(ins, model, tmp_path):
+    output = str(tmp_path)
+    subdir = "proposal"
+    ins.model = model
+    ins.output = output
+    instance = object()
+    with patch(
+        "nessai.samplers.importancesampler.ImportanceFlowProposal",
+        return_value=instance,
+    ) as mock_class:
+        out = INS.get_proposal(ins, subdir, test=1)
+    assert out is instance
+    mock_class.assert_called_once_with(
+        model,
+        os.path.join(output, subdir, ""),
+        test=1,
+    )
 
 
 @pytest.mark.parametrize("weighted_kl", [False, True])
@@ -59,3 +80,48 @@ def test_draw_n_samples(ins, samples, log_q, history):
 
     np.testing.assert_array_equal(out[1], log_q)
     assert_structured_arrays_equal(out[0], expected)
+
+
+def test_update_proposal_weights(ins):
+    ins.samples_unit = np.ones(10)
+    ins.sample_counts = {-1: 2, 0: 4, 1: 4}
+    ins.proposal = MagicMock(spec=ImportanceFlowProposal)
+    INS.update_proposal_weights(ins)
+    expected_weights = {-1: 0.2, 0: 0.4, 1: 0.4}
+    ins.proposal.update_proposal_weights.assert_called_once_with(
+        expected_weights
+    )
+
+
+def test_add_new_proposal_weight(ins):
+    n = 8
+    n_new = 2
+    sample_counts = {-1: 2, 0: 3, 1: 3}
+    iteration = 2
+
+    ins.samples_unit = np.ones(n)
+    ins.sample_counts = sample_counts
+    ins.proposal = MagicMock(spec=ImportanceFlowProposal)
+
+    INS.add_new_proposal_weight(ins, iteration, n_new)
+
+    assert ins.sample_counts[2] == 2
+    expected_weights = {-1: 0.2, 0: 0.3, 1: 0.3, 2: 0.2}
+    ins.proposal.update_proposal_weights.assert_called_once_with(
+        expected_weights
+    )
+
+
+def test_add_new_proposal_weight_error(ins):
+    n = 8
+    n_new = 2
+    sample_counts = {-1: 2, 0: 3, 1: 3, 2: 2}
+    iteration = 2
+
+    ins.samples_unit = np.ones(n)
+    ins.sample_counts = sample_counts
+
+    with pytest.raises(
+        RuntimeError, match="Samples already drawn from proposal 2"
+    ):
+        INS.add_new_proposal_weight(ins, iteration, n_new)

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -171,3 +171,11 @@ def test_update_evidence(ins, iid):
     ins.training_samples.update_evidence.assert_called_once()
     if iid:
         ins.iid_samples.update_evidence.assert_called_once()
+
+
+def test_update_sample_counts(ins):
+    ins.samples_unit = {"it": np.array([-1, 0, 2, 2, 2])}
+    ins.proposal = MagicMock()
+    ins.proposal.n_proposals = 5
+    INS.update_sample_counts(ins)
+    assert ins.sample_counts == {-1: 1, 0: 1, 1: 0, 2: 3, 3: 0}

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -49,6 +49,7 @@ def test_populate_live_points_no_iid(ins, model):
     n = 100
     ins.n_initial = n
     ins.model = model
+    ins.sample_counts = {}
     ins.draw_iid_live = False
 
     INS.populate_live_points(ins)
@@ -65,6 +66,7 @@ def test_populate_live_points_iid(ins, model):
     ins.n_initial = n
     ins.model = model
     ins.draw_iid_live = True
+    ins.sample_counts = {}
     ins.iid_samples = create_autospec(OrderedSamples)
 
     INS.populate_live_points(ins)


### PR DESCRIPTION
This PR simplifies how weights are stored in the proposal for the importance nested sampler. They must now be set manually after training, rather than being set based on how many samples have been drawn. This will make it easier to e.g. change the weights during sampling