### PR TITLE
Unit hypercube prior for INS

### DIFF
--- a/examples/importance_nested_sampler/hypercube_prior.py
+++ b/examples/importance_nested_sampler/hypercube_prior.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+# Example of using the importance nested sampler with a non-uniform
+# prior in the unit hypercube space.
+
+import numpy as np
+import os
+from scipy.stats import norm, truncnorm
+
+from nessai.flowsampler import FlowSampler
+from nessai.model import Model
+from nessai.utils import setup_logger
+from nessai.plot import corner_plot
+
+output = os.path.join("outdir", "ins_non_uniform_prior")
+logger = setup_logger(output=output)
+
+
+class ModelWithNonUniformPrior(Model):
+    """A likelihood that has a non-uniform prior in the unit-hypercube"""
+
+    def __init__(self, dims):
+        self.names = [f"x_{d}" for d in range(dims)]
+        self.bounds = {n: [-10.0, 10.0] for n in self.names}
+
+        # Gaussian prior truncated on [-10, 10] with mean 0 and scale 0.5
+        scale = 0.5
+        self.prior_dist = truncnorm(-10 / scale, 10 / scale, scale=scale)
+
+        # Define the distribution in the uniform hypercube
+        # Will be centred at 0.5
+        loc = 0.5
+        h_scale = scale / 20
+        self.hypercube_prior_dist = truncnorm(
+            (0 - loc) / h_scale,  # Limits [0, 1]
+            (1 - loc) / h_scale,
+            loc=loc,
+            scale=h_scale,
+        )
+        self.likelihood_dist = norm(loc=1.0, scale=0.5)
+
+    def log_prior(self, x):
+        """Log-prior"""
+        log_p = np.log(self.in_bounds(x), dtype=float)
+        log_p += self.prior_dist.logpdf(self.unstructured_view(x)).sum(axis=-1)
+        return log_p
+
+    def log_likelihood(self, x):
+        "Log-likelihood"
+        return self.likelihood_dist.logpdf(self.unstructured_view(x)).sum(
+            axis=-1
+        )
+
+    def from_unit_hypercube(self, x):
+        """Mapping from the unit hypercube.
+
+        This mapping does not map from uniform to the correct prior.
+        """
+        x_out = x.copy()
+        for n in self.names:
+            x_out[n] = (self.bounds[n][1] - self.bounds[n][0]) * x[
+                n
+            ] + self.bounds[n][0]
+        return x_out
+
+    def log_prior_unit_hypercube(self, x) -> np.ndarray:
+        """The log-prior defined in the unit hypercube space.
+
+        This must be defined based on the how `from_unit_hypercube` is
+        defined.
+        """
+        return np.log(
+            self.in_unit_hypercube(x), dtype=float
+        ) + self.hypercube_prior_dist.logpdf(self.unstructured_view(x)).sum(
+            axis=-1
+        )
+
+
+# Run standard nessai for reference
+model = ModelWithNonUniformPrior(2)
+fs = FlowSampler(
+    model,
+    nlive=1000,
+    output=os.path.join(output, "standard"),
+    resume=False,
+    seed=1234,
+    importance_nested_sampler=False,
+)
+fs.run()
+
+# Run the importance nested sampler
+model = ModelWithNonUniformPrior(2)
+fs_ins = FlowSampler(
+    model,
+    nlive=1000,
+    output=os.path.join(output, "ins"),
+    resume=False,
+    seed=1234,
+    importance_nested_sampler=True,
+)
+fs_ins.run()
+
+# Compare the evidences
+print(f"Log-evidences: {fs.log_evidence:.3f} vs {fs_ins.log_evidence:.3f}")
+
+# Plot a comparison of the posteriors
+fig = corner_plot(fs.posterior_samples, color="C0", include=model.names)
+fig = corner_plot(
+    fs_ins.posterior_samples,
+    color="C1",
+    fig=fig,
+    include=model.names,
+    filename=os.path.join(output, "comparison.png"),
+)

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -107,6 +107,7 @@ class Model(ABC):
     """
     _vectorised_likelihood = None
     _vectorised_prior = None
+    _vectorised_prior_unit_hypercube = None
     _pool_configured = False
     n_pool = None
 
@@ -233,6 +234,26 @@ class Model(ABC):
 
     @vectorised_prior.setter
     def vectorised_prior(self, value):
+        """Manually set the value for vectorised prior."""
+        self._vectorised_prior = value
+
+    @property
+    def vectorised_prior_unit_hypercube(self):
+        if self._vectorised_prior_unit_hypercube is None:
+            if self.allow_vectorised_prior:
+                # Avoids calling prior on multiple points
+                x = np.concatenate([self.new_point() for _ in range(10)])
+                self._vectorised_prior = check_vectorised_function(
+                    self.log_prior,
+                    x,
+                    dtype=config.livepoints.default_float_dtype,
+                )
+            else:
+                self._vectorised_prior_unit_hypercube = False
+        return self._vectorised_prior_unit_hypercube
+
+    @vectorised_prior_unit_hypercube.setter
+    def vectorised_prior_unit_hypercube(self, value):
         """Manually set the value for vectorised prior."""
         self._vectorised_prior = value
 
@@ -504,6 +525,15 @@ class Model(ABC):
             names=self.names,
         )
 
+    def log_prior_unit_hypercube(self, x) -> np.ndarray:
+        """Compute the log-prior in the unit-hyper cube.
+
+        By default this returns log(1) and checks if the values are in unit
+        hypercube.
+        """
+        x = self.unstructured_view(x)
+        return np.log(np.any((x >= 0) & (x <= 1), axis=1))
+
     def from_unit_hypercube(self, x):
         """Map from the unit hypercube to the priors.
 
