### PR TITLE
Fix reparam resuming

### DIFF
--- a/nessai/flowmodel/base.py
+++ b/nessai/flowmodel/base.py
@@ -41,7 +41,6 @@ class FlowModel:
         not specified, the current working directory is used.
     """
 
-    model_config = None
     noise_scale = None
     noise_type = None
     model: BaseFlow = None

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -503,7 +503,8 @@ class FlowProposal(RejectionProposal):
         if not os.path.exists(self.output):
             os.makedirs(self.output, exist_ok=True)
 
-        if not resumed and not self.initialised:
+        # Initialise if not resuming or resuming but initialised is False
+        if not resumed or not self.initialised:
             self.set_rescaling()
             self.verify_rescaling()
             if self.expansion_fraction and self.expansion_fraction is not None:
@@ -1682,6 +1683,7 @@ class FlowProposal(RejectionProposal):
         self.acceptance = []
         self._draw_func = None
         self._populate_dist = None
+        self._reparameterisation.reset()
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -170,8 +170,8 @@ class FlowProposal(RejectionProposal):
         super(FlowProposal, self).__init__(model)
         logger.debug("Initialising FlowProposal")
 
-        self._x_dtype = False
-        self._x_prime_dtype = False
+        self._x_dtype = None
+        self._x_prime_dtype = None
         self._draw_func = None
         self._populate_dist = None
 
@@ -193,7 +193,7 @@ class FlowProposal(RejectionProposal):
         self._reparameterisation = None
         self.rescaling_set = False
         self.use_x_prime_prior = False
-        self.update_bounds = False
+        self.should_update_reparameterisations = False
         self.accumulate_weights = accumulate_weights
 
         self.reparameterisations = reparameterisations
@@ -279,7 +279,7 @@ class FlowProposal(RejectionProposal):
     @property
     def x_dtype(self):
         """Return the dtype for the x space"""
-        if not self._x_dtype:
+        if self._x_dtype is None:
             self._x_dtype = get_dtype(
                 self.parameters, config.livepoints.default_float_dtype
             )
@@ -288,7 +288,7 @@ class FlowProposal(RejectionProposal):
     @property
     def x_prime_dtype(self):
         """Return the dtype for the x prime space"""
-        if not self._x_prime_dtype:
+        if self._x_prime_dtype is None:
             self._x_prime_dtype = get_dtype(
                 self.prime_parameters, config.livepoints.default_float_dtype
             )
@@ -484,7 +484,7 @@ class FlowProposal(RejectionProposal):
         """Update the flow configuration dictionary."""
         self.flow_config["n_inputs"] = self.rescaled_dims
 
-    def initialise(self):
+    def initialise(self, resumed: bool = False) -> None:
         """
         Initialise the proposal class.
 
@@ -492,23 +492,28 @@ class FlowProposal(RejectionProposal):
             * Setting up the rescaling
             * Verifying the rescaling is invertible
             * Initialising the FlowModel
+
+        Parameters
+        ----------
+        resumed : bool
+            Indicates if the proposal is being initialised after being resumed
+            or not. When true, the reparameterisations will not be
+            reinitialised.
         """
         if not os.path.exists(self.output):
             os.makedirs(self.output, exist_ok=True)
 
-        self._x_dtype = False
-        self._x_prime_dtype = False
+        if not resumed and not self.initialised:
+            self.set_rescaling()
+            self.verify_rescaling()
+            if self.expansion_fraction and self.expansion_fraction is not None:
+                logger.info("Overwriting fuzz factor with expansion fraction")
+                self.fuzz = (1 + self.expansion_fraction) ** (
+                    1 / self.rescaled_dims
+                )
+                logger.info(f"New fuzz factor: {self.fuzz}")
 
-        self.set_rescaling()
-        self.verify_rescaling()
-        if self.expansion_fraction and self.expansion_fraction is not None:
-            logger.info("Overwriting fuzz factor with expansion fraction")
-            self.fuzz = (1 + self.expansion_fraction) ** (
-                1 / self.rescaled_dims
-            )
-            logger.info(f"New fuzz factor: {self.fuzz}")
-
-        self.configure_constant_volume()
+            self.configure_constant_volume()
         self.update_flow_config()
         self.flow = self._FlowModelClass(
             flow_config=self.flow_config,
@@ -697,10 +702,10 @@ class FlowProposal(RejectionProposal):
             r = FallbackClass(parameters=other_params, **fallback_kwargs)
             self._reparameterisation.add_reparameterisations(r)
 
-        if any(r._update_bounds for r in self._reparameterisation.values()):
-            self.update_bounds = True
+        if any(r._update for r in self._reparameterisation.values()):
+            self.should_update_reparameterisations = True
         else:
-            self.update_bounds = False
+            self.should_update_reparameterisations = False
 
         if self._reparameterisation.has_prime_prior:
             self.use_x_prime_prior = True
@@ -738,6 +743,17 @@ class FlowProposal(RejectionProposal):
             FutureWarning,
         )
         return self.prime_parameters
+
+    @property
+    def update_bounds(self):
+        warn(
+            (
+                "`update_bounds` is deprecated, use "
+                "`should_update_reparameterisations` instead."
+            ),
+            FutureWarning,
+        )
+        return self.should_update_reparameterisations
 
     def set_rescaling(self):
         """
