### PR TITLE
Simplify reparameterisations and update defaults

### DIFF
--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -1,6 +1,6 @@
-###################
+===================
 Reparameterisations
-###################
+===================
 
 In ``nessai`` three spaces are defined:
 
@@ -10,11 +10,18 @@ In ``nessai`` three spaces are defined:
 
 The key to efficient sampling with ``nessai`` is to reparameterise the sampling space such that the prime space is simpler for normalising flow to learn.
 
+The reparameterisations are controlled via three keyword arguments:
+
+- :code:`reparameterisations: dict|str|None`: either a dictionary specifying various reparameterisations, a string specifying a single reparameterisation for all parameters or `None` to use the defaults/fallback. See
+- :code:`fallback_reparameterisations: None|str`: reparameterisation use if a reparameterisation has not been specified for a parameter. If `None`, no reparameterisation is used.
+- :code:`use_default_reparameterisations: bool|None`: if :code:`True` any default reparameterisations included in the proposal class, e.g. those in :code:`GWFlowProposal` will be used for any parameters not specified in :code:`reparameterisations`. If :code:`False`, these defaults will be ignored. If :code:`None`, the behaviour will depende on the proposal class.
+- :code:`reverse_reparameterisations: bool`: if :code:`True`, the order of the reparmeterisations will be reversed.
+
 There are two main methods for configuring reparameterisations in ``nessai``. The first is simpler but more limited and the second is more complex but allows for greater control of the specific reparameterisations used.
 
-************************************
-Method 1: general reparameterisation
-************************************
+
+Configuring reparameterisations
+===============================
 
 This method is limited to the following types of reparameterisation:
 

--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -12,51 +12,27 @@ The key to efficient sampling with ``nessai`` is to reparameterise the sampling 
 
 The reparameterisations are controlled via three keyword arguments:
 
-- :code:`reparameterisations: dict|str|None`: either a dictionary specifying various reparameterisations, a string specifying a single reparameterisation for all parameters or `None` to use the defaults/fallback. See
+- :code:`reparameterisations: dict|str|None`: either a dictionary specifying various reparameterisations, a string specifying a single reparameterisation for all parameters or `None` to use the defaults/fallback. See :ref:`configuring reparameterisations<Configuring reparameterisations>` for more details.
 - :code:`fallback_reparameterisations: None|str`: reparameterisation use if a reparameterisation has not been specified for a parameter. If `None`, no reparameterisation is used.
 - :code:`use_default_reparameterisations: bool|None`: if :code:`True` any default reparameterisations included in the proposal class, e.g. those in :code:`GWFlowProposal` will be used for any parameters not specified in :code:`reparameterisations`. If :code:`False`, these defaults will be ignored. If :code:`None`, the behaviour will depende on the proposal class.
 - :code:`reverse_reparameterisations: bool`: if :code:`True`, the order of the reparmeterisations will be reversed.
-
-There are two main methods for configuring reparameterisations in ``nessai``. The first is simpler but more limited and the second is more complex but allows for greater control of the specific reparameterisations used.
 
 
 Configuring reparameterisations
 ===============================
 
