### PR TITLE
CI: use mamba to manage environment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,21 +23,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Configure environment with Python ${{ matrix.python-version}}
+      if: runner.os != 'Windows'
+      uses: mamba-org/setup-micromamba@v1
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
+        micromamba-version: '1.5.8-0'
+        environment-file: ci_environment.yaml
+        create-args: >-
+          python=${{ matrix.python-version }}
+          lalsuite
+        init-shell: bash
+        cache-environment: true
+        post-cleanup: 'all'
+    - name: Configure environment with Python ${{ matrix.python-version}} (Windows)
+      if: runner.os == 'Windows'
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.5.8-0'
+        environment-file: ci_environment.yaml
+        create-args: >-
+          python=${{ matrix.python-version }}
+        init-shell: bash
+        cache-environment: true
+        post-cleanup: 'all'
+    - name: Install nessai
       run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
-        pip install .[dev,nflows]
-        pip install .[gw]
-    - name: Check dependencies
-      if: success() || failure()
-      run: |
-        python -m pip check
+        pip install . --no-deps
+      shell: bash -el {0}
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |
@@ -48,6 +60,8 @@ jobs:
     - name: Run (quick) integration tests
       run: |
         python -m pytest -v -m "integration_test"
+      shell: bash -el {0}
     - name: Run slow integration tests
       run: |
         python -m pytest -v -m "slow_integration_test"
+      shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: '1.5.8-0'
+        environment-name: nessai-ci
         environment-file: ci_environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
@@ -38,7 +39,7 @@ jobs:
     - name: Install LALSuite
       if: runner.os != 'Windows'
       run: |
-        micromamba install conda-forge::lalsuite
+        micromamba install conda-forge::lalsuite -n nessai-ci
     - name: Install nessai
       run: |
         pip install . --no-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,7 @@ jobs:
         create-args: >-
           python=${{ matrix.python-version }}
           lalsuite
-        init-shell: >-
-          bash
-          powershell
+        init-shell: bash
         cache-environment: true
         post-cleanup: 'all'
     - name: Configure environment with Python ${{ matrix.python-version}} (Windows)
@@ -45,9 +43,7 @@ jobs:
         environment-file: ci_environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
-        init-shell: >-
-          bash
-          powershell
+        init-shell: powershell
         cache-environment: true
         post-cleanup: 'all'
     - name: Install nessai

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,8 @@ jobs:
         init-shell: powershell
         cache-environment: true
         post-cleanup: 'all'
+    - name: Activate environment
+      run: micromamba activate nessai-ci
     - name: Install nessai
       run: |
         pip install . --no-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Configure mamba environment with Python ${{ matrix.python-version}}
+    - name: Configure environment with Python ${{ matrix.python-version}}
+      if: runner.os != 'Windows'
       uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: '1.5.8-0'
-        environment-name: nessai-ci
+        environment-file: ci_environment.yaml
+        create-args: >-
+          python=${{ matrix.python-version }}
+          lalsuite
+        init-shell: >-
+          bash
+          powershell
+        cache-environment: true
+        post-cleanup: 'all'
+    - name: Configure environment with Python ${{ matrix.python-version}} (Windows)
+      if: runner.os == 'Windows'
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.5.8-0'
         environment-file: ci_environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
@@ -36,10 +50,6 @@ jobs:
           powershell
         cache-environment: true
         post-cleanup: 'all'
-    - name: Install LALSuite
-      if: runner.os != 'Windows'
-      run: |
-        micromamba install conda-forge::lalsuite -n nessai-ci
     - name: Install nessai
       run: |
         pip install . --no-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,4 +66,3 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
-      shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,11 +46,10 @@ jobs:
         init-shell: powershell
         cache-environment: true
         post-cleanup: 'all'
-    - name: Activate environment
-      run: micromamba activate nessai-ci
     - name: Install nessai
       run: |
         pip install . --no-deps
+      shell: bash -el {0}
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |
@@ -61,8 +60,10 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest --cov-report=xml --without-integration --without-slow-integration
+      shell: bash -el {0}
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
+      shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,17 +23,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Configure mamba with Python ${{ matrix.python-version}}
+      uses: mamba-org/setup-micromamba@v1
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        micromamba-version: '1.5.8-0'
+        create-args: >-
+          python=${{ matrix.python-version }}
+        cache-environment: true
+        post-cleanup: 'all'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
-        pip install .[dev,nflows]
-        pip install .[gw]
+        conda env update -f base_environment.yaml
+    - name: Install nessai
+      run: |
+        pip install . --no-deps
     - name: Check dependencies
       if: success() || failure()
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,13 +35,13 @@ jobs:
           powershell
         cache-environment: true
         post-cleanup: 'all'
