### PR TITLE
ENH: Add log posterior weights

### DIFF
--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -582,6 +582,10 @@ class ImportanceNestedSampler(BaseNestedSampler):
         return self.model.from_unit_hypercube(self.samples_unit)
 
     @property
+    def log_posterior_weights(self) -> np.ndarray:
+        return self._ordered_samples.state.log_posterior_weights
+
+    @property
     def log_q(self) -> np.ndarray:
         return self._ordered_samples.log_q
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_posterior.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_posterior.py
@@ -6,7 +6,7 @@ from nessai.evidence import _INSIntegralState
 from unittest.mock import MagicMock
 
 
-def test_log_posterior_weights_propetry(ins):
+def test_log_posterior_weights_property(ins):
     ins._ordered_samples = MagicMock(spec=OrderedSamples)
     ins._ordered_samples.state = MagicMock(spec=_INSIntegralState)
     assert (

--- a/tests/test_samplers/test_importance_nested_sampler/test_posterior.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_posterior.py
@@ -1,0 +1,15 @@
+from nessai.samplers.importancesampler import (
+    ImportanceNestedSampler as INS,
+    OrderedSamples,
+)
+from nessai.evidence import _INSIntegralState
+from unittest.mock import MagicMock
+
+
+def test_log_posterior_weights_propetry(ins):
+    ins._ordered_samples = MagicMock(spec=OrderedSamples)
+    ins._ordered_samples.state = MagicMock(spec=_INSIntegralState)
+    assert (
+        INS.log_posterior_weights.__get__(ins)
+        is ins._ordered_samples.state.log_posterior_weights
+    )


### PR DESCRIPTION
Add `log_posterior_weights` to the INS sampler to make the bilby interface simpler.