### PR TITLE
ENH: add support for discrete parameters

### DIFF
--- a/docs/discrete-parameters.rst
+++ b/docs/discrete-parameters.rst
@@ -1,0 +1,36 @@
+Sampling with discrete parameters
+=================================
+
+The normalising flows in ``nessai`` do not support discrete parameters.
+As such, any discrete parameters in a model must be handled differently to
+other parameters.
+
+.. note::
+
+    The importance nested sampler does not currently support sampling with
+    discrete parameters.
+
+==============
+Dequantisation
+==============
+
+Dequantisation is a technique used to convert discrete data into continuous data.
+It is designed for use with integer values and works by adding random noise
+on :math:`[0, 1)` to the data:
+
+.. math::
+
+    x_{dequantise} = x + a \quad \text{where} \quad a \sim U[0, 1).
+
+
+In ``nessai``, dequantisation is available via a reparameterisation called
+``dequantise``. See below for an example of how it is used.
+
+
+============================
+Example using dequantisation
+============================
+
+
+.. literalinclude:: ../examples/discrete_parameter.py
+    :language: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ For questions or other support, please either use our `gitter room <https://app.
    normalising-flows-configuration
    parallelisation
    gravitational-wave-inference
+   discrete-parameters
    plugins
    further-details
    API reference </autoapi/nessai/index>

--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -51,6 +51,7 @@ There are a number of pre-configured reparameterisations included in ``nessai``:
 - ``angle-sine``: Same as :code:`angle` but for angles with sine priors
 - ``angle-2pi``: Same as :code:`angle-pi` but for angles defined on [0, :math:`2\pi`]
 - ``angle-pair``: Reparameterisation for pairs of angles, see :py:class:`nessai.reparameterisations.AnglePair` for details.
+- ``dequantise``: Reparameterisation for discrete parameters for that adds random noise to each integer values.
 - ``'none'``: No reparameterisation is applied.
 
 For details on each of these reparameterisations see :py:mod:`~nessai.reparameterisations`.

--- a/examples/discrete_parameter.py
+++ b/examples/discrete_parameter.py
@@ -1,0 +1,94 @@
+"""
+Example showing how to handle discrete parameters using reparametersations.
+"""
+
+from nessai.flowsampler import FlowSampler
+from nessai.model import Model
+from nessai.utils import setup_logger
+from nessai.livepoint import empty_structured_array
+import numpy as np
+
+# Configure the output directory and logger
+output = "./outdir/discrete_example/"
+logger = setup_logger(output=output, log_level="INFO")
+
+
+# Define the mode class, this model has two signal models and a discrete
+# variable that determines which is used for the computing the log-likelihood
+class MultiModelLikelihood(Model):
+
+    def __init__(self, x_data, y_data):
+        # x and y data
+        self.x_data = x_data
+        self.y_data = y_data
+        # Assume the standard deviation is known
+        self.sigma = 1
+        self.bounds = {"m": [-5.0, 5.0], "c": [-5.0, 5.0], "model": [0, 1]}
+        self.names = list(self.bounds.keys())
+        # Specify the list of discrete parameters
+        self.discrete_parameters = ["model"]
+
+    def new_point(self, N=1):
+        # Redefine the new point method so that it correctly samples the
+        # discrete parameter
+        x = empty_structured_array(N, self.names)
+        x["m"] = np.random.uniform(*self.bounds["m"], size=N)
+        x["c"] = np.random.uniform(*self.bounds["c"], size=N)
+        x["model"] = np.random.choice([0, 1], size=N)
+        return x
+
+    def new_point_log_prob(self, x):
+        # Update the function that defines the log-probability for the
+        # `new_point` method.
+        log_prob = -np.log(
+            np.ptp(self.bounds["m"]) * np.ptp(self.bounds["c"]) * 0.5
+        ) * np.ones(len(x))
+        return log_prob
+
+    def log_prior(self, x):
+        # Check the values are within the prior bounds
+        log_p = np.log(self.in_bounds(x), dtype="float")
+        # Compute the log-prior for the uniform parameters
+        for n in ["m", "c"]:
+            log_p -= np.log(self.bounds[n][1] - self.bounds[n][0])
+        # Only accept the allow values for model, log(0) = -inf
+        log_p += np.log(~(x["model"] % 1).astype(bool))
+        return log_p
+
+    def log_likelihood(self, x):
+        # Use a different depending on the value of the "model" parameters
+        # We use the following two models (mx + c) and (mx^1.1 + c)
+        y_fit = np.where(
+            x["model"] == 1,
+            (x["m"] * self.x_data + x["c"]),
+            (x["m"] * self.x_data**1.1 + x["c"]),
+        )
+        # Standard Gaussian likelihood
+        log_l = np.sum(
+            -0.5 * (((self.y_data - y_fit) / self.sigma) ** 2)
+            - np.log(2 * np.pi * self.sigma**2),
+            axis=0,
+        )
+        return log_l
+
+
+# Generate some fake data.
+# We use the straight line model for this example.
+x_data = np.linspace(0, 10, 100)
+y_data = 2.5 * x_data + 1.4 + np.random.randn(len(x_data))
+
+# Define the sampler and specify the 'dequantise' reparameterisation for the
+# discrete parameter.
+# This adds random noise from [0, 1) to the discrete values, without this
+# the sampling would be inefficient since the flow will not propose integer
+# values.
+fs = FlowSampler(
+    MultiModelLikelihood(x_data, y_data),
+    output=output,
+    resume=False,
+    seed=1234,
+    reparameterisations={"model": "dequantise"},
+)
+
+# And run as usual
+fs.run()

--- a/examples/discrete_parameter.py
+++ b/examples/discrete_parameter.py
@@ -13,7 +13,7 @@ output = "./outdir/discrete_example/"
 logger = setup_logger(output=output, log_level="INFO")
 
 
-# Define the mode class, this model has two signal models and a discrete
+# Define the model class, this model has two signal models and a discrete
 # variable that determines which is used for the computing the log-likelihood
 class MultiModelLikelihood(Model):
 
@@ -51,13 +51,15 @@ class MultiModelLikelihood(Model):
         # Compute the log-prior for the uniform parameters
         for n in ["m", "c"]:
             log_p -= np.log(self.bounds[n][1] - self.bounds[n][0])
-        # Only accept the allow values for model, log(0) = -inf
+        # Only accept the allowed values for 'model', log(0) = -inf
         log_p += np.log(~(x["model"] % 1).astype(bool))
         return log_p
 
     def log_likelihood(self, x):
-        # Use a different depending on the value of the "model" parameters
-        # We use the following two models (mx + c) and (mx^1.1 + c)
+        # Use a different likelihood depending on the value of the "model"
+        # parameter. We use the following two models:
+        # 1. (mx + c)
+        # 2. (mx^1.1 + c)
         y_fit = np.where(
             x["model"] == 1,
             (x["m"] * self.x_data + x["c"]),

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -106,6 +106,11 @@ class Model(ABC):
     bool
         Parallelise calculating the log-prior using the multiprocessing pool.
     """
+    has_discrete_parameters = False
+    """
+    bool
+        Indicates if the model contains discrete parameters.
+    """
     _vectorised_likelihood = None
     _vectorised_prior = None
     _vectorised_prior_unit_hypercube = None
@@ -739,7 +744,7 @@ class Model(ABC):
         if (
             np.isfinite(self.lower_bounds).all()
             and np.isfinite(self.upper_bounds).all()
-        ):
+        ) and not self.has_discrete_parameters:
             logP = -np.inf
             counter = 0
             while (logP == -np.inf) or (logP == np.inf):

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -173,7 +173,7 @@ class Model(ABC):
     def discrete_parameters(self):
         """List of discrete parameters.
 
-        None of there are no discrete parameters.
+        None if there are no discrete parameters.
         """
         return self._discrete_parameters
 

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -106,11 +106,6 @@ class Model(ABC):
     bool
         Parallelise calculating the log-prior using the multiprocessing pool.
     """
-    has_discrete_parameters = False
-    """
-    bool
-        Indicates if the model contains discrete parameters.
-    """
     _vectorised_likelihood = None
     _vectorised_prior = None
     _vectorised_prior_unit_hypercube = None
@@ -172,6 +167,27 @@ class Model(ABC):
         if d == 0:
             d = None
         return d
+
+    @property
+    def discrete_parameters(self):
+        """List of discrete parameters.
+
+        None of there are no discrete parameters.
+        """
+        return self._discrete_parameters
+
+    @discrete_parameters.setter
+    def discrete_parameters(self, parameters):
+        logger.warning(
+            "Handling discrete parameters is experimental and may change in "
+            "future releases!"
+        )
+        self._discrete_parameters = parameters
+
+    @property
+    def has_discrete_parameters(self):
+        """Indicates if the model contains discrete parameters."""
+        return self._discrete_parameters is not None
 
     def _set_upper_lower(self):
         """Set the upper and lower bounds arrays"""
@@ -762,7 +778,9 @@ class Model(ABC):
                         "after 10000 tries, check the log prior function."
                     )
         else:
-            logger.warning("Model has infinite bounds(s)")
+            logger.warning(
+                "Model has infinite bounds(s) and/or discrete parameters"
+            )
             logger.warning("Testing with `new_point`")
             try:
                 x = self.new_point(1)

--- a/nessai/model.py
+++ b/nessai/model.py
@@ -111,6 +111,7 @@ class Model(ABC):
     _vectorised_prior_unit_hypercube = None
     _pool_configured = False
     n_pool = None
+    _discrete_parameters = None
 
     @property
     def names(self):

--- a/nessai/reparameterisations/__init__.py
+++ b/nessai/reparameterisations/__init__.py
@@ -9,6 +9,7 @@ functions and classes.
 from .angle import Angle, AnglePair, ToCartesian
 from .base import Reparameterisation
 from .combined import CombinedReparameterisation
+from .discrete import Dequantise
 from .null import NullReparameterisation
 from .rescale import Rescale, RescaleToBounds, ScaleAndShift
 from .utils import get_reparameterisation
@@ -70,6 +71,15 @@ default_reparameterisations = {
     "angle-pair": (AnglePair, None),
     "periodic": (Angle, {"scale": None}),
     "to-cartesian": (ToCartesian, None),
+    "dequantise": (Dequantise, None),
+    "dequantise-logit": (
+        Dequantise,
+        {
+            "rescale_bounds": [0.0, 1.0],
+            "update_bounds": False,
+            "post_rescaling": "logit",
+        },
+    ),
     "none": (NullReparameterisation, None),
     "null": (NullReparameterisation, None),
     None: (NullReparameterisation, None),
@@ -80,6 +90,7 @@ __all__ = [
     "Angle",
     "AnglePair",
     "CombinedReparameterisation",
+    "Dequantise",
     "NullReparameterisation",
     "Reparameterisation",
     "Rescale",

--- a/nessai/reparameterisations/discrete.py
+++ b/nessai/reparameterisations/discrete.py
@@ -1,0 +1,70 @@
+"""Reparameterisations for discrete variables"""
+
+import numpy as np
+
+from .rescale import RescaleToBounds
+
+
+class Dequantise(RescaleToBounds):
+    """Reparameterisation that adds noise to discrete variables and then
+    rescales to the specified bounds.
+
+    Can also optionally apply a sigmoid/logit transform after rescaling.
+    See :py:class:`~nessai.reparameterisations.rescale.RescaleToBounds` for
+    more details.
+
+    Note that :code:`update_bounds` is disabled by default and its use is not
+    recommended with this reparameterisation.
+
+    Parameters
+    ----------
+    parameters : list[str]
+        List of parameters to apply the reparameterisation to
+    prior_bounds : dict
+        Dictionary of prior bounds
+    rescale_bounds : Optional[list]
+        Bounds to rescale to. Defaults to [-1, 1].
+    update_bounds : bool
+        Update the bounds for rescaling during sampling. Can be enabled but
+        not recommended.
+    post_rescaling : Optional[str]
+        Name of the rescaling to apply after rescaling to the specified bounds.
+    """
+
+    def __init__(
+        self,
+        parameters=None,
+        prior_bounds=None,
+        rescale_bounds=None,
+        update_bounds=False,
+        post_rescaling=None,
+    ):
+        super().__init__(
+            parameters=parameters,
+            prior_bounds=prior_bounds,
+            prior=None,
+            rescale_bounds=rescale_bounds,
+            boundary_inversion=None,
+            detect_edges=False,
+            offset=None,
+            update_bounds=update_bounds,
+            pre_rescaling=None,
+            post_rescaling=post_rescaling,
+        )
+
+        self.has_pre_rescaling = True
+        self.has_prime_prior = False
+
+    def set_bounds(self, prior_bounds):
+        super().set_bounds(prior_bounds)
+        # The allowed bounds must in in the maximum value + 1
+        self.bounds = {
+            p: [b[0], b[1] + 1] for p, b in self.prior_bounds.items()
+        }
+
+    def pre_rescaling(self, x):
+        n = len(x)
+        return x + np.random.rand(n), np.zeros(n)
+
+    def pre_rescaling_inv(self, x):
+        return np.floor(x), np.zeros(len(x))

--- a/nessai/reparameterisations/discrete.py
+++ b/nessai/reparameterisations/discrete.py
@@ -62,9 +62,11 @@ class Dequantise(RescaleToBounds):
             p: [b[0], b[1] + 1] for p, b in self.prior_bounds.items()
         }
 
-    def pre_rescaling(self, x):
+    @staticmethod
+    def pre_rescaling(x):
         n = len(x)
         return x + np.random.rand(n), np.zeros(n)
 
-    def pre_rescaling_inv(self, x):
+    @staticmethod
+    def pre_rescaling_inv(x):
         return np.floor(x), np.zeros(len(x))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -179,6 +179,27 @@ def test_upper_bounds(model):
     np.testing.assert_array_equal(bounds, np.array([1, 1]))
 
 
+def test_discrete_parameters(model):
+    value = ["a", "b"]
+    model._discrete_parameters = value
+    assert Model.discrete_parameters.__get__(model) == value
+
+
+def test_discrete_parameters_setter(model, caplog):
+    value = ["a", "b"]
+    Model.discrete_parameters.__set__(model, value)
+    assert model._discrete_parameters == value
+    assert "discrete parameters is experimental" in str(caplog.text)
+
+
+@pytest.mark.parametrize(
+    "value, expected", [(["a", "b"], True), (None, False)]
+)
+def test_has_discrete_parameters(model, value, expected):
+    model._discrete_parameters = value
+    assert Model.has_discrete_parameters.__get__(model) is expected
+
+
 @pytest.mark.parametrize("value", [True, False])
 def test_vectorised_likelihood(model, value):
     """Assert the correct value is stored if allow_vectorised is True"""

--- a/tests/test_reparameterisations/test_discrete.py
+++ b/tests/test_reparameterisations/test_discrete.py
@@ -1,0 +1,59 @@
+from nessai.livepoint import dict_to_live_points, empty_structured_array
+from nessai.reparameterisations.discrete import Dequantise
+from nessai.utils.testing import assert_structured_arrays_equal
+import numpy as np
+
+
+def test_dequantise_init():
+    reparam = Dequantise(parameters=["a"], prior_bounds={"a": [0, 10]})
+    assert reparam.has_pre_rescaling is True
+    assert reparam.has_prime_prior is False
+
+    # Bounds should be one more than the max
+    assert reparam.bounds["a"][0] == 0
+    assert reparam.bounds["a"][1] == 11
+
+
+def test_pre_rescaling():
+    x = np.array([0, 0, 0, 1, 1, 1])
+    out, log_j = Dequantise.pre_rescaling(x)
+    assert all((out[:3] > 0) & (out[:3] < 1))
+    assert all((out[3:] > 1) & (out[3:] < 2))
+    np.testing.assert_equal(log_j, 0.0)
+
+
+def test_pre_rescaling_inv():
+    x = np.array([0.5, 1.1, 2.3])
+    out, log_j = Dequantise.pre_rescaling_inv(x)
+    np.testing.assert_array_equal(out, np.array([0, 1, 2]))
+    np.testing.assert_equal(log_j, 0.0)
+
+
+def test_dequantise_integration():
+    values = [0, 1, 2, 4, 8]
+    x = dict_to_live_points({"a": np.random.choice(values, size=10)})
+
+    reparam = Dequantise(
+        parameters="a",
+        prior_bounds={"a": [0, 8]},
+        rescale_bounds=[0, 1],
+    )
+
+    x_prime = empty_structured_array(len(x), names=reparam.prime_parameters)
+    x_out, x_prime, log_j_out = reparam.reparameterise(
+        x, x_prime, np.zeros(len(x))
+    )
+    assert_structured_arrays_equal(x_out, x)
+
+    assert not np.array_equal(x_prime["a_prime"], x["a"])
+    assert all((x_prime["a_prime"] > 0) & (x_prime["a_prime"] < 1))
+    # Should have 10 unique values
+    assert len(np.unique(x_prime["a_prime"]) == len(x))
+
+    x_re, x_prime_re, log_j_re = reparam.inverse_reparameterise(
+        x_out.copy(), x_prime.copy(), np.zeros(len(x))
+    )
+    assert_structured_arrays_equal(x_prime_re, x_prime)
+
+    assert_structured_arrays_equal(x_re, x)
+    np.testing.assert_array_equal(-log_j_re, log_j_out)


### PR DESCRIPTION
Add support for discrete parameters via a dequantisation reparameterisation. This adds random noise on [0, 1) to the discrete values.

The code mostly reuses the `RescaleToBounds` reparameterisation with a hard coded `pre_rescaling` function.


**To-Do**

- [x] Add tests
- [x] Update documentation
- [x] Add example