### PR TITLE
MAINT: change defualt seaborn style

### DIFF
--- a/nessai/config.py
+++ b/nessai/config.py
@@ -123,7 +123,7 @@ class PlottingConfig(_BaseConfig):
     Useful since all plotting functions use the
     :py:func:`~nessai.plot.nessai_style` decorator by default.
     """
-    sns_style: str = "ticks"
+    sns_style: str = None
     """Default seaborn style."""
     base_colour: str = "#02979d"
     """Base colour for plots."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -53,7 +53,7 @@ def test_nessai_style_enabled(line_styles):
     ) as mock_style, patch("matplotlib.rc_context") as mock_rc:
         out = plot.nessai_style(line_styles=line_styles)(func)(1, 2)
     assert out == 3
-    mock_style.assert_called_with("ticks")
+    mock_style.assert_called_with(None)
     mock_rc.assert_called_once()
     d = mock_rc.call_args[0][0]["axes.prop_cycle"].by_key()
     if line_styles:


### PR DESCRIPTION
Change the default seaborn style to `None`. This should address the plotting issue on CIT that results in this warning:

```
/cvmfs/software.igwn.org/conda/envs/igwn-testing/lib/python3.10/site-packages/nessai/samplers/nestedsampler.py:1075: UserWarning: Glyph 8722 (\N{MINUS SIGN}) missing from current font.

```

The previous style can still be used by setting `sns_style = "ticks"`