### PR TITLE
MAINT: change setuptools-scm version scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ nflows = [
 ]
 
 [tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
The current configuration for `setuptools_scm` doesn't return a sensible version number. My understanding is that this is a result of having a release branch that has the v0.13.2 and v0.13.1 releases on it rather than them being in master. The current version gives:

```
nessai-0.13.1.dev62+gb142cc4.d20240823
```

After this change, the version on `main` would be

```
nessai-0.14.0.dev62+gb142cc4
```

and the `release-0.13.x` branch it returns

```
nessai-0.13.3.dev0+g06af460
```