+    - name: Install LALSuite
+      if: runner.os != 'Windows'
+      run: |
+        mamba install conda-forge::lalsuite
     - name: Install nessai
       run: |
         pip install . --no-deps
-    - name: Check dependencies
-      if: success() || failure()
-      run: |
-        python -m pip check
     - name: Set MPL backend on Windows
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         environment-file: ci_environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
-        init-shell: powershell
+        init-shell: bash
         cache-environment: true
         post-cleanup: 'all'
     - name: Install nessai

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,12 @@ jobs:
       uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: '1.5.8-0'
-        environment-file: environment.yaml
+        environment-file: ci_environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
+        init-shell: >-
+          bash
+          powershell
         cache-environment: true
         post-cleanup: 'all'
     - name: Install nessai

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,18 +23,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Configure mamba with Python ${{ matrix.python-version}}
+    - name: Configure mamba environment with Python ${{ matrix.python-version}}
       uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: '1.5.8-0'
-        environment-name: base
+        environment-file: environment.yaml
         create-args: >-
           python=${{ matrix.python-version }}
         cache-environment: true
         post-cleanup: 'all'
-    - name: Install dependencies
-      run: |
-        conda env update -f base_environment.yaml
     - name: Install nessai
       run: |
         pip install . --no-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       uses: mamba-org/setup-micromamba@v1
       with:
         micromamba-version: '1.5.8-0'
+        environment-name: base
         create-args: >-
           python=${{ matrix.python-version }}
         cache-environment: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install LALSuite
       if: runner.os != 'Windows'
       run: |
-        mamba install conda-forge::lalsuite
+        micromamba install conda-forge::lalsuite
     - name: Install nessai
       run: |
         pip install . --no-deps

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -17,7 +17,6 @@ dependencies:
   - tqdm
   - corner
   - bilby
-  - lalsuite
   - astropy
   - pytest
   - pytest-cov

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -27,4 +27,4 @@ dependencies:
   - pip
   - pip:
     - nflows
-    - ray[default] ; sys_platform != 'win32' or (sys_platform == 'win32' and python_version < '3.11')
+    - ray[default] ; (sys_platform != 'win32' and python_version < '3.12' or (sys_platform == 'win32' and python_version < '3.12')

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -24,7 +24,7 @@ dependencies:
   - pytest-timeout
   - pytest-rerunfailures
   - pytest-integration
-  - ray-default # [py<312]
   - pip
   - pip:
     - nflows
+    - ray[default] ; sys_platform != 'win32' or (sys_platform == 'win32' and python_version < '3.11')

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-timeout
   - pytest-rerunfailures
   - pytest-integration
-  - ray-default
+  - ray-default # [py<312]
+  - pip
   - pip:
     - nflows

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -1,4 +1,4 @@
-name: nessai
+name: nessai-ci
 channels:
   - default
   - pytorch
@@ -24,5 +24,6 @@ dependencies:
   - pytest-timeout
   - pytest-rerunfailures
   - pytest-integration
+  - ray-default
   - pip:
     - nflows

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -26,4 +26,4 @@ dependencies:
   - pip
   - pip:
     - nflows
-    - ray[default] ; (sys_platform != 'win32' and python_version < '3.12' or (sys_platform == 'win32' and python_version < '3.12')
+    - ray[default] ; (sys_platform != 'win32' and python_version < '3.12') or (sys_platform == 'win32' and python_version < '3.12')

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,28 @@
+name: nessai
+channels:
+  - default
+  - pytorch
+  - conda-forge
+dependencies:
+  - numpy
+  - pandas
+  - scipy>=0.16
+  - matplotlib>=2.0
+  - seaborn
+  - tqdm
+  - pytorch>=1.11.0
+  - cpuonly
+  - glasflow
+  - h5py
+  - tqdm
+  - corner
+  - bilby
+  - lalsuite
+  - astropy
+  - pytest
+  - pytest-cov
+  - pytest-timeout
+  - pytest-rerunfailures
+  - pytest-integration
+  - pip:
+    - nflows


### PR DESCRIPTION
Move the CI to use mamba instead of pip

**Motivation**
The CI for https://github.com/mj-will/nessai/pull/380 is failing because of issues with a dependency that cannot be installed via pip on Mac and Windows.