### PR TITLE
Improve resuming when run is finished

### DIFF
--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -732,7 +732,7 @@ class FlowProposal(RejectionProposal):
     def rescaled_names(self):
         warn(
             (
-                "`rescaled_names` is deprecated, use `rescaled_parameters` "
+                "`rescaled_names` is deprecated, use `prime_parameters` "
                 "instead"
             ),
             FutureWarning,

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -1254,6 +1254,9 @@ class NestedSampler(BaseNestedSampler):
         nested_samples : numpy.ndarray
             Array of nested samples.
         """
+        if self.finalised:
+            logger.info("Running has already finished!")
+            return self.state.logZ, np.array(self.nested_samples)
         self.sampling_start_time = datetime.datetime.now()
         if not self.initialised:
             self.initialise(live_points=True)

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -1255,8 +1255,8 @@ class NestedSampler(BaseNestedSampler):
             Array of nested samples.
         """
         if self.finalised:
-            logger.info("Running has already finished!")
-            return self.state.logZ, np.array(self.nested_samples)
+            logger.info("Run has already finished!")
+            return self.log_evidence, np.array(self.nested_samples)
         self.sampling_start_time = datetime.datetime.now()
         if not self.initialised:
             self.initialise(live_points=True)

--- a/tests/test_samplers/test_nested_sampler/test_core_sampling.py
+++ b/tests/test_samplers/test_nested_sampler/test_core_sampling.py
@@ -289,3 +289,15 @@ def test_nested_sampling_loop_prior_sampling(sampler, close_pool):
     sampler.finalise.assert_called_once()
     assert_structured_arrays_equal(samples, sampler.nested_samples)
     assert evidence == -5.99
+
+
+def test_nested_sampling_loop_already_finished(sampler, caplog):
+    caplog.set_level("INFO")
+    sampler.finalised = True
+    sampler.log_evidence = 0.1
+    sampler.nested_samples = [1, 2, 3]
+    logz, ns = NestedSampler.nested_sampling_loop(sampler)
+    assert "Run has already finished!" in str(caplog.text)
+    sampler.check_resume.assert_not_called()
+    assert logz is sampler.log_evidence
+    np.testing.assert_array_equal(ns, np.array(sampler.nested_samples))

--- a/tests/test_samplers/test_nested_sampler/test_core_sampling.py
+++ b/tests/test_samplers/test_nested_sampler/test_core_sampling.py
@@ -272,6 +272,7 @@ def test_nested_sampling_loop(sampler, config):
 def test_nested_sampling_loop_prior_sampling(sampler, close_pool):
     """Test the nested sampling loop for prior sampling"""
     sampler.initialised = False
+    sampler.finalised = False
     sampler.nested_samples = sampler.model.new_point(10)
     sampler.prior_sampling = True
     sampler._close_pool = close_pool


### PR DESCRIPTION
This is a small fix to avoid redrawing live points when resuming a run that is already finished.

I also fixed a typo I spotted in one of the warnings.