### PR TITLE
Support numpy 2.0

### DIFF
--- a/nessai/evidence.py
+++ b/nessai/evidence.py
@@ -218,7 +218,7 @@ class _NSIntegralState(_BaseNSIntegralState):
         # Extra point represents X=0 and assume max(L) = L[-1]
         self.logZ = log_integrate_log_trap(
             np.array(self.logLs + [self.logLs[-1]]),
-            np.array(self.log_vols + [np.NINF]),
+            np.array(self.log_vols + [-np.inf]),
         )
         return self.logZ
 
@@ -255,7 +255,7 @@ class _NSIntegralState(_BaseNSIntegralState):
     def log_posterior_weights(self):
         """Compute the log-posterior weights."""
         log_L = np.array(self.logLs + [self.logLs[-1]])
-        log_vols = np.array(self.log_vols + [np.NINF])
+        log_vols = np.array(self.log_vols + [-np.inf])
         log_Z = log_integrate_log_trap(log_L, log_vols)
         log_w = logsubexp(log_vols[:-1], log_vols[1:])
         log_post_w = log_L[1:-1] + log_w[:-1] - log_Z

--- a/nessai/posterior.py
+++ b/nessai/posterior.py
@@ -56,12 +56,12 @@ def compute_weights(samples, nlive, expectation="logt"):
     n_vols = len(samples) + 2
     log_vols = np.zeros(n_vols)
     log_vols[1:-1] = np.cumsum(logt)
-    log_vols[-1] = np.NINF
+    log_vols[-1] = -np.inf
 
     # First point represents the entire prior
     # Last point represents X=0 and assume max(L) = L[-1]
     log_likelihoods = np.concatenate(
-        [np.array([np.NINF]), samples, np.array([samples[-1]])]
+        [np.array([-np.inf]), samples, np.array([samples[-1]])]
     )
 
     log_evidence = log_integrate_log_trap(log_likelihoods, log_vols)

--- a/tests/test_evidence/test_ins_evidence.py
+++ b/tests/test_evidence/test_ins_evidence.py
@@ -40,7 +40,7 @@ def nested_samples(model, ins_parameters):
 def test_init(state):
     """Test the init method"""
     INSState.__init__(state)
-    assert state._logZ == np.NINF
+    assert state._logZ == -np.inf
 
 
 def test_log_Z(state):

--- a/tests/test_evidence/test_standard_evidence.py
+++ b/tests/test_evidence/test_standard_evidence.py
@@ -205,7 +205,7 @@ def test_plot_w_filename(nlive, tmpdir):
 def test_log_posterior_weights(ns_state):
     """Test the log-posterior weights property"""
     log_vols = [0.0, -0.1, -0.2, -0.3]
-    logL = [np.NINF, -10.0, -5.0, -0.0]
+    logL = [-np.inf, -10.0, -5.0, -0.0]
     ns_state.log_vols = log_vols
     ns_state.logLs = logL
     log_z = -1.0
@@ -216,7 +216,7 @@ def test_log_posterior_weights(ns_state):
 
     trap_inputs = mock_int.call_args[0]
     np.testing.assert_array_equal(trap_inputs[0], logL + [-0.0])
-    np.testing.assert_array_equal(trap_inputs[1], log_vols + [np.NINF])
+    np.testing.assert_array_equal(trap_inputs[1], log_vols + [-np.inf])
     # Output should one shorted than logL since the initial point is not a
     # nested sample.
     assert len(out) == (len(logL) - 1)

--- a/tests/test_utils/test_stats_utils.py
+++ b/tests/test_utils/test_stats_utils.py
@@ -60,5 +60,5 @@ def test_weighted_quantile_value_error_neff():
         ValueError, match=r"Effective sample size is not finite.*"
     ):
         weighted_quantile(
-            [1, 2], 0.5, log_weights=np.array([np.NINF, np.NINF])
+            [1, 2], 0.5, log_weights=np.array([-np.inf, -np.inf])
         )


### PR DESCRIPTION
Update the code in preparation for numpy 2.0

These changes were made using

```
(nessai) mjwill@mjwill-xps-9320:~/git_repos/nessai$ ruff check nessai tests/ --select NPY201 --
nessai/evidence.py:221:39: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
nessai/evidence.py:258:46: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
nessai/posterior.py:59:20: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
nessai/posterior.py:64:20: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
tests/test_evidence/test_ins_evidence.py:43:27: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
tests/test_evidence/test_standard_evidence.py:208:13: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
tests/test_evidence/test_standard_evidence.py:219:63: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
tests/test_utils/test_stats_utils.py:63:48: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
tests/test_utils/test_stats_utils.py:63:57: NPY201 [*] `np.NINF` will be removed in NumPy 2.0. Use `-np.inf` instead.
Found 9 errors.
[*] 9 fixable with the `--fix` option.
(nessai) mjwill@mjwill-xps-9320:~/git_repos/nessai$ ruff check nessai tests/ --select NPY201 --fix
Found 9 errors (9 fixed, 0 remaining).

```