-This method is limited to the following types of reparameterisation:
-
-- rescaling to a fixed range,
-- applying inversion along a bound.
-
-These can be applied on parameter by parameter basis using keyword arguments. The relevant arguments:
-
-- :code:`rescale_parameters`: This is either a :code:`bool` or :code:`list` of parameters. If :code:`True`, then all of the parameters in the model are rescaled. If a list is provided only those parameters are rescaled. It's generally recommend to rescale parameters to a common range to improve the efficiency of training. The inputs are rescaled to the range defined by :code:`rescale_bounds`.
-- :code:`rescale_bounds`: A :code:`list` of length two containing the upper and lower bounds of the range for rescaling, the default value is [-1, 1].
-- :code:`update_bounds`: A boolean, if :code:`True` the minimum and maximum values of parameters are update each time the normalising flow is trained. If :code:`False` the parameters are always rescaled using the initial prior bounds. It's recommended to enable this option.
-- :code:`boundary_inversion`: This is either a :code:`bool` or :code:`list` and determines if boundary inversion is applied to any of the parameters. If :code:`True` it is applied to all parameters and if a list is specified it is only applied to those parameters. This forces the samples for the parameters and one of the bounds to be mirrored along that bound. The bounds is chosen based on the density of samples. It's not recommended to enable this setting unless there are parameters for which the posterior distributions will consistently rail against the prior bounds. NOTE: this forces :code:`update_bounds=True`.
-- :code:`detect_edges`: This setting is only relevant when using :code:`boundary_inversion` and it allows the sampler to detect hard bounds in the samples (or lack thereof)
-
-
-**************************************
-Method 2: specific reparameterisations
-**************************************
-
-This methods allows for use of the all the reparameterisations included in ``nessai``. However it requires parameters to be configured individually. All the reparameterisations are configure using the keyword argument `reparameterisations` which is an instance of :code:`dict`.
-
-When using this method reparameterisations are added to the proposal method based on the dictionary. Each entry in the reparameterisations dictionary is interpreted and add to the combined reparameterisation that is applied to all parameters.
-These the following key-value pairs are understood:
+The :code:`reparameterisations` keyword allows for fine-grained configuration of the reparameterisations using a dictionary.
+Each entry in the reparameterisations dictionary is interpreted and add to the combined reparameterisation that is applied to all parameters.
+The following key-value pairs are understood:
 
 - **Parameter & Reparameterisation**: the key is the parameter to which the reparameterisation is applied and the reparameterisation to apply. For example :code:`reparameterisations={'x': 'default'}`, this tells the sampler to use the default reparameterisation for x, which rescales to [-1, 1].
 
 - **Parameter & Kwargs**: the key is the same as in the previous case but instead of the name of the reparameterisation, a dictionary with the configuration is specified. For example: :code:`reparamterisations={'x': {'reparameterisation': 'default', 'rescale_bounds': [0, 1]}}`, this tells the sampler to use the default reparameterisation but with a specific keyword argument :code:`rescale_bounds`. The resulting reparameterisation will rescale to [0, 1] instead of [-1, 1].
 
-- **Reparameterisation & Kwargs**: here the key is the name of reparameterisation and the kwargs are the used to configure the reparameterisation. This dictionary MUST contain the name of the parameter(s) to which the reparameterisation is applied. For example: :code:`reparameterisation={'default': {'parameters': ['x'], 'rescale_bounds':[0, 1]}`. This applied the default reparameterisation to x but with rescaling to [0, 1]. This method also supports specifying multiple parameters for reparameterisations that support it, for example: :code:`reparameterisation={'default': 'parameters': ['x', 'y']}`. This is necessary for reparameterisations that are applied to groups of parameters, such as the pairs of angles.
+- **Reparameterisation & Kwargs**: here the key is the name of reparameterisation and the kwargs are the used to configure the reparameterisation. This dictionary MUST contain the name of the parameter(s) to which the reparameterisation is applied. For example: :code:`reparameterisation={'default': {'parameters': ['x'], 'rescale_bounds':[0, 1]}`. This applied the default reparameterisation to x but with rescaling to [0, 1]. This method also supports specifying multiple parameters for reparameterisations that support it, for example: :code:`reparameterisation={'default': 'parameters': ['x', 'y']}`. This is necessary for reparameterisations that are applied to groups of parameters, such as the pairs of angles. This methods also supports regex for configuring multiple parameters.
 
 
 See the `examples directory <https://github.com/mj-will/nessai/tree/master/examples>`_ for an example of using this method of defining the reparmeterisations.
-
-.. note::
-    Missing section on use of x prime prior
 
 
 Available reparameterisations

--- a/examples/half_gaussian.py
+++ b/examples/half_gaussian.py
@@ -43,7 +43,7 @@ fs = FlowSampler(
     output=output,
     resume=False,
     seed=1234,
-    boundary_inversion=["y"],
+    reparameterisations={"y": "inversion"},
 )
 
 # And go!