@@ -606,6 +636,33 @@ class Model(ABC):
             self.log_prior,
             x,
             self.allow_vectorised_prior and self.vectorised_prior,
+            func_wrapper=log_prior_wrapper,
+            pool=self.pool if self.parallelise_prior else None,
+            n_pool=self.n_pool,
+        )
+
+    def batch_evaluate_log_prior_unit_hypercube(
+        self, x: np.ndarray
+    ) -> np.ndarray:
+        """Evaluate the log-prior in the unit hypercube for a batch of samples.
+
+        Uses the pool if available.
+
+        Parameters
+        ----------
+        x : :obj:`numpy.ndarray`
+            Array of samples
+
+        Returns
+        -------
+        :obj:`numpy.ndarray`
+            Array of log-prior values
+        """
+        return batch_evaluate_function(
+            self.log_prior_unit_hypercube,
+            x,
+            self.allow_vectorised_prior
+            and self.vectorised_prior_unit_hypercube,
             func_wrapper=log_prior_wrapper,
             pool=self.pool if self.parallelise_prior else None,
             n_pool=self.n_pool,

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -244,10 +244,12 @@ class Model(ABC):
             if self.allow_vectorised_prior:
                 # Avoids calling prior on multiple points
                 x = self.sample_unit_hypercube(n=10)
-                self._vectorised_prior = check_vectorised_function(
-                    self.log_prior_unit_hypercube,
-                    x,
-                    dtype=config.livepoints.default_float_dtype,
+                self._vectorised_prior_unit_hypercube = (
+                    check_vectorised_function(
+                        self.log_prior_unit_hypercube,
+                        x,
+                        dtype=config.livepoints.default_float_dtype,
+                    )
                 )
             else:
                 self._vectorised_prior_unit_hypercube = False
@@ -256,7 +258,7 @@ class Model(ABC):
     @vectorised_prior_unit_hypercube.setter
     def vectorised_prior_unit_hypercube(self, value):
         """Manually set the value for vectorised prior."""
-        self._vectorised_prior = value
+        self._vectorised_prior_unit_hypercube = value
 
     @property
     def _view_dtype(self):

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -19,6 +19,7 @@ from .utils.multiprocessing import (
     get_n_pool,
     log_likelihood_wrapper,
     log_prior_wrapper,
+    log_prior_unit_hypercube_wrapper,
     batch_evaluate_function,
     check_vectorised_function,
 )
@@ -663,7 +664,7 @@ class Model(ABC):
             x,
             self.allow_vectorised_prior
             and self.vectorised_prior_unit_hypercube,
-            func_wrapper=log_prior_wrapper,
+            func_wrapper=log_prior_unit_hypercube_wrapper,
             pool=self.pool if self.parallelise_prior else None,
             n_pool=self.n_pool,
         )

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -526,7 +526,7 @@ class Model(ABC):
         )
 
     def log_prior_unit_hypercube(self, x) -> np.ndarray:
