### PR TITLE
BUG: avoid populating live points when resuming a finished run

### DIFF
--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -768,7 +768,7 @@ class NestedSampler(BaseNestedSampler):
         else:
             self.proposal = self._flow_proposal
 
-        if live_points and self.live_points is None:
+        if live_points and self.live_points is None and not self.finalised:
             self.populate_live_points()
             flags[2] = True
 

--- a/tests/test_samplers/test_nested_sampler/test_core_sampling.py
+++ b/tests/test_samplers/test_nested_sampler/test_core_sampling.py
@@ -60,6 +60,7 @@ def test_initialise(sampler):
     sampler.tolerance = 0.1
     sampler.initialised = False
     sampler.uninformed_sampling = True
+    sampler.finalised = False
 
     NestedSampler.initialise(sampler)
 

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -518,10 +518,12 @@ def test_sampling_resume_finalised(integration_model, tmp_path):
     fs = FlowSampler(
         integration_model,
         output=output,
-        nlive=100,
+        nlive=10,
         plot=False,
+        stopping=10,
     )
     fs.run(save=False, plot=False)
+    assert fs.ns.live_points is None
     assert os.path.exists(fs.ns.resume_file)
 
     fs = FlowSampler(
@@ -529,9 +531,11 @@ def test_sampling_resume_finalised(integration_model, tmp_path):
         output=output,
         nlive=100,
         plot=False,
+        stopping=10,
     )
 
     fs.run(save=False, plot=False)
+    assert fs.ns.live_points is None
 
 
 @pytest.mark.slow_integration_test


### PR DESCRIPTION
Fix a bug that caused the live points to be redrawn when resuming a finished run.