--- a/nessai/experimental/proposal/clustering.py
+++ b/nessai/experimental/proposal/clustering.py
@@ -51,7 +51,7 @@ class ClusteringFlowProposal(FlowProposal):
         )
         prime_array = live_points_to_array(
             self.training_data_prime,
-            self.rescaled_names,
+            self.prime_parameters,
         )
         cluster_labels = self.flow.get_cluster_labels(prime_array)
 
@@ -82,7 +82,7 @@ class ClusteringFlowProposal(FlowProposal):
 
         x_prime_gen, log_prob = self.backward_pass(z_gen, rescale=False)
         gen_cluster_labels = self.flow.get_cluster_labels(
-            live_points_to_array(x_prime_gen, self.rescaled_names)
+            live_points_to_array(x_prime_gen, self.prime_parameters)
         )
         x_prime_gen["logL"] = log_prob
         x_gen, log_J = self.inverse_rescale(x_prime_gen)
@@ -120,7 +120,7 @@ class ClusteringFlowProposal(FlowProposal):
             plot_1d_comparison(
                 self.training_data_prime,
                 x_prime_gen,
-                parameters=self.rescaled_names,
+                parameters=self.prime_parameters,
                 labels=["live points", "generated"],
                 filename=os.path.join(output, "x_prime_comparison.png"),
             )

--- a/nessai/proposal/augmented.py
+++ b/nessai/proposal/augmented.py
@@ -65,11 +65,10 @@ class AugmentedFlowProposal(FlowProposal):
         # set rescaling.
         self._base_rescale = self.rescale
         self.rescale = self._augmented_rescale
-        self.augment_names = [f"e_{i}" for i in range(self.augment_dims)]
-        self.parameters += self.augment_names
-        self.prime_parameters += self.augment_names
+        self.augment_parameters = [f"e_{i}" for i in range(self.augment_dims)]
+        self.parameters += self.augment_parameters
+        self.prime_parameters += self.augment_parameters
         logger.info(f"augmented x space parameters: {self.parameters}")
-        logger.info(f"parameters to rescale {self.rescale_parameters}")
         logger.info(
             f"Augmented x prime space parameters: {self.prime_parameters}"
         )
@@ -113,10 +112,10 @@ class AugmentedFlowProposal(FlowProposal):
                 generate_augment = "gaussian"
 
         if generate_augment in ["zeros", "zeroes"]:
-            for an in self.augment_names:
+            for an in self.augment_parameters:
                 x_prime[an] = np.zeros(x_prime.size)
         elif generate_augment == "gaussian":
-            for an in self.augment_names:
+            for an in self.augment_parameters:
                 x_prime[an] = np.random.randn(x_prime.size)
         else:
             raise RuntimeError("Unknown method for generating augment samples")
@@ -131,7 +130,7 @@ class AugmentedFlowProposal(FlowProposal):
         """
         log_p = 0.0
         if not self.marginalise_augment:
-            for n in self.augment_names:
+            for n in self.augment_parameters:
                 log_p += stats.norm.logpdf(x[n])
         return log_p
 

--- a/nessai/proposal/augmented.py
+++ b/nessai/proposal/augmented.py
@@ -66,12 +66,12 @@ class AugmentedFlowProposal(FlowProposal):
         self._base_rescale = self.rescale
         self.rescale = self._augmented_rescale
         self.augment_names = [f"e_{i}" for i in range(self.augment_dims)]
-        self.names += self.augment_names
-        self.rescaled_names += self.augment_names
-        logger.info(f"augmented x space parameters: {self.names}")
+        self.parameters += self.augment_names
+        self.prime_parameters += self.augment_names
+        logger.info(f"augmented x space parameters: {self.parameters}")
         logger.info(f"parameters to rescale {self.rescale_parameters}")
         logger.info(
-            f"Augmented x prime space parameters: {self.rescaled_names}"
+            f"Augmented x prime space parameters: {self.prime_parameters}"
         )
 
     def update_flow_config(self):
@@ -202,7 +202,7 @@ class AugmentedFlowProposal(FlowProposal):
         x, log_prob = x[valid], log_prob[valid]
         x = numpy_array_to_live_points(
             x.astype(config.livepoints.default_float_dtype),
-            self.rescaled_names,
+            self.prime_parameters,
         )
         # Apply rescaling in rescale=True
         if rescale:

--- a/nessai/reparameterisations/base.py
+++ b/nessai/reparameterisations/base.py
@@ -139,3 +139,10 @@ class Reparameterisation:
         Does nothing by default.
         """
         pass