@@ -1633,14 +1649,13 @@ class FlowProposal(RejectionProposal):
         """
         super().resume(model)
         self.flow_config = flow_config
-        self._reparameterisation = None
 
         if self.mask is not None:
             if isinstance(self.mask, list):
                 m = np.array(self.mask)
             self.flow_config["mask"] = m
 
-        self.initialise()
+        self.initialise(resumed=True)
 
         if weights_file is None:
             weights_file = self.weights_file
@@ -1651,12 +1666,6 @@ class FlowProposal(RejectionProposal):
                 self.flow.reload_weights(weights_file)
         else:
             logger.warning("Could not reload weights for flow")
-
-        if self.update_bounds:
-            if self.training_data is not None:
-                self.check_state(self.training_data)
-            elif self.training_data is None and self.training_count:
-                raise RuntimeError("Could not resume! Missing training data!")
 
     def reset(self):
         """Reset the proposal"""
@@ -1696,7 +1705,6 @@ class FlowProposal(RejectionProposal):
 
         # user provides model and config for resume
         # flow can be reconstructed from resume
-        del state["_reparameterisation"]
         del state["model"]
         del state["_flow_config"]
         del state["flow"]

--- a/nessai/reparameterisations/base.py
+++ b/nessai/reparameterisations/base.py
@@ -21,7 +21,7 @@ class Reparameterisation:
         Prior bounds for the parameter(s).
     """
 
-    _update_bounds = False
+    _update = False
     has_prior = False
     has_prime_prior = False
     requires_prime_prior = False

--- a/nessai/reparameterisations/rescale.py
+++ b/nessai/reparameterisations/rescale.py
@@ -404,7 +404,7 @@ class RescaleToBounds(Reparameterisation):
             self.has_prime_prior = False
 
             if post_rescaling in ["logit", "log"]:
-                if self._update_bounds:
+                if self._update:
                     raise RuntimeError(
                         "Cannot use log or logit with update bounds"
                     )

--- a/nessai/reparameterisations/rescale.py
+++ b/nessai/reparameterisations/rescale.py
@@ -294,7 +294,7 @@ class RescaleToBounds(Reparameterisation):
             for p in self.boundary_inversion:
                 self.rescale_bounds[p] = [0, 1]
 
-        self._update_bounds = update_bounds if not detect_edges else True
+        self._update = update_bounds if not detect_edges else True
         self.detect_edges = detect_edges
         if self.boundary_inversion:
             self._edges = {n: None for n in self.parameters}
@@ -608,7 +608,7 @@ class RescaleToBounds(Reparameterisation):
 
     def update_bounds(self, x):
         """Update the bounds used for the reparameterisation"""
-        if self._update_bounds:
+        if self._update:
             self.bounds = {
                 p: [
                     self.pre_rescaling(np.min(x[p]))[0] - self.offsets[p],

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -46,3 +46,12 @@ def test_flowproposal_rescaled_names_warning():
     proposal.prime_parameters = ["x"]
     with pytest.warns(FutureWarning, match=r"`rescaled_names` is deprecated"):
         assert FlowProposal.rescaled_names.__get__(proposal) == ["x"]
+
+
+def test_flowproposal_update_bounds_warning():
+    from nessai.proposal import FlowProposal
+
+    proposal = create_autospec(FlowProposal)
+    proposal.should_update_reparameterisations = True
+    with pytest.warns(FutureWarning, match=r"`update_bounds` is deprecated"):
+        assert FlowProposal.update_bounds.__get__(proposal) is True

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -331,7 +331,7 @@ def test_post_rescaling_with_str(reparam, rescaling):
 
     Also test the config for the logit
     """
-    reparam._update_bounds = False
+    reparam._update = False
     reparam.parameters = ["x"]
     from nessai.utils.rescaling import rescaling_functions
 
@@ -346,7 +346,7 @@ def test_post_rescaling_with_str(reparam, rescaling):
 @pytest.mark.parametrize("rescaling", ["log", "logit"])
 def test_post_rescaling_with_logit_update_bounds(reparam, rescaling):
     """Assert an error is raised if using logit and update bounds"""
-    reparam._update_bounds = True
+    reparam._update = True
     with pytest.raises(
         RuntimeError, match=r"Cannot use log or logit with update bounds"
     ):
@@ -370,7 +370,7 @@ def test_post_rescaling_invalid_input(reparam):
 def test_update_bounds_disabled(reparam, caplog):
     """Assert nothing happens in _update_bounds is False"""
     caplog.set_level("DEBUG")
-    reparam._update_bounds = False
+    reparam._update = False
     RescaleToBounds.update_bounds(reparam, [0, 1])
     assert "Update bounds not enabled" in str(caplog.text)
 


### PR DESCRIPTION
The issue in https://github.com/mj-will/nessai/issues/405 was most likely due to the reparameterisations not being correctly initialised when resuming the sampler. This PR fixes this by pickling the reparameterisations with the proposal and no longer reinitialising them.


To-do

- [ ] Add tests