### PR TITLE
BLD: drop python 3.8

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - numpy
   - pandas
-  - scipy>=0.16
+  - scipy>=0.16, <1.14    # tmp fix for a bilby issue
   - matplotlib>=2.0
   - seaborn
   - tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Nessai: Nested Sampling with Artificial Intelligence"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Drop support for Python 3.8.

[Numpy dropped support over a year ago](https://numpy.org/neps/nep-0029-deprecation_policy.html) and its [end-of-life](https://endoflife.date/python) is only a couple of months away.

This will also make the CI quicker to run.