### PR TITLE
Support one-to-many reparameterisations

### DIFF
--- a/nessai/proposal/flowproposal.py
+++ b/nessai/proposal/flowproposal.py
@@ -801,6 +801,11 @@ class FlowProposal(RejectionProposal):
             raise RuntimeError(
                 "Rescaling must be set before it can be verified"
             )
+        if not self._reparameterisation.one_to_one:
+            logger.warning(
+                "Could not check if reparameterisation is invertible"
+            )
+            return
         logger.info("Verifying rescaling functions")
         x = self.model.new_point(N=1000)
         for inversion in ["lower", "upper", False, None]:

--- a/nessai/reparameterisations/base.py
+++ b/nessai/reparameterisations/base.py
@@ -28,6 +28,7 @@ class Reparameterisation:
     requires_bounded_prior = False
     prior_bounds = None
     prime_prior_bounds = None
+    one_to_one = True
 
     def __init__(self, parameters=None, prior_bounds=None):
         if not isinstance(parameters, (str, list)):

--- a/nessai/reparameterisations/combined.py
+++ b/nessai/reparameterisations/combined.py
@@ -47,6 +47,10 @@ class CombinedReparameterisation(dict):
         return any(r.requires_prime_prior for r in self.values())
 
     @property
+    def one_to_one(self):
+        return all(r.one_to_one for r in self.values())
+
+    @property
     def to_prime_order(self):
         """Order when converting to the prime space"""
         if self.reverse_order:

--- a/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal_rescaling.py
@@ -576,6 +576,7 @@ def test_verify_rescaling(proposal, has_inversion):
     proposal.check_state = MagicMock()
     proposal.rescaling_set = True
     proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = True
 
     FlowProposal.verify_rescaling(proposal)
 
@@ -611,6 +612,8 @@ def test_verify_rescaling_invertible_error(proposal, has_inversion):
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
     proposal.rescaling_set = True
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -640,6 +643,8 @@ def test_verify_rescaling_invertible_error_non_sampling(
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
     proposal.rescaling_set = True
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -665,6 +670,8 @@ def test_verify_rescaling_jacobian_error(proposal, has_inversion):
     proposal.rescale = MagicMock(return_value=(x_prime, log_j))
     proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
     proposal.rescaling_set = True
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = True
 
     with pytest.raises(RuntimeError) as excinfo:
         FlowProposal.verify_rescaling(proposal)
@@ -676,6 +683,18 @@ def test_verify_rescaling_rescaling_not_set(proposal):
     proposal.rescaling_set = False
     with pytest.raises(RuntimeError, match=r"Rescaling must be set .*"):
         FlowProposal.verify_rescaling(proposal)
+
+
+def test_verify_rescaling_not_one_to_one(proposal, caplog):
+    proposal.rescaling_set = True
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = False
+    proposal.model.new_point = MagicMock()
+    FlowProposal.verify_rescaling(proposal)
+    assert "Could not check if reparameterisation is invertible" in str(
+        caplog.text
+    )
+    proposal.model.new_point.assert_not_called()
 
 
 def test_check_state_update(proposal, map_to_unit_hypercube):


### PR DESCRIPTION
This PR adds support for one-to-many reparameterisations, e.g. for the reparameterisation proposed in https://github.com/mj-will/nessai-gw/pull/1.

The main change is to skip the steps that ensure the reparameterisation are invertible if `one_to_one` is `False`.