+
+    def reset(self):
+        """Reset the reparameterisation.
+
+        Does nothing by default.
+        """
+        pass

--- a/nessai/reparameterisations/combined.py
+++ b/nessai/reparameterisations/combined.py
@@ -185,6 +185,11 @@ class CombinedReparameterisation(dict):
         for r in self.values():
             r.update(x)
 
+    def reset(self):
+        """Reset the reparameterisations"""
+        for r in self.values():
+            r.reset()
+
     def log_prior(self, x):
         """
         Compute any additional priors for auxiliary parameters

--- a/nessai/reparameterisations/rescale.py
+++ b/nessai/reparameterisations/rescale.py
@@ -31,7 +31,8 @@ class ScaleAndShift(Reparameterisation):
         x' = (x - shift) / scale
 
     Can apply the Z-score rescaling if :code:`estimate_scale` and
-    :code:`estimate_shift` are both enabled.
+    :code:`estimate_shift` are both enabled. The values are initialised to
+    one and zero respectively.
 
     Parameters
     ----------
@@ -76,12 +77,12 @@ class ScaleAndShift(Reparameterisation):
             self._update = False
 
         if self.estimate_scale:
-            self.scale = {p: None for p in parameters}
+            self.scale = {p: 1.0 for p in parameters}
         elif scale:
             self.scale = self._check_value(scale, "scale")
 
         if self.estimate_shift:
-            self.shift = {p: None for p in parameters}
+            self.shift = {p: 0.0 for p in parameters}
         elif shift:
             self.shift = self._check_value(shift, "shift")
         else:

--- a/nessai/reparameterisations/rescale.py
+++ b/nessai/reparameterisations/rescale.py
@@ -160,6 +160,14 @@ class ScaleAndShift(Reparameterisation):
                 if self.estimate_shift:
                     self.shift[p] = np.mean(x[p])
 
+    def reset(self):
+        """Reset the scale and shift parameters"""
+        for p in self.parameters:
+            if self.estimate_scale:
+                self.scale[p] = 1.0
+            if self.estimate_shift:
+                self.shift[p] = 0.0
+
 
 class Rescale(ScaleAndShift):
     """Reparameterisation that rescales the parameters by a constant factor
@@ -647,6 +655,14 @@ class RescaleToBounds(Reparameterisation):
         """
         self.update_bounds(x)
         self.reset_inversion()
+
+    def reset(self):
+        """Reset the reparameterisation.
+
+        Resets the inversion and the bounds.
+        """
+        self.reset_inversion()
+        self.set_bounds(self.prior_bounds)
 
     def x_prime_log_prior(self, x_prime):
         """Compute the prior in the prime space assuming a uniform prior"""

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -3,6 +3,7 @@
 Tests for modules/functions that are soon to be deprecated.
 """
 import pytest
+from unittest.mock import create_autospec
 
 
 def test_nested_sampler_deprecation():
@@ -27,3 +28,21 @@ def test_bilbyutils_warning():
         FutureWarning, match=r"`nessai.utils.bilbyutils` is deprecated"
     ):
         from nessai.utils.bilbyutils import get_all_kwargs  # noqa
+
+
+def test_flowproposal_names_warning():
+    from nessai.proposal import FlowProposal
+
+    proposal = create_autospec(FlowProposal)
+    proposal.parameters = ["x"]
+    with pytest.warns(FutureWarning, match=r"`names` is deprecated"):
+        assert FlowProposal.names.__get__(proposal) == ["x"]
+
+
+def test_flowproposal_rescaled_names_warning():
+    from nessai.proposal import FlowProposal
+
+    proposal = create_autospec(FlowProposal)
+    proposal.prime_parameters = ["x"]
+    with pytest.warns(FutureWarning, match=r"`rescaled_names` is deprecated"):
+        assert FlowProposal.rescaled_names.__get__(proposal) == ["x"]

