### PR TITLE
Always set random seed

### DIFF
--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -173,13 +173,15 @@ class BaseNestedSampler(ABC):
         Parameters
         ----------
         seed : Optional[int]
-            The random seed. If not specified, no seed is set.
+            The random seed. If not specified, a random seed is generated.
         """
+        if seed is None:
+            logger.debug("Seed not specified, generating random seed")
+            seed = np.random.randint(0, 1e10)
+        logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
-        if self.seed is not None:
-            logger.debug(f"Setting random seed to {seed}")
-            np.random.seed(seed=self.seed)
-            torch.manual_seed(self.seed)
+        np.random.seed(seed=self.seed)
+        torch.manual_seed(self.seed)
 
     def configure_periodic_logging(self, logging_interval, log_on_iteration):
         """Configure the periodic logging.

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -177,7 +177,7 @@ class BaseNestedSampler(ABC):
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, np.iinfo(np.uint32).max)
+            seed = np.random.randint(0, np.iinfo(np.uintc).max)
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
         np.random.seed(seed=self.seed)

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -177,7 +177,7 @@ class BaseNestedSampler(ABC):
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, 1e10)
+            seed = np.random.randint(0, np.iinfo(np.uint32).max)
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
         np.random.seed(seed=self.seed)

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -177,7 +177,7 @@ class BaseNestedSampler(ABC):
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, np.iinfo(np.uintc).max - 1)
+            seed = np.random.randint(0, np.iinfo(int).max)
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
         np.random.seed(seed=self.seed)

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -177,7 +177,7 @@ class BaseNestedSampler(ABC):
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, np.iinfo(int).max)
+            seed = np.random.randint(0, min(np.iinfo(int).max, 2**32 - 1))
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
         np.random.seed(seed=self.seed)

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -177,7 +177,7 @@ class BaseNestedSampler(ABC):
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, np.iinfo(np.uintc).max)
+            seed = np.random.randint(0, np.iinfo(np.uintc).max - 1)
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
         np.random.seed(seed=self.seed)

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -149,6 +149,15 @@ def test_no_random_seed(mock_int, mock1, mock2, sampler):
     assert sampler.seed == 10
 
 
+@patch("numpy.random.seed")
+@patch("torch.manual_seed")
+def test_no_random_seed_numpy(mock1, mock2, sampler):
+    """Assert a random seed is set if seed=None"""
+    BaseNestedSampler.configure_random_seed(sampler, None)
+    mock1.assert_called_once()
+    mock2.assert_called_once()
+
+
 def test_configure_output(sampler, tmpdir):
     """Test setting up the output directories"""
     p = tmpdir.mkdir("outputs")

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -134,15 +134,19 @@ def test_set_random_seed(mock1, mock2, sampler):
     BaseNestedSampler.configure_random_seed(sampler, 150914)
     mock1.assert_called_once_with(150914)
     mock2.assert_called_once_with(seed=150914)
+    assert sampler.seed == 150914
 
 
 @patch("numpy.random.seed")
 @patch("torch.manual_seed")
-def test_no_random_seed(mock1, mock2, sampler):
-    """Assert no seed is set if seed=None"""
+@patch("numpy.random.randint", return_value=10)
+def test_no_random_seed(mock_int, mock1, mock2, sampler):
+    """Assert a random seed is set if seed=None"""
     BaseNestedSampler.configure_random_seed(sampler, None)
-    mock1.assert_not_called()
-    mock2.assert_not_called()
+    mock_int.assert_called_once()
+    mock1.assert_called_once_with(10)
+    mock2.assert_called_once_with(seed=10)
+    assert sampler.seed == 10
 
 
 def test_configure_output(sampler, tmpdir):


### PR DESCRIPTION
Set the seed to a random value if not specified.

This should make it possible to reproduce an analysis where the seed was not set.