-        """Compute the log-prior in the unit-hyper cube.
+        """Compute the log-prior in the unit hypercube.
 
         By default this returns log(1) and checks if the values are in unit
         hypercube.

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -242,9 +242,9 @@ class Model(ABC):
         if self._vectorised_prior_unit_hypercube is None:
             if self.allow_vectorised_prior:
                 # Avoids calling prior on multiple points
-                x = np.concatenate([self.new_point() for _ in range(10)])
+                x = self.sample_unit_hypercube(n=10)
                 self._vectorised_prior = check_vectorised_function(
-                    self.log_prior,
+                    self.log_prior_unit_hypercube,
                     x,
                     dtype=config.livepoints.default_float_dtype,
                 )

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -528,11 +528,11 @@ class Model(ABC):
     def log_prior_unit_hypercube(self, x) -> np.ndarray:
         """Compute the log-prior in the unit hypercube.
 
-        By default this returns log(1) and checks if the values are in unit
+        By default this returns log(1) and checks if the values are in the unit
         hypercube.
         """
         x = self.unstructured_view(x)
-        return np.log(np.any((x >= 0) & (x <= 1), axis=-1))
+        return np.log(~np.any((x < 0) | (x >= 1), axis=-1))
 
     def from_unit_hypercube(self, x):
         """Map from the unit hypercube to the priors.

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -532,7 +532,7 @@ class Model(ABC):
         hypercube.
         """
         x = self.unstructured_view(x)
