### PR TITLE
CI: update actions

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -28,8 +28,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # Install CPU-only version of PyTorch
+        pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install -e .[test]
         pip install bilby
-    - name: Run bilby compatibility tests
+    - name: Run bilby compatibility tests (without plugin)
+      run: |
+        python -m pytest --bilby-compatibility -m "bilby_compatibility"
+    - name: Install bilby plugin
+      run: |
+        pip install nessai-bilby
+    - name: Run bilby compatibility tests (with plugin)
       run: |
         python -m pytest --bilby-compatibility -m "bilby_compatibility"

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'  # Based on bilby
+        python-version: '3.11'  # Based on bilby
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install pypa/build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         python -m pytest --cov-report=xml --without-integration --without-slow-integration
       shell: bash -el {0}
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests


### PR DESCRIPTION
Some actions are deprecated and need updating.

I also bumped the Python version for the bilby compatibility test, since bilby will drop Python 3.9 support soon.