--- a/tests/test_gw/test_reparameterisation_integration.py
+++ b/tests/test_gw/test_reparameterisation_integration.py
@@ -50,8 +50,8 @@ def test_invertibility(
     x_prime, _ = proposal.rescale(x)
     x_out, _ = proposal.inverse_rescale(x_prime)
 
-    flags = {n: False for n in proposal.names}
-    for name in proposal.names:
+    flags = {n: False for n in proposal.parameters}
+    for name in proposal.parameters:
         flags[name] = np.unique(x_out[name].round(decimals=10)).size == n
     if not all(flags.values()):
         msg = f"""Number of unique samples has changed.

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_add_reparam.py
@@ -83,7 +83,9 @@ def test_configure_reparameterisation_angle_pair(tmpdir, model):
 
 @pytest.mark.integration_test
 def test_default_reparameterisations(caplog, tmpdir):
-    """Assert that by default the reparameterisation is RescaleToBounds"""
+    """Assert that by default the reparameterisation is z-score"""
+    from nessai.reparameterisations import ScaleAndShift
+
     caplog.set_level("INFO")
     model = MagicMock()
     model.names = ["x1", "x10", "x11"]
@@ -98,4 +100,7 @@ def test_default_reparameterisations(caplog, tmpdir):
     reparams = list(proposal._reparameterisation.values())
     assert len(reparams) == 1
     assert reparams[0].parameters == ["x1", "x10", "x11"]
-    assert proposal.rescale_parameters == ["x1", "x10", "x11"]
+    assert proposal.prime_parameters == ["x1_prime", "x10_prime", "x11_prime"]
+    assert isinstance(reparams[0], ScaleAndShift)
+    assert reparams[0].estimate_scale is True
+    assert reparams[0].estimate_shift is True

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_flow.py
@@ -35,7 +35,7 @@ def test_train_plot_false(mock_os_makedirs, proposal, model):
     """Test the train method"""
     x = model.new_point(2)
     x_prime = model.new_point(2)
-    proposal.rescaled_names = model.names
+    proposal.prime_parameters = model.names
     proposal.save_training_data = False
     proposal.training_count = 0
     proposal.populated = True
@@ -60,7 +60,7 @@ def test_forward_pass(proposal, model, n):
     z = np.random.randn(n, model.dims)
     proposal.clip = False
     proposal.rescale = MagicMock(return_value=[x, 2 * np.ones(n)])
-    proposal.rescaled_names = model.names
+    proposal.prime_parameters = model.names
     proposal.flow = MagicMock()
     proposal.flow.forward_and_log_prob = MagicMock(
         return_value=[z, np.ones(n)]
@@ -88,7 +88,7 @@ def test_backward_pass(proposal, model, log_p, discard_nans):
     proposal.inverse_rescale = MagicMock(
         side_effect=lambda a: (a, np.ones(a.size))
     )
-    proposal.rescaled_names = model.names
+    proposal.prime_parameters = model.names
     proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
@@ -112,9 +112,10 @@ def test_backward_pass(proposal, model, log_p, discard_nans):
 @pytest.mark.parametrize("save", [True, False])
 @pytest.mark.parametrize("plot", [True, False])
 @pytest.mark.parametrize("plot_training", [True, False])
-def test_training(proposal, tmpdir, save, plot, plot_training):
+def test_training(proposal, tmp_path, save, plot, plot_training):
     """Test the training method"""
-    output = tmpdir.mkdir("test")
+    output = tmp_path / "test"
+    output.mkdir()
     data = np.random.randn(10, 2)
     data_prime = data / 2
     x = numpy_array_to_live_points(data, ["x", "y"])
@@ -126,7 +127,7 @@ def test_training(proposal, tmpdir, save, plot, plot_training):
     proposal.populated = True
     proposal._plot_training = plot_training
     proposal.save_training_data = save
-    proposal.rescaled_names = ["x_prime", "y_prime"]
+    proposal.prime_parameters = ["x_prime", "y_prime"]
     proposal.output = output
 
     proposal.check_state = MagicMock()

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -204,7 +204,7 @@ def test_resume_pickle(model, tmpdir, reparameterisation, init, latent_prior):
 
     if init:
         assert proposal.fuzz == proposal_re.fuzz
-        assert proposal.rescaled_names == proposal_re.rescaled_names
+        assert proposal.prime_parameters == proposal_re.rescaled_names
 
 
 def test_reset(proposal):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_plots.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_plots.py
@@ -11,10 +11,11 @@ from nessai.livepoint import numpy_array_to_live_points
 
 
 @pytest.mark.parametrize("plot", [False, "all"])
-def test_training_plots(proposal, tmpdir, plot):
-    """Make sure traings plots are correctly produced"""
+def test_training_plots(proposal, tmp_path, plot):
+    """Make sure trainings plots are correctly produced"""
     proposal._plot_training = plot
-    output = tmpdir.mkdir("test")
+    output = tmp_path / "test"
+    output.mkdir()
 
     names = ["x", "y"]
     prime_names = ["x_prime", "y_prime"]
@@ -38,9 +39,7 @@ def test_training_plots(proposal, tmpdir, plot):
         array["logL"] = 0.0
 
     proposal.dims = 2
-    proposal.rescale_parameters = True
-    proposal.parameters_to_rescale = names
-    proposal.rescaled_names = prime_names
+    proposal.prime_parameters = prime_names
 
     proposal.forward_pass = MagicMock(return_value=(z, None))
     proposal.backward_pass = MagicMock(return_value=(x_prime_gen, np.ones(10)))

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_properties.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_properties.py
@@ -22,19 +22,19 @@ def test_poolsize(proposal):
 
 def test_dims(proposal):
     """Test dims property"""
-    proposal.names = ["x", "y"]
+    proposal.parameters = ["x", "y"]
     assert FlowProposal.dims.__get__(proposal) == 2
 
 
 def test_rescaled_dims(proposal):
     """Test rescaled_dims property"""
-    proposal.rescaled_names = ["x", "y"]
+    proposal.prime_parameters = ["x", "y"]
     assert FlowProposal.rescaled_dims.__get__(proposal) == 2
 
 
 def test_dtype(proposal):
     """Test dims property"""
-    proposal.names = ["x", "y"]
+    proposal.parameters = ["x", "y"]
     proposal._x_dtype = None
     assert (
         FlowProposal.x_dtype.__get__(proposal)
@@ -44,7 +44,7 @@ def test_dtype(proposal):
 
 def test_prime_dtype(proposal):
     """Test dims property"""
-    proposal.rescaled_names = ["x", "y"]
+    proposal.prime_parameters = ["x", "y"]
     proposal._x_prime_dtype = None
     assert (
         FlowProposal.x_prime_dtype.__get__(proposal)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -214,7 +214,7 @@ def test_configure_reparameterisations_dict_missing(mocked_class, proposal):
     assert "No reparameterisation found for x" in str(excinfo.value)
 
 
-def test_configure_reparameterisations_str(proposal):
+def test_configure_reparameterisations_dict_str(proposal):
     """Test configuration for reparameterisations dictionary from a str"""
     proposal.add_default_reparameterisations = MagicMock()
     proposal.get_reparameterisation = get_reparameterisation
@@ -294,6 +294,30 @@ def test_configure_reparameterisations_none(proposal):
     assert all(
         [
             isinstance(r, NullReparameterisation)
+            for r in proposal._reparameterisation.reparameterisations.values()
+        ]
+    )
+
+
+def test_configure_reparameterisations_string(proposal):
+    """Test configuration when input is a string"""
+    proposal.add_default_reparameterisations = MagicMock()
+    proposal.get_reparameterisation = get_reparameterisation
+    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
+    proposal.model.names = ["x", "y"]
+    proposal.fallback_reparameterisation = None
+    FlowProposal.configure_reparameterisations(proposal, "rescaletobounds")
+    proposal.add_default_reparameterisations.assert_not_called()
+    assert proposal.prime_parameters == ["x_prime", "y_prime"]
+
+    assert proposal._reparameterisation.parameters == ["x", "y"]
+    assert proposal._reparameterisation.prime_parameters == [
+        "x_prime",
+        "y_prime",
+    ]
+    assert all(
+        [
+            isinstance(r, RescaleToBounds)
             for r in proposal._reparameterisation.reparameterisations.values()
         ]
     )

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -2,6 +2,7 @@
 """
 Test the base reparameterisation.
 """
+import copy
 import numpy as np
 from numpy.testing import assert_equal
 import pytest
@@ -117,3 +118,9 @@ def test_update(reparam):
     """
     x = np.array((1, 2), dtype=[("x", "f8"), ("y", "f8")])
     Reparameterisation.update(reparam, x)
+
+
+def test_reset(reparam):
+    expected = copy.deepcopy(reparam)
+    Reparameterisation.reset(reparam)
+    assert expected == reparam

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -225,6 +225,14 @@ def test_update(reparam):
     reparam.update_bounds.assert_called_once_with(x)
 
 
+def test_reset(reparam):
+    prior_bounds = {"x": [0, 1]}
+    reparam.prior_bounds = prior_bounds
+    RescaleToBounds.reset(reparam)
+    reparam.reset_inversion.assert_called_once()
+    reparam.set_bounds.assert_called_once_with(prior_bounds)
+
+
 def test_x_prime_log_prior_error(reparam):
     """Assert an error is raised if the prime prior is not defined."""
     reparam.has_prime_prior = False

--- a/tests/test_reparameterisations/test_scale_and_shift.py
+++ b/tests/test_reparameterisations/test_scale_and_shift.py
@@ -77,8 +77,8 @@ def test_init_estimate(reparam, parameters, prior_bounds):
     assert reparam.estimate_shift is True
     assert list(reparam.scale) == parameters
     assert list(reparam.shift) == parameters
-    assert all([v is None for v in reparam.scale.values()])
-    assert all([v is None for v in reparam.shift.values()])
+    assert all([v == 1 for v in reparam.scale.values()])
+    assert all([v == 0 for v in reparam.shift.values()])
     assert reparam._update is True
 
 

--- a/tests/test_reparameterisations/test_scale_and_shift.py
+++ b/tests/test_reparameterisations/test_scale_and_shift.py
@@ -258,6 +258,25 @@ def test_update_both(reparam, parameters, est_scale, est_shift):
         assert all([v is None for v in reparam.shift.values()])
 
 
+@pytest.mark.parametrize("est_scale", [False, True])
+@pytest.mark.parametrize("est_shift", [False, True])
+def test_reset(reparam, parameters, est_scale, est_shift):
+    reparam.parameters = parameters
+    reparam.scale = {p: None for p in parameters}
+    reparam.shift = {p: None for p in parameters}
+    reparam.estimate_scale = est_scale
+    reparam.estimate_shift = est_shift
+    ScaleAndShift.reset(reparam)
+    if est_scale:
+        assert all(s == 1.0 for s in reparam.scale.values())
+    else:
+        assert all(s is None for s in reparam.scale.values())
+    if est_shift:
+        assert all(s == 0.0 for s in reparam.shift.values())
+    else:
+        assert all(s is None for s in reparam.shift.values())
+
+
 def test_init_no_scale():
     """Make sure an error is raised if the scale is not given"""
     with pytest.raises(


### PR DESCRIPTION
I decided to remove the old reparameterisation options in favour of just using the more complete method. This removes a few arguments and should make maintaining the code easier.

I also changed the default reparameterisation to `zscore` to support models without prior bounds out-of-the-box.

Whilst doing this, I added a `reset` method to the reparameterisations classes.