-        return np.log(np.any((x >= 0) & (x <= 1), axis=1))
+        return np.log(np.any((x >= 0) & (x <= 1), axis=-1))
 
     def from_unit_hypercube(self, x):
         """Map from the unit hypercube to the priors.

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -565,14 +565,10 @@ class ImportanceFlowProposal(Proposal):
         x, log_j = self.rescale(samples)
         return self.compute_log_Q(x, log_j=log_j)
 
-    def _log_prior(self, x: np.ndarray) -> np.ndarray:
-        """Helper function that returns the prior in the unit hyper-cube."""
-        return self.model.batch_evaluate_log_prior_unit_hypercube(x)
-
     def get_proposal_log_prob(self, it: int) -> Callable:
         """Get a pointer to the function for ith proposal."""
         if it == -1:
-            return self._log_prior
+            return self.model.batch_evaluate_log_prior_unit_hypercube
         elif it < len(self.flow.models):
             return lambda x: self.flow.log_prob_ith(x, it)
         else:

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -138,6 +138,10 @@ class ImportanceFlowProposal(Proposal):
             raise RuntimeError(
                 "logW field missing in non-sampling parameters."
             )
+        if "logU" not in config.livepoints.non_sampling_parameters:
+            raise RuntimeError(
+                "logU field missing in non-sampling parameters."
+            )
 
     def initialise(self):
         """Initialise the proposal"""
@@ -487,7 +491,8 @@ class ImportanceFlowProposal(Proposal):
             x["logP"] = self.model.batch_evaluate_log_prior(
                 x, unit_hypercube=True
             )
-            x["logW"] = -x["logQ"]
+            x["logU"] = self.model.batch_evaluate_log_prior_unit_hypercube(x)
+            x["logW"] = x["logU"] - x["logQ"]
             accept = (
                 np.isfinite(x["logP"])
                 & ~np.isposinf(x["logW"])
@@ -562,7 +567,7 @@ class ImportanceFlowProposal(Proposal):
 
     def _log_prior(self, x: np.ndarray) -> np.ndarray:
         """Helper function that returns the prior in the unit hyper-cube."""
-        return np.zeros(x.shape[0])
+        return self.model.batch_evaluate_log_prior_unit_hypercube(x)
 
     def get_proposal_log_prob(self, it: int) -> Callable:
         """Get a pointer to the function for ith proposal."""
@@ -614,10 +619,13 @@ class ImportanceFlowProposal(Proposal):
     def draw_from_prior(self, n: int) -> Tuple[np.ndarray, np.ndarray]:
         """Draw from the prior"""
         samples = self.model.sample_unit_hypercube(n)
+        samples["logU"] = self.model.batch_evaluate_log_prior_unit_hypercube(
+            samples
+        )
         prime_samples, log_j = self.rescale(samples)
         log_Q, log_q = self.compute_log_Q(prime_samples, log_j=log_j)
         samples["logQ"] = log_Q
-        samples["logW"] = -log_Q
+        samples["logW"] = samples["logU"] - log_Q
         return samples, log_q
 
     def draw_from_flows(

--- a/nessai/proposal/importance.py
+++ b/nessai/proposal/importance.py
@@ -565,10 +565,16 @@ class ImportanceFlowProposal(Proposal):
         x, log_j = self.rescale(samples)
         return self.compute_log_Q(x, log_j=log_j)
 
+    def _log_prob_initial(self, x: np.ndarray) -> np.ndarray:
+        """Helper function that returns the log-probability for the initial
+        points.
+        """
+        return np.zeros(x.shape[0])
+
     def get_proposal_log_prob(self, it: int) -> Callable:
         """Get a pointer to the function for ith proposal."""
         if it == -1:
-            return self.model.batch_evaluate_log_prior_unit_hypercube
+            return self._log_prob_initial
         elif it < len(self.flow.models):
             return lambda x: self.flow.log_prob_ith(x, it)
         else:

--- a/nessai/utils/multiprocessing.py
+++ b/nessai/utils/multiprocessing.py
@@ -109,6 +109,26 @@ def log_prior_wrapper(x):
     return _model.log_prior(x)
 
 
+def log_prior_unit_hypercube_wrapper(x):
+    """Wrapper for the log-prior in the unit-hypercube for use with
+    multiprocessing.
+
+    Should be used alongside
+    :py:func:`nessai.utils.multiprocessing.initialise_pool_variables`
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray`
+        Array of samples.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Array of log-prior values in the unit-hypercube.
+    """
+    return _model.log_prior_unit_hypercube(x)
+
+
 def batch_evaluate_function(
     func,
     x,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def mp_context(request):
 def ins_parameters():
     """Add (and remove) the standard INS parameters for the tests."""
     # Before every test
-    add_extra_parameters_to_live_points(["logQ", "logW"])
+    add_extra_parameters_to_live_points(["logQ", "logW", "logU"])
     yield
     reset_extra_live_points_parameters()
 

--- a/tests/test_livepoint.py
+++ b/tests/test_livepoint.py
@@ -47,7 +47,7 @@ def non_sampling_parameters(request):
     return request.param
 
 
-@pytest.fixture(autouse=True, params=[[], ["logQ", "logW"]])
+@pytest.fixture(autouse=True, params=[[], ["logQ", "logW", "logU"]])
 def extra_parameters(request):
     """Add (and remove) extra parameters for the tests."""
     # Before every test

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ Tests for `nessai.model`
 import datetime
 import logging
 import numpy as np
+import numpy.lib.recfunctions as rfn
 import pytest
 from scipy.stats import norm
 from unittest.mock import MagicMock, call, create_autospec, patch
@@ -457,6 +458,17 @@ def test_from_unit_hypercube(model):
     """Assert an error is raised by default"""
     with pytest.raises(NotImplementedError):
         Model.from_unit_hypercube(model, 1)
+
+
+def test_log_prior_unit_hypercube(model):
+    model.names = ["x", "y"]
+    x = np.array(
+        [(0.5, 0.5), (-0.1, 0.5)], dtype=[(n, "f8") for n in model.names]
+    )
+    model.unstructured_view = rfn.structured_to_unstructured
+    out = Model.log_prior_unit_hypercube(model, x)
+    assert out[0] == 0
+    assert out[1] == -np.inf
 
 
 def test_missing_log_prior():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -257,6 +257,32 @@ def test_vectorised_prior_setter(model):
     assert model._vectorised_prior == "test"
 
 
+@pytest.mark.parametrize("check_value", [True, False])
+@pytest.mark.parametrize("allow_vectorised", [True, False])
+def test_vectorised_log_prior_unit_hypercube(
+    model, check_value, allow_vectorised
+):
+
+    model._vectorised_prior_unit_hypercube = None
+    model.allow_vectorised_prior = allow_vectorised
+
+    with patch(
+        "nessai.model.check_vectorised_function", return_value=check_value
+    ):
+        out = Model.vectorised_prior_unit_hypercube.__get__(model)
+
+    assert out is (check_value and allow_vectorised)
+    assert model._vectorised_prior_unit_hypercube is (
+        check_value and allow_vectorised
+    )
+
+
+def test_vectorised_prior_unit_setter(model):
+    """Assert the setter sets the correct value"""
+    Model.vectorised_prior_unit_hypercube.__set__(model, "test")
+    assert model._vectorised_prior_unit_hypercube == "test"
+
+
 def test_in_bounds(model):
     """Test the `in_bounds` method.
 

--- a/tests/test_proposal/test_importance/test_config.py
+++ b/tests/test_proposal/test_importance/test_config.py
@@ -42,6 +42,16 @@ def test_check_fields_logW():
     reset_extra_live_points_parameters()
 
 
+def test_check_fields_logU():
+    """Assert an error is raised if logW is missing"""
+    add_extra_parameters_to_live_points(["logQ", "logW"])
+    with pytest.raises(
+        RuntimeError, match=r"logU field missing in non-sampling parameters."
+    ):
+        IFP._check_fields()
+    reset_extra_live_points_parameters()
+
+
 def test_initialise(ifp):
     output = "test_init"
     flow_config = {"a": 1}

--- a/tests/test_proposal/test_importance/test_prob.py
+++ b/tests/test_proposal/test_importance/test_prob.py
@@ -30,6 +30,11 @@ def test_update_proposal_weights_vaild(ifp):
         IFP.update_proposal_weights(ifp, weights)
 
 
+def test_initial_log_prob(ifp):
+    x = np.random.randn(10, 2)
+    np.testing.assert_array_equal(IFP._log_prob_initial(ifp, x), np.zeros(10))
+
+
 def test_compute_log_Q(ifp, x_prime):
     n_flows = 3
     ifp.weights_array = np.array([0.25, 0.25, 0.25, 0.25])

--- a/tests/test_proposal/test_importance/test_prob.py
+++ b/tests/test_proposal/test_importance/test_prob.py
@@ -16,11 +16,6 @@ def ifp(ifp):
     return ifp
 
 
-def test_log_prior(ifp):
-    x = np.random.randn(10, 2)
-    np.testing.assert_array_equal(IFP._log_prior(ifp, x), np.zeros(10))
-
-
 def test_update_proposal_weights(ifp):
     ifp._weights = {-1: 0.5, 1: 0.5}
     weights = {-1: 1 / 3, 0: 1 / 3, 1: 1 / 3}

--- a/tests/test_proposal/test_importance/test_prob.py
+++ b/tests/test_proposal/test_importance/test_prob.py
@@ -35,6 +35,12 @@ def test_initial_log_prob(ifp):
     np.testing.assert_array_equal(IFP._log_prob_initial(ifp, x), np.zeros(10))
 
 
+def test_get_proposal_log_prob_initial(ifp):
+    ifp._log_prob_initial = object()
+    func = IFP.get_proposal_log_prob(ifp, -1)
+    assert func is ifp._log_prob_initial
+
+
 def test_compute_log_Q(ifp, x_prime):
     n_flows = 3
     ifp.weights_array = np.array([0.25, 0.25, 0.25, 0.25])

--- a/tests/test_proposal/test_importance/test_sampling.py
+++ b/tests/test_proposal/test_importance/test_sampling.py
@@ -12,14 +12,18 @@ import pytest
 
 @pytest.mark.parametrize("n", [1, 10])
 @pytest.mark.usefixtures("ins_parameters")
-def test_draw_from_prior(ifp, x, n):
+def test_draw_from_prior(ifp, n, model):
     """Test drawing from the prior"""
     n_proposals = 4
     x_prime = np.random.randn(n, 2)
+    x = numpy_array_to_live_points(np.random.rand(n, 2), names=model.names)
     log_j = np.random.rand(n)
     log_Q = np.random.randn(n)
     log_q = np.random.randn(n_proposals, n)
     ifp.model.sample_unit_hypercube = MagicMock(return_value=x)
+    ifp.model.batch_evaluate_log_prior_unit_hypercube = MagicMock(
+        return_value=np.zeros(n)
+    )
     ifp.rescale = MagicMock(return_value=(x_prime, log_j))
     ifp.compute_log_Q = MagicMock(return_value=(log_Q, log_q))
 

--- a/tests/test_samplers/test_importance_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_importance_nested_sampler/conftest.py
@@ -19,7 +19,7 @@ from scipy.special import logsumexp
 @pytest.fixture(scope="module", autouse=True)
 def ins_livepoint_params():
     reset_extra_live_points_parameters()
-    add_extra_parameters_to_live_points(["logW", "logQ"])
+    add_extra_parameters_to_live_points(["logW", "logQ", "logU"])
     # Test happens here
     yield
 

--- a/tests/test_samplers/test_importance_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_importance_nested_sampler/conftest.py
@@ -12,12 +12,6 @@ import numpy as np
 from scipy.special import logsumexp
 
 
-@pytest.fixture(scope="module", autouse=True)
-@pytest.mark.usefixtures("ins_parameters")
-def ins_parameters():
-    pass
-
-
 @pytest.fixture(scope="module", params=[False, True])
 def iid(request):
     return request.param
@@ -49,7 +43,7 @@ def n_samples():
 
 
 @pytest.fixture
-def samples(model, n_samples, n_it, log_q):
+def samples(model, n_samples, n_it, log_q, ins_parameters):
     x = model.sample_unit_hypercube(n_samples)
     x["it"] = np.random.randint(-1, n_it - 1, size=len(x))
     x["logL"] = model.log_likelihood(x)

--- a/tests/test_samplers/test_importance_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_importance_nested_sampler/conftest.py
@@ -7,24 +7,15 @@ from nessai.samplers.importancesampler import (
     ImportanceNestedSampler,
     OrderedSamples,
 )
-from nessai.livepoint import (
-    add_extra_parameters_to_live_points,
-    reset_extra_live_points_parameters,
-)
 from nessai.model import Model
 import numpy as np
 from scipy.special import logsumexp
 
 
 @pytest.fixture(scope="module", autouse=True)
-def ins_livepoint_params():
-    reset_extra_live_points_parameters()
-    add_extra_parameters_to_live_points(["logW", "logQ", "logU"])
-    # Test happens here
-    yield
-
-    # Called after every test
-    reset_extra_live_points_parameters()
+@pytest.mark.usefixtures("ins_parameters")
+def ins_parameters():
+    pass
 
 
 @pytest.fixture(scope="module", params=[False, True])

--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -21,6 +21,7 @@ def test_add_fields():
     INS.add_fields()
     assert "logW" in nessai_config.livepoints.non_sampling_parameters
     assert "logQ" in nessai_config.livepoints.non_sampling_parameters
+    assert "logU" in nessai_config.livepoints.non_sampling_parameters
 
 
 @pytest.mark.parametrize("it, expected", [(None, -1), (100, 100)])

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -51,6 +51,7 @@ def test_populate_live_points_no_iid(ins, model):
     ins.model = model
     ins.sample_counts = {}
     ins.draw_iid_live = False
+    ins.sample_counts = {}
 
     INS.populate_live_points(ins)
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -8,6 +8,7 @@ from nessai.samplers.importancesampler import (
     OrderedSamples,
 )
 import numpy as np
+import pytest
 
 
 def test_ordered_samples_property(ins):
@@ -45,6 +46,7 @@ def test_nested_samples_property(ins):
     )
 
 
+@pytest.mark.usefixtures("ins_parameters")
 def test_populate_live_points_no_iid(ins, model):
     n = 100
     ins.n_initial = n
@@ -61,6 +63,7 @@ def test_populate_live_points_no_iid(ins, model):
     ].shape == (n, 1)
 
 
+@pytest.mark.usefixtures("ins_parameters")
 def test_populate_live_points_iid(ins, model):
     n = 100
     ins.n_initial = n

--- a/tests/test_samplers/test_importance_nested_sampler/test_samples.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_samples.py
@@ -49,7 +49,6 @@ def test_populate_live_points_no_iid(ins, model):
     n = 100
     ins.n_initial = n
     ins.model = model
-    ins.sample_counts = {}
     ins.draw_iid_live = False
     ins.sample_counts = {}
 

--- a/tests/test_utils/test_multiprocessing_utils.py
+++ b/tests/test_utils/test_multiprocessing_utils.py
@@ -16,19 +16,28 @@ from nessai.utils.multiprocessing import (
     initialise_pool_variables,
     get_n_pool,
     log_likelihood_wrapper,
+    log_prior_wrapper,
+    log_prior_unit_hypercube_wrapper,
 )
 
 
 def test_pool_variables():
     """Assert initialising the variables and calling the likelihood work"""
     model = MagicMock()
-    model.log_likelihood = lambda x: x
+    model.log_likelihood = lambda x: x * 100
+    model.log_prior = lambda x: x * 10
+    model.log_prior_unit_hypercube = lambda x: x / 10
     initialise_pool_variables(model)
     pool = Pool(1)
-    out = pool.map(log_likelihood_wrapper, [1, 2, 3])
+    out_ll = pool.map(log_likelihood_wrapper, [1, 2, 3])
+    out_lp = pool.map(log_prior_wrapper, [1, 2, 3])
+    out_lpu = pool.map(log_prior_unit_hypercube_wrapper, [1, 2, 3])
     pool.close()
     pool.terminate()
-    assert out == [1, 2, 3]
+
+    assert out_ll == [100, 200, 300]
+    assert out_lp == [10, 20, 30]
+    assert out_lpu == [0.1, 0.2, 0.3]
 
     # Reset to the default value
     initialise_pool_variables(None)


### PR DESCRIPTION
Add support for non-uniform priors in the unit-hypercube.

I've opted to add a new method to the `Model` class since I think reusing the `log_prior` method could cause some issues with e.g. the bilby interface.

Requires https://github.com/mj-will/nessai/pull/376