### PR TITLE
ENH: add `output` to resume functions

### DIFF
--- a/docs/further-details.rst
+++ b/docs/further-details.rst
@@ -112,6 +112,12 @@ priority over the resume file.
 This will be passed to the :python:`resume_from_pickled_sampler` of the
 corresponding sampler class.
 
+.. note::
+
+    If the output directory has been moved, make sure to change the
+    :code`output` argument when calling :code:`FlowSampler`. The sampler
+    will then automatically update the relevant paths.
+
 
 Checkpoint callbacks
 --------------------

--- a/nessai/flowsampler.py
+++ b/nessai/flowsampler.py
@@ -85,7 +85,7 @@ class FlowSampler:
     def __init__(
         self,
         model,
-        output=os.getcwd(),
+        output=None,
         importance_nested_sampler=False,
         resume=True,
         resume_file="nested_sampler_resume.pkl",
@@ -145,6 +145,8 @@ class FlowSampler:
             logger.debug("Overriding `parallelise_prior` in the model")
             model.parallelise_prior = parallelise_prior
 
+        if output is None:
+            output = os.getcwd()
         self.output = os.path.join(output, "")
         os.makedirs(self.output, exist_ok=True)
         self.save_kwargs(kwargs)
@@ -160,6 +162,7 @@ class FlowSampler:
                     SamplerClass,
                     resume_data=resume_data,
                     model=model,
+                    output=self.output,
                     weights_path=weights_path,
                     flow_config=kwargs.get("flow_config"),
                     checkpoint_callback=kwargs.get("checkpoint_callback"),
@@ -168,6 +171,7 @@ class FlowSampler:
                 self.ns = self._resume_from_file(
                     SamplerClass,
                     model=model,
+                    output=self.output,
                     resume_file=resume_file,
                     weights_path=weights_path,
                     flow_config=kwargs.get("flow_config"),

--- a/nessai/proposal/base.py
+++ b/nessai/proposal/base.py
@@ -5,6 +5,7 @@ Base object for all proposal classes.
 
 import datetime
 import logging
+import os
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -52,6 +53,24 @@ class Proposal(ABC):
         Initialise the proposal
         """
         self.initialised = True
+
+    def update_output(self, output: str) -> None:
+        """
+        Update the output directory.
+
+        Only updates the output if the proposal has an output attribute.
+
+        Parameters
+        ----------
+        output: str
+            Path to the output directory
+        """
+        if hasattr(self, "output"):
+            logger.debug(f"Updating output directory to {output}")
+            self.output = output
+            os.makedirs(self.output, exist_ok=True)
+        else:
+            logger.debug("No output directory to update")
 
     def evaluate_likelihoods(self):
         """Evaluate the likelihoods for the pool of live points."""

--- a/nessai/samplers/base.py
+++ b/nessai/samplers/base.py
@@ -357,13 +357,12 @@ class BaseNestedSampler(ABC):
         model.likelihood_evaluation_time += datetime.timedelta(
             seconds=sampler._previous_likelihood_evaluation_time
         )
-        if output is not None:
-            if output != sampler.output:
-                logger.info(
-                    f"Overwriting output from {sampler.output} to {output}"
-                )
-                os.makedirs(output, exist_ok=True)
-                sampler.update_output(output)
+        if output is not None and output != sampler.output:
+            logger.info(
+                f"Overwriting output from {sampler.output} to {output}"
+            )
+            os.makedirs(output, exist_ok=True)
+            sampler.update_output(output)
         sampler.model = model
         sampler.resumed = True
         sampler.checkpoint_callback = checkpoint_callback

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -718,6 +718,13 @@ class ImportanceNestedSampler(BaseNestedSampler):
         proposal = ImportanceFlowProposal(self.model, output, **kwargs)
         return proposal
 
+    def update_output(self, output: str) -> None:
+        super().update_output(output)
+        if self.proposal is not None:
+            # ImportanceFlowProposal uses a subdirectory
+            subdir = os.path.basename(os.path.normpath(self.proposal.output))
+            self.proposal.update_output(os.path.join(self.output, subdir, ""))
+
     def configure_iterations(
         self,
         min_iteration: Optional[int] = None,

--- a/nessai/samplers/importancesampler.py
+++ b/nessai/samplers/importancesampler.py
@@ -723,7 +723,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         if self.proposal is not None:
             # ImportanceFlowProposal uses a subdirectory
             subdir = os.path.basename(os.path.normpath(self.proposal.output))
-            self.proposal.update_output(os.path.join(self.output, subdir, ""))
+            self.proposal.update_output(os.path.join(output, subdir, ""))
 
     def configure_iterations(
         self,

--- a/nessai/samplers/nestedsampler.py
+++ b/nessai/samplers/nestedsampler.py
@@ -499,6 +499,26 @@ class NestedSampler(BaseNestedSampler):
         if self.plot:
             os.makedirs(os.path.join(output, "diagnostics"), exist_ok=True)
 
+    def update_output(self, output: str) -> None:
+        """Update the output directory.
+
+        Also creates a "diagnostics" directory for plotting.
+
+        Parameters
+        ----------
+        output : str
+            Path to the output directory.
+        """
+        super().update_output(output)
+        if self.plot:
+            os.makedirs(os.path.join(output, "diagnostics"), exist_ok=True)
+        if self._flow_proposal is not None:
+            # FlowProposal uses a subdirectory
+            subdir = os.path.basename(
+                os.path.normpath(self._flow_proposal.output)
+            )
+            self._flow_proposal.update_output(os.path.join(output, subdir, ""))
+
     def configure_flow_reset(
         self, reset_weights, reset_permutations, reset_flow
     ):

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -172,7 +172,7 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
 
 def test_resume_from_resume_data(flow_sampler, model, tmp_path):
     """Test for resume from data"""
-    output = tmp_path / "test"
+    output = str(tmp_path / "test")
     data = object()
     flow_sampler.check_resume = MagicMock(return_value=True)
     flow_sampler._resume_from_data = MagicMock()
@@ -183,6 +183,7 @@ def test_resume_from_resume_data(flow_sampler, model, tmp_path):
         NestedSampler,
         resume_data=data,
         model=model,
+        output=os.path.join(output, ""),
         weights_path=None,
         flow_config=None,
         checkpoint_callback=None,
@@ -191,7 +192,7 @@ def test_resume_from_resume_data(flow_sampler, model, tmp_path):
 
 def test_resume_from_resume_file(flow_sampler, model, tmp_path):
     """Test for resume from data"""
-    output = tmp_path / "test"
+    output = str(tmp_path / "test")
     resume_file = "resume.pkl"
     flow_sampler.check_resume = MagicMock(return_value=True)
     flow_sampler._resume_from_file = MagicMock()
@@ -207,6 +208,7 @@ def test_resume_from_resume_file(flow_sampler, model, tmp_path):
         NestedSampler,
         resume_file=resume_file,
         model=model,
+        output=os.path.join(output, ""),
         weights_path=None,
         flow_config=None,
         checkpoint_callback=None,
@@ -381,6 +383,7 @@ def test_init_resume(tmp_path, test_old, error):
     mock_resume.assert_called_with(
         expected_rf,
         integration_model,
+        output=os.path.join(output, ""),
         flow_config=flow_config,
         weights_path=weights_file,
         checkpoint_callback=None,

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -113,7 +113,10 @@ def test_check_resume_files_do_not_exist(flow_sampler, tmp_path):
 
 @pytest.mark.parametrize("resume", [False, True])
 @pytest.mark.parametrize("use_ins", [False, True])
-def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
+@pytest.mark.parametrize("specify_output", [False, True])
+def test_init_no_resume_file(
+    flow_sampler, tmp_path, resume, use_ins, specify_output
+):
     """Test the init method when there is no run to resume from"""
 
     integration_model = MagicMock()
@@ -139,11 +142,12 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
             f"nessai.flowsampler.{sampler_class}", return_value="ns"
         ) as mock,
         patch("nessai.flowsampler.configure_threads") as mock_threads,
+        patch("os.getcwd", return_value=output) as mock_getcwd,
     ):
         FlowSampler.__init__(
             flow_sampler,
             integration_model,
-            output=output,
+            output=output if specify_output else None,
             resume=resume,
             exit_code=exit_code,
             pytorch_threads=pytorch_threads,
@@ -168,6 +172,9 @@ def test_init_no_resume_file(flow_sampler, tmp_path, resume, use_ins):
     assert flow_sampler.ns == "ns"
 
     flow_sampler.save_kwargs.assert_called_once_with(kwargs)
+
+    if not specify_output:
+        mock_getcwd.assert_called_once()
 
 
 def test_resume_from_resume_data(flow_sampler, model, tmp_path):

--- a/tests/test_proposal/test_base_proposal.py
+++ b/tests/test_proposal/test_base_proposal.py
@@ -4,6 +4,7 @@ Test the base proposal class.
 """
 
 import logging
+import os
 import pickle
 from unittest.mock import MagicMock, Mock, create_autospec
 
@@ -60,6 +61,19 @@ def test_initialise(proposal):
     """Test the initialise method"""
     Proposal.initialise(proposal)
     assert proposal.initialised is True
+
+
+def test_update_output(proposal, tmp_path):
+    tmp_path = tmp_path / "test"
+    proposal.output = tmp_path / "orig"
+    Proposal.update_output(proposal, tmp_path)
+    assert proposal.output == tmp_path
+    assert os.path.exists(tmp_path)
+
+
+def test_update_output_no_output(proposal):
+    Proposal.update_output(proposal, "test")
+    assert not hasattr(proposal, "output")
 
 
 def test_evaluate_likelihoods(proposal):

--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -1,6 +1,7 @@
 """Test configuration of INS"""
 
-from unittest.mock import MagicMock
+import os
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -81,3 +82,21 @@ def check_configuration_okay(ins):
     ins.nlive = 100
     ins.min_remove = 1
     assert INS.check_configuration(ins) is True
+
+
+@pytest.mark.parametrize("has_proposal", [False, True])
+def test_update_output(ins, tmp_path, has_proposal):
+    output = tmp_path / "new"
+    if has_proposal:
+        ins.proposal = MagicMock()
+        ins.proposal.output = tmp_path / "orig" / "levels"
+    else:
+        ins.proposal = None
+    with patch("nessai.samplers.base.BaseNestedSampler.update_output") as mock:
+        INS.update_output(ins, output)
+
+    mock.assert_called_once_with(output)
+    if has_proposal:
+        ins.proposal.update_output.assert_called_once_with(
+            os.path.join(output, "levels", "")
+        )


### PR DESCRIPTION
The PR adds features to enable resuming from a different directory to where the sampler was originally run.

This requires updating all the output paths stored within the sampler and proposal classes.

**Note:** this will likely break resuming older runs with the release that contains this fix.

**To-Do**

- [x] Add unit tests