### PR TITLE
CI: test on Python 3.13

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS, Ubuntu, Windows]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -15,13 +15,14 @@ dependencies:
   - corner
   - bilby
   - astropy
-  - faiss-cpu>=1.7.3,!=1.7.4    # conda release for 1.7.4 is broken
   - multiprocess
   - pytest
   - pytest-cov
   - pytest-timeout
   - pytest-rerunfailures
   - pytest-integration
+  - python<3.13:
+    - faiss-cpu>=1.7.3,!=1.7.4    # conda release for 1.7.4 is broken
   - pip
   - pip:
     - nflows

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -1,6 +1,5 @@
 name: nessai-ci
 channels:
-  - default
   - pytorch
   - conda-forge
 dependencies:

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -21,8 +21,6 @@ dependencies:
   - pytest-timeout
   - pytest-rerunfailures
   - pytest-integration
-  - python<3.13:
-    - faiss-cpu>=1.7.3,!=1.7.4    # conda release for 1.7.4 is broken
   - pip
   - pip:
     - nflows

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -23,5 +23,4 @@ dependencies:
   - pytest-integration
   - pip
   - pip:
-    - nflows
     - ray[default] ; (sys_platform != 'win32' and python_version < '3.12') or (sys_platform == 'win32' and python_version < '3.12')

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -1,6 +1,5 @@
 name: nessai-ci
 channels:
-  - pytorch
   - conda-forge
 dependencies:
   - numpy
@@ -8,8 +7,7 @@ dependencies:
   - scipy>=0.16
   - matplotlib>=2.0
   - seaborn
-  - pytorch>=1.11.0
-  - cpuonly
+  - pytorch-cpu>=2.0
   - glasflow
   - h5py
   - corner

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - numpy
   - pandas
-  - scipy>=0.16, <1.14    # tmp fix for a bilby issue
+  - scipy>=0.16
   - matplotlib>=2.0
   - seaborn
   - pytorch>=1.11.0


### PR DESCRIPTION
Include Python 3.13 in the CI.

This will probably break things!