### PR TITLE
BUG: Handle case where `linear_transform='None'`

### DIFF
--- a/nessai/flows/nsf.py
+++ b/nessai/flows/nsf.py
@@ -110,10 +110,14 @@ class NeuralSplineFlow(NFlow):
 
         transforms_list = []
         for i in range(num_layers):
-            if linear_transform is not None:
+            if (
+                linear_transform is not None
+                and linear_transform.lower() != "none"
+            ):
                 transforms_list.append(
                     create_linear_transform(linear_transform, features)
                 )
+
             transforms_list.append(spline_constructor(i))
             if batch_norm_between_layers:
                 transforms_list.append(transforms.BatchNorm(features=features))

--- a/nessai/flows/realnvp.py
+++ b/nessai/flows/realnvp.py
@@ -191,7 +191,10 @@ class RealNVP(NFlow):
                     transforms.normalization.ActNorm(features=features)
                 )
 
-            if linear_transform is not None:
+            if (
+                linear_transform is not None
+                and linear_transform.lower() != "none"
+            ):
                 layers.append(
                     create_linear_transform(linear_transform, features)
                 )

--- a/tests/test_flows/test_specific_flows.py
+++ b/tests/test_flows/test_specific_flows.py
@@ -23,6 +23,7 @@ from nessai.flows import (
         dict(linear_transform="svd"),
         dict(linear_transform="lu"),
         dict(linear_transform=None),
+        dict(linear_transform="None"),
         dict(mask=np.array([[1, -1], [-1, 1]])),
         dict(mask=[1, -1]),
         dict(pre_transform="batch_norm"),
@@ -75,6 +76,7 @@ def test_realnvp_actnorm_batchnorm():
         dict(linear_transform="svd"),
         dict(linear_transform="lu"),
         dict(linear_transform=None),
+        dict(linear_transform="None"),
         dict(num_bins=10),
     ],
 )


### PR DESCRIPTION
This case seems to come up when using bilby_pipe.

I'll probably also port this fix back to a 0.13.x and make a bug fix release.