### PR TITLE
MAINT: migrate numpy RNG to use generators

### DIFF
--- a/docs/further-details.rst
+++ b/docs/further-details.rst
@@ -26,7 +26,9 @@ Importantly the structured arrays used for live points can also contain multiple
 .. code-block:: python
 
     >>> from nessai.livepoint import numpy_array_to_live_points
-    >>> x = np.random.rand(10, 2)    # 10 live points with 2 parameters
+    >>> import numpy as np
+    >>> rng = np.random.default_rng()
+    >>> x = rng.random((10, 2))    # 10 live points with 2 parameters
     >>> print(x)
     [[0.72451217 0.1788154 ]
      [0.31549832 0.55898106]

--- a/src/nessai/experimental/flowmodel/clustering.py
+++ b/src/nessai/experimental/flowmodel/clustering.py
@@ -17,7 +17,9 @@ class ClusteringFlowModel(FlowModel):
     n_clusters: int = None
     cluster_weights: np.ndarray = None
 
-    def __init__(self, flow_config=None, training_config=None, output=None):
+    def __init__(
+        self, flow_config=None, training_config=None, output=None, rng=None
+    ):
         try:
             import faiss
 
@@ -32,6 +34,7 @@ class ClusteringFlowModel(FlowModel):
             flow_config=flow_config,
             training_config=training_config,
             output=output,
+            rng=rng,
         )
 
     def setup_from_input_dict(
@@ -96,7 +99,7 @@ class ClusteringFlowModel(FlowModel):
 
     def sample_cluster_labels(self, n: int) -> np.ndarray:
         """Sample n random cluster labels"""
-        return np.random.choice(
+        return self.rng.choice(
             self.n_clusters, size=(n, 1), p=self.cluster_weights
         )
 

--- a/src/nessai/experimental/proposal/clustering.py
+++ b/src/nessai/experimental/proposal/clustering.py
@@ -65,7 +65,7 @@ class ClusteringFlowProposal(FlowProposal):
         fig.savefig(os.path.join(output, "training_clusters"))
         plt.close(fig)
 
-        z_gen = np.random.randn(self.training_data.size, self.dims)
+        z_gen = self.rng.standard_normal((self.training_data.size, self.dims))
 
         fig = plt.figure()
         plt.hist(np.sqrt(np.sum(z_training_data**2, axis=1)), "auto")

--- a/src/nessai/flowmodel/base.py
+++ b/src/nessai/flowmodel/base.py
@@ -51,10 +51,15 @@ class FlowModel:
         flow_config: Union[dict, None] = None,
         training_config: Union[dict, None] = None,
         output: Union[str, None] = None,
+        rng: Optional[np.random.Generator] = None,
     ) -> None:
         if output is None:
             output = os.getcwd()
         self.model = None
+        if rng is None:
+            logger.debug("No rng specified, using the default rng.")
+            rng = np.random.default_rng()
+        self.rng = rng
         self.initialised = False
         self.output = output
         os.makedirs(self.output, exist_ok=True)
@@ -271,7 +276,7 @@ class FlowModel:
         if weights is not None and conditional is not None:
             raise RuntimeError("weights and conditional inputs not supported")
 
-        idx = np.random.permutation(samples.shape[0])
+        idx = self.rng.permutation(samples.shape[0])
         samples = samples[idx]
         if weights is not None:
             if not np.isfinite(weights).all():

--- a/src/nessai/flowmodel/importance.py
+++ b/src/nessai/flowmodel/importance.py
@@ -31,11 +31,13 @@ class ImportanceFlowModel(FlowModel):
         flow_config: dict = None,
         training_config: dict = None,
         output: str = None,
+        rng: Optional[np.random.Generator] = None,
     ):
         super().__init__(
             flow_config=flow_config,
             training_config=training_config,
             output=output,
+            rng=rng,
         )
         self.weights_files = []
         self.models = torch.nn.ModuleList()

--- a/src/nessai/flowsampler.py
+++ b/src/nessai/flowsampler.py
@@ -289,6 +289,11 @@ class FlowSampler:
         else:
             return self._nested_samples
 
+    @property
+    def rng(self):
+        """Return the random number generator"""
+        return self.ns.rng
+
     def run(
         self,
         plot=True,
@@ -390,6 +395,7 @@ class FlowSampler:
             self._nested_samples,
             log_w=self.ns.state.log_posterior_weights,
             method=posterior_sampling_method,
+            rng=self.rng,
         )
         logger.info(
             f"Returned {self.posterior_samples.size} " "posterior samples"

--- a/src/nessai/model.py
+++ b/src/nessai/model.py
@@ -18,6 +18,7 @@ from .livepoint import (
     parameters_to_live_point,
     unstructured_view,
 )
+from .utils.errors import RNGNotSetError, RNGSetError
 from .utils.multiprocessing import (
     batch_evaluate_function,
     check_vectorised_function,
@@ -129,7 +130,7 @@ class Model(ABC):
             logger.debug("No rng specified, using the default rng.")
             rng = np.random.default_rng()
         if self.rng is not None:
-            raise RuntimeError("Random number generator already set!")
+            raise RNGSetError()
         self.rng = rng
 
     @property
@@ -435,7 +436,7 @@ class Model(ABC):
             and log-prior (logP) and log-likelihood (logL)
         """
         if not self.rng:
-            raise RuntimeError("Random number generator not set!")
+            raise RNGNotSetError()
         logP = -np.inf
         while logP == -np.inf:
             p = parameters_to_live_point(
@@ -464,7 +465,7 @@ class Model(ABC):
             and log-prior (logP) and log-likelihood (logL)
         """
         if not self.rng:
-            raise RuntimeError("Random number generator not set!")
+            raise RNGNotSetError()
         new_points = empty_structured_array(N, names=self.names)
         n = 0
         while n < N:
@@ -570,7 +571,7 @@ class Model(ABC):
             Structured array of samples
         """
         if not self.rng:
-            raise RuntimeError("Random number generator not set!")
+            raise RNGNotSetError()
         return numpy_array_to_live_points(
             self.rng.random((n, self.dims)),
             names=self.names,
@@ -773,7 +774,7 @@ class Model(ABC):
             )
 
         if not self.rng:
-            raise RuntimeError("Random number generator not set!")
+            raise RNGNotSetError()
 
         if self.dims == 1:
             raise OneDimensionalModelError(

--- a/src/nessai/model.py
+++ b/src/nessai/model.py
@@ -6,6 +6,7 @@ Object for defining the use-defined model.
 import datetime
 import logging
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import numpy as np
 
@@ -113,6 +114,23 @@ class Model(ABC):
     _pool_configured = False
     n_pool = None
     _discrete_parameters = None
+    rng = None
+
+    def set_rng(self, rng: Optional[np.random.Generator] = None):
+        """Set the random number generator.
+
+        Parameters
+        ----------
+        rng : np.random.Generator, optional
+            Random number generator. If not provided, a new generator is
+            created.
+        """
+        if rng is None:
+            logger.debug("No rng specified, using the default rng.")
+            rng = np.random.default_rng()
+        if self.rng is not None:
+            raise RuntimeError("Random number generator already set!")
+        self.rng = rng
 
     @property
     def names(self):
@@ -416,10 +434,12 @@ class Model(ABC):
             Numpy structured array with fields for each parameter
             and log-prior (logP) and log-likelihood (logL)
         """
+        if not self.rng:
+            raise RuntimeError("Random number generator not set!")
         logP = -np.inf
         while logP == -np.inf:
             p = parameters_to_live_point(
-                np.random.uniform(
+                self.rng.uniform(
                     self.lower_bounds, self.upper_bounds, self.dims
                 ),
                 self.names,
@@ -443,11 +463,13 @@ class Model(ABC):
             Numpy structured array with fields for each parameter
             and log-prior (logP) and log-likelihood (logL)
         """
+        if not self.rng:
+            raise RuntimeError("Random number generator not set!")
         new_points = empty_structured_array(N, names=self.names)
         n = 0
         while n < N:
             p = numpy_array_to_live_points(
-                np.random.uniform(
+                self.rng.uniform(
                     self.lower_bounds, self.upper_bounds, [N, self.dims]
                 ),
                 self.names,
@@ -547,8 +569,10 @@ class Model(ABC):
         numpy.ndarray
             Structured array of samples
         """
+        if not self.rng:
+            raise RuntimeError("Random number generator not set!")
         return numpy_array_to_live_points(
-            np.random.rand(n, self.dims),
+            self.rng.random((n, self.dims)),
             names=self.names,
         )
 
@@ -748,6 +772,9 @@ class Model(ABC):
                 f"`bounds` is not set to a valid value: {self.bounds}"
             )
 
+        if not self.rng:
+            raise RuntimeError("Random number generator not set!")
+
         if self.dims == 1:
             raise OneDimensionalModelError(
                 "model is one-dimensional. "
@@ -769,7 +796,7 @@ class Model(ABC):
             counter = 0
             while (logP == -np.inf) or (logP == np.inf):
                 x = numpy_array_to_live_points(
-                    np.random.uniform(
+                    self.rng.uniform(
                         self.lower_bounds, self.upper_bounds, [1, self.dims]
                     ),
                     self.names,

--- a/src/nessai/proposal/analytic.py
+++ b/src/nessai/proposal/analytic.py
@@ -5,8 +5,6 @@ Proposal method for initial sampling when priors can be sampled analytically.
 
 import datetime
 
-import numpy as np
-
 from .base import Proposal
 
 
@@ -56,7 +54,7 @@ class AnalyticProposal(Proposal):
         self.samples["logP"] = self.model.batch_evaluate_log_prior(
             self.samples
         )
-        self.indices = np.random.permutation(self.samples.shape[0]).tolist()
+        self.indices = self.rng.permutation(self.samples.shape[0]).tolist()
         self.samples["logL"] = self.model.batch_evaluate_log_likelihood(
             self.samples
         )

--- a/src/nessai/proposal/augmented.py
+++ b/src/nessai/proposal/augmented.py
@@ -115,7 +115,7 @@ class AugmentedFlowProposal(FlowProposal):
                 x_prime[an] = np.zeros(x_prime.size)
         elif generate_augment == "gaussian":
             for an in self.augment_parameters:
-                x_prime[an] = np.random.randn(x_prime.size)
+                x_prime[an] = self.rng.standard_normal(x_prime.size)
         else:
             raise RuntimeError("Unknown method for generating augment samples")
 
@@ -153,7 +153,7 @@ class AugmentedFlowProposal(FlowProposal):
         """
         x_prime = np.repeat(x_prime, self.n_marg, axis=0)
 
-        x_prime[:, -self.augment_dims :] = np.random.randn(
+        x_prime[:, -self.augment_dims :] = self.rng.standard_normal(
             x_prime.shape[0], self.augment_dims
         )
 

--- a/src/nessai/proposal/augmented.py
+++ b/src/nessai/proposal/augmented.py
@@ -154,7 +154,7 @@ class AugmentedFlowProposal(FlowProposal):
         x_prime = np.repeat(x_prime, self.n_marg, axis=0)
 
         x_prime[:, -self.augment_dims :] = self.rng.standard_normal(
-            x_prime.shape[0], self.augment_dims
+            (x_prime.shape[0], self.augment_dims)
         )
 
         _, log_prob = self.flow.forward_and_log_prob(x_prime)

--- a/src/nessai/proposal/base.py
+++ b/src/nessai/proposal/base.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import os
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import numpy as np
 
@@ -21,10 +22,16 @@ class Proposal(ABC):
     ----------
     model: obj
         User-defined model
+    rng: np.random.Generator, optional
+        Random number generator. If not provided, a new generator is created.
     """
 
-    def __init__(self, model):
+    def __init__(self, model, rng: Optional[np.random.Generator] = None):
         self.model = model
+        if rng is None:
+            logger.debug("No rng specified, using the default rng.")
+            rng = np.random.default_rng()
+        self.rng = rng
         self.populated = True
         self._initialised = False
         self.training_count = 0

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 from abc import abstractmethod
+from typing import Optional
 from warnings import warn
 
 import matplotlib.pyplot as plt
@@ -100,6 +101,7 @@ class BaseFlowProposal(RejectionProposal):
     def __init__(
         self,
         model,
+        rng: Optional[np.random.Generator] = None,
         flow_config=None,
         training_config=None,
         output=None,
@@ -116,7 +118,7 @@ class BaseFlowProposal(RejectionProposal):
         reverse_reparameterisations=False,
         map_to_unit_hypercube=False,
     ):
-        super().__init__(model)
+        super().__init__(model, rng=rng)
 
         self._x_dtype = None
         self._x_prime_dtype = None
@@ -351,6 +353,7 @@ class BaseFlowProposal(RejectionProposal):
             flow_config=self.flow_config,
             training_config=self.training_config,
             output=self.output,
+            rng=self.rng,
         )
         self.flow.initialise()
         self.populated = False

--- a/src/nessai/proposal/importance.py
+++ b/src/nessai/proposal/importance.py
@@ -689,7 +689,7 @@ class ImportanceFlowProposal(Proposal):
             logger.debug(f"Drawing {m} samples from the {id}th proposal.")
             if id == -1:
                 prime_samples[count : (count + m)] = self.to_prime(
-                    self.rng.random(m, self.model.dims)
+                    self.rng.random((m, self.model.dims))
                 )[0]
             else:
                 prime_samples[count : (count + m)] = self.flow.sample_ith(

--- a/src/nessai/proposal/rejection.py
+++ b/src/nessai/proposal/rejection.py
@@ -108,10 +108,10 @@ class RejectionProposal(AnalyticProposal):
         x = self.draw_proposal(N=N)
         log_w, x["logP"] = self.compute_weights(x, return_log_prior=True)
         log_w -= np.nanmax(log_w)
-        log_u = np.log(np.random.rand(N))
+        log_u = np.log(self.rng.random(N))
         indices = np.where((log_w - log_u) >= 0)[0]
         self.samples = x[indices]
-        self.indices = np.random.permutation(self.samples.shape[0]).tolist()
+        self.indices = self.rng.permutation(self.samples.shape[0]).tolist()
         self.population_acceptance = self.samples.size / N
         self.samples["logL"] = self.model.batch_evaluate_log_likelihood(
             self.samples

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -45,9 +45,16 @@ class Angle(Reparameterisation):
     requires_bounded_prior = True
 
     def __init__(
-        self, parameters=None, prior_bounds=None, scale=1.0, prior=None
+        self,
+        parameters=None,
+        prior_bounds=None,
+        scale=1.0,
+        prior=None,
+        rng=None,
     ):
-        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
 
         if len(self.parameters) == 1:
             self.parameters.append(self.parameters[0] + "_radial")
@@ -212,7 +219,7 @@ class ToCartesian(Angle):
             x_prime = np.concatenate([x_prime, x_prime])
             log_j = np.concatenate([log_j, log_j])
         elif self.mode == "split":
-            neg = np.random.choice(angle.size, angle.size // 2, replace=False)
+            neg = self.rng.choice(angle.size, angle.size // 2, replace=False)
             angle[neg] *= -1
 
         angle *= self.scale

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -31,7 +31,11 @@ class Reparameterisation:
     prime_prior_bounds = None
     one_to_one = True
 
-    def __init__(self, parameters=None, prior_bounds=None):
+    def __init__(self, parameters=None, prior_bounds=None, rng=None):
+        if rng is None:
+            logger.debug("No rng specified, using the default rng.")
+            rng = np.random.default_rng()
+        self.rng = rng
         if not isinstance(parameters, (str, list)):
             raise TypeError("Parameters must be a str or list.")
 

--- a/src/nessai/reparameterisations/discrete.py
+++ b/src/nessai/reparameterisations/discrete.py
@@ -38,6 +38,7 @@ class Dequantise(RescaleToBounds):
         rescale_bounds=None,
         update_bounds=False,
         post_rescaling=None,
+        rng=None,
     ):
         super().__init__(
             parameters=parameters,
@@ -50,6 +51,7 @@ class Dequantise(RescaleToBounds):
             update_bounds=update_bounds,
             pre_rescaling=None,
             post_rescaling=post_rescaling,
+            rng=rng,
         )
 
         self.has_pre_rescaling = True
@@ -62,11 +64,9 @@ class Dequantise(RescaleToBounds):
             p: [b[0], b[1] + 1] for p, b in self.prior_bounds.items()
         }
 
-    @staticmethod
-    def pre_rescaling(x):
+    def pre_rescaling(self, x):
         n = len(x)
-        return x + np.random.rand(n), np.zeros(n)
+        return x + self.rng.random(n), np.zeros(n)
 
-    @staticmethod
-    def pre_rescaling_inv(x):
+    def pre_rescaling_inv(self, x):
         return np.floor(x), np.zeros(len(x))

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -21,8 +21,10 @@ class NullReparameterisation(Reparameterisation):
         Prior bounds for parameters. Unused for this reparameterisation.
     """
 
-    def __init__(self, parameters=None, prior_bounds=None):
-        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+    def __init__(self, parameters=None, prior_bounds=None, rng=None):
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
         self.prime_parameters = self.parameters
         logger.debug(f"Initialised reparameterisation: {self.name}")
 

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -172,10 +172,13 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         estimate_shift=False,
         pre_rescaling=None,
         post_rescaling=None,
+        rng=None,
     ):
         if scale is None and not estimate_scale:
             raise RuntimeError("Must specify a scale or enable estimate_scale")
-        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
 
         self.estimate_scale = estimate_scale
         self.estimate_shift = estimate_shift
@@ -365,8 +368,11 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         update_bounds=True,
         pre_rescaling=None,
         post_rescaling=None,
+        rng=None,
     ):
-        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
 
         self.bounds = None
         self._edges = None
@@ -552,7 +558,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
                 log_j = np.concatenate([log_j, log_j])
             else:
                 logger.debug("Inverting with splitting")
-                inv = np.random.choice(
+                inv = self.rng.choice(
                     x_prime.size, x_prime.size // 2, replace=False
                 )
                 x_prime[pp][inv] *= -1

--- a/src/nessai/samplers/base.py
+++ b/src/nessai/samplers/base.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import os
 import pickle
+import random
 import time
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Optional, Union
@@ -71,6 +72,7 @@ class BaseNestedSampler(ABC):
         nlive: int,
         output: str = None,
         seed: int = None,
+        rng: Optional[np.random.Generator] = None,
         checkpointing: bool = True,
         checkpoint_interval: int = 600,
         checkpoint_on_iteration: bool = False,
@@ -86,6 +88,8 @@ class BaseNestedSampler(ABC):
 
         self.info_enabled = logger.isEnabledFor(logging.INFO)
         self.debug_enabled = logger.isEnabledFor(logging.DEBUG)
+        self.configure_random_seed(seed, rng)
+        model.set_rng(self.rng)
         model.verify_model()
         self.n_pool = n_pool
         self.model = model
@@ -107,7 +111,6 @@ class BaseNestedSampler(ABC):
         self.finalised = False
         self.resumed = False
 
-        self.configure_random_seed(seed)
         self.configure_output(output, resume_file=resume_file)
         self.configure_periodic_logging(logging_interval, log_on_iteration)
 
@@ -180,20 +183,38 @@ class BaseNestedSampler(ABC):
         resume_file = os.path.split(self.resume_file)[1]
         self.resume_file = os.path.join(output, resume_file)
 
-    def configure_random_seed(self, seed: Optional[int]):
+    def configure_random_seed(
+        self, seed: Optional[int], rng: Optional[np.random.Generator]
+    ):
         """Initialise the random seed.
+
+        If a seed is not specified, a random seed is generated using the
+        specified random number generator, or the default numpy random number
+        if not specified. In the latter case, the seed is then used to seed
+        the new numpy random number generator.
 
         Parameters
         ----------
         seed : Optional[int]
             The random seed. If not specified, a random seed is generated.
+        rng: Optional[np.random.Generator]
+            Random number generator. If not specified, the default numpy
+            random number generator is used with the specified seed.
         """
         if seed is None:
             logger.debug("Seed not specified, generating random seed")
-            seed = np.random.randint(0, min(np.iinfo(int).max, 2**32 - 1))
+            if rng is None:
+                seed = random.randint(0, min(np.iinfo(int).max, 2**32 - 1))
+            else:
+                seed = rng.integers(0, min(np.iinfo(int).max, 2**32 - 1))
         logger.debug(f"Setting random seed to {seed}")
         self.seed = seed
-        np.random.seed(seed=self.seed)
+        if rng is None:
+            logger.debug(
+                f"No rng specified, using the default rng with seed={seed}."
+            )
+            rng = np.random.default_rng(self.seed)
+        self.rng = rng
         torch.manual_seed(self.seed)
 
     def configure_periodic_logging(self, logging_interval, log_on_iteration):

--- a/src/nessai/samplers/importancesampler.py
+++ b/src/nessai/samplers/importancesampler.py
@@ -346,6 +346,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         n_initial: Optional[int] = None,
         output: Optional[str] = None,
         seed: Optional[int] = None,
+        rng: Optional[np.random.Generator] = None,
         checkpointing: bool = True,
         checkpoint_interval: int = 600,
         checkpoint_on_iteration: bool = False,
@@ -394,6 +395,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             nlive,
             output=output,
             seed=seed,
+            rng=rng,
             checkpointing=checkpointing,
             checkpoint_interval=checkpoint_interval,
             checkpoint_on_iteration=checkpoint_on_iteration,
@@ -1310,7 +1312,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
         log_evidence_errors = np.empty(n_batches)
         proposal = self.proposal
         for i in range(n_batches):
-            new_counts = np.random.multinomial(
+            new_counts = self.rng.multinomial(
                 orig_n_total,
                 weights,
             )
@@ -1348,7 +1350,7 @@ class ImportanceNestedSampler(BaseNestedSampler):
             cc = 0
             for it, c, nc in zip(its, counts, new_counts):
                 assert c >= nc
-                idx = np.random.choice(
+                idx = self.rng.choice(
                     np.arange(cc, cc + c), size=nc, replace=False
                 )
                 idx_keep[idx] = True

--- a/src/nessai/samplers/nestedsampler.py
+++ b/src/nessai/samplers/nestedsampler.py
@@ -171,6 +171,7 @@ class NestedSampler(BaseNestedSampler):
         log_on_iteration=True,
         resume_file=None,
         seed=None,
+        rng=None,
         pool=None,
         close_pool=False,
         n_pool=None,
@@ -204,6 +205,7 @@ class NestedSampler(BaseNestedSampler):
             nlive,
             output=output,
             seed=seed,
+            rng=rng,
             checkpointing=checkpointing,
             checkpoint_interval=checkpoint_interval,
             checkpoint_on_iteration=checkpoint_on_iteration,
@@ -438,7 +440,9 @@ class NestedSampler(BaseNestedSampler):
 
         logger.debug(f"Using uninformed proposal: {uninformed_proposal}")
         logger.debug(f"Parsing kwargs to uninformed proposal: {kwargs}")
-        self._uninformed_proposal = uninformed_proposal(self.model, **kwargs)
+        self._uninformed_proposal = uninformed_proposal(
+            self.model, rng=self.rng, **kwargs
+        )
 
     def configure_flow_proposal(
         self, flow_proposal_class, flow_config, proposal_plots, **kwargs
@@ -474,6 +478,7 @@ class NestedSampler(BaseNestedSampler):
         logger.info(f"Passing kwargs to {ProposalClass.__name__}: {kwargs}")
         self._flow_proposal = ProposalClass(
             self.model,
+            rng=self.rng,
             flow_config=flow_config,
             output=proposal_output,
             plot=proposal_plots,

--- a/src/nessai/utils/errors.py
+++ b/src/nessai/utils/errors.py
@@ -1,0 +1,28 @@
+"""Custom exceptions for the nessai package."""
+
+
+class RNGError(Exception):
+    """Base class for exceptions related to random number generation."""
+
+    pass
+
+
+class RNGNotSetError(RNGError):
+    """Exception raised when the random number generator has not been set"""
+
+    def __init__(
+        self, msg="Random number generator has not been set", *args, **kwargs
+    ):
+        super().__init__(msg, *args, **kwargs)
+
+
+class RNGSetError(RNGError):
+    """Exception raised when the random number generator has already been set"""
+
+    def __init__(
+        self,
+        msg="Random number generator has already been set",
+        *args,
+        **kwargs,
+    ):
+        super().__init__(msg, *args, **kwargs)

--- a/src/nessai/utils/multiprocessing.py
+++ b/src/nessai/utils/multiprocessing.py
@@ -223,10 +223,10 @@ def check_vectorised_function(func, x, dtype=None, atol=1e-15, rtol=1e-15):
     if len(x) <= 1:
         raise ValueError("Input has length <= 1")
 
-    target = np.array([func(xx) for xx in x], dtype=dtype)
+    target = np.array([func(xx) for xx in x], dtype=dtype).flatten()
 
     try:
-        batch = func(x).astype(dtype)
+        batch = func(x).astype(dtype).flatten()
     except (TypeError, ValueError, AttributeError):
         logger.debug("Assuming function is not vectorised")
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import time
 import numpy as np
 import pytest
 import torch
-from numpy.random import seed
 from scipy.stats import norm
 
 from nessai.livepoint import (
@@ -17,14 +16,18 @@ from nessai.livepoint import (
 from nessai.model import Model
 from nessai.utils.testing import IntegrationTestModel
 
-seed(170817)
 torch.manual_seed(170817)
 
 _requires_dependency_cache = dict()
 
 
 @pytest.fixture()
-def model():
+def rng():
+    return np.random.default_rng(170817)
+
+
+@pytest.fixture()
+def model(rng):
     class TestModel(Model):
         def __init__(self):
             self.bounds = {"x": [-5, 5], "y": [-5, 5]}
@@ -54,12 +57,15 @@ def model():
                 x_out[n] = np.ptp(self.bounds[n]) * x[n] + self.bounds[n][0]
             return x_out
 
-    return TestModel()
+    m = TestModel()
+    m.set_rng(rng)
+    return m
 
 
-@pytest.fixture()
-def integration_model():
-    return IntegrationTestModel()
+@pytest.fixture(scope="function")
+def integration_model(rng):
+    model = IntegrationTestModel()
+    return model
 
 
 @pytest.fixture()

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -67,3 +67,13 @@ def test_get_region_sampler_proposal_class_warning():
         match=r"`get_region_sampler_proposal_class` is deprecated",
     ):
         get_region_sampler_proposal_class(None)
+
+
+def test_configure_random_seed_warning():
+    from nessai.samplers.base import BaseNestedSampler
+
+    sampler = create_autospec(BaseNestedSampler)
+    with pytest.warns(
+        FutureWarning, match=r"`configure_random_seed` is deprecated"
+    ):
+        BaseNestedSampler.configure_random_seed(sampler, seed=0)

--- a/tests/test_experimental/test_flowmodel/test_clustering.py
+++ b/tests/test_experimental/test_flowmodel/test_clustering.py
@@ -12,7 +12,7 @@ def cfm():
 
 
 @pytest.mark.requires("faiss")
-def test_init(cfm, tmp_path, caplog):
+def test_init(cfm, tmp_path, caplog, rng):
     caplog.set_level("DEBUG")
     flow_config = {}
     training_config = {}
@@ -25,10 +25,14 @@ def test_init(cfm, tmp_path, caplog):
             flow_config=flow_config,
             training_config=training_config,
             output=output,
+            rng=rng,
         )
 
     mock_parent_init.assert_called_once_with(
-        flow_config=flow_config, training_config=training_config, output=output
+        flow_config=flow_config,
+        training_config=training_config,
+        output=output,
+        rng=rng,
     )
     assert "faiss version" in str(caplog.text)
 

--- a/tests/test_flowmodel/test_flowmodel_importance.py
+++ b/tests/test_flowmodel/test_flowmodel_importance.py
@@ -14,15 +14,15 @@ from nessai.flowmodel.importance import ImportanceFlowModel as IFM
 
 
 @pytest.fixture()
-def ifm():
-    return create_autospec(IFM)
+def ifm(rng):
+    return create_autospec(IFM, rng=rng)
 
 
 class DummyFlow(torch.nn.Module):
     pass
 
 
-def test_init(ifm):
+def test_init(ifm, rng):
     training_config = dict(patience=20)
     flow_config = dict(n_neurons=4)
     output = "test"
@@ -32,9 +32,13 @@ def test_init(ifm):
             output=output,
             flow_config=flow_config,
             training_config=training_config,
+            rng=rng,
         )
     mock_init.assert_called_once_with(
-        flow_config=flow_config, training_config=training_config, output=output
+        flow_config=flow_config,
+        training_config=training_config,
+        output=output,
+        rng=rng,
     )
     assert ifm.weights_files == []
     assert len(ifm.models) == 0

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -626,6 +626,7 @@ def test_log_evidence_error(flow_sampler):
 
 def test_rng(flow_sampler, rng):
     """Test rng property"""
+    flow_sampler.ns = MagicMock()
     flow_sampler.ns.rng = rng
     assert FlowSampler.rng.__get__(flow_sampler) is rng
 

--- a/tests/test_flowsampler.py
+++ b/tests/test_flowsampler.py
@@ -624,6 +624,12 @@ def test_log_evidence_error(flow_sampler):
     assert FlowSampler.log_evidence_error.__get__(flow_sampler) is out
 
 
+def test_rng(flow_sampler, rng):
+    """Test rng property"""
+    flow_sampler.ns.rng = rng
+    assert FlowSampler.rng.__get__(flow_sampler) is rng
+
+
 @pytest.mark.parametrize("use_ins", [False, True])
 def test_run(flow_sampler, use_ins):
     flow_sampler.importance_nested_sampler = use_ins

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -56,12 +56,16 @@ def model():
 
 
 @pytest.fixture
-def live_point(integration_model):
+def live_point(integration_model, rng):
+    if integration_model.rng is None:
+        integration_model.set_rng(rng)
     return integration_model.new_point()
 
 
 @pytest.fixture
-def live_points(integration_model):
+def live_points(integration_model, rng):
+    if integration_model.rng is None:
+        integration_model.set_rng(rng)
     return integration_model.new_point(10)
 
 
@@ -341,7 +345,7 @@ def test_new_point_single(model):
     model._single_new_point.assert_called_once()
 
 
-def test_single_new_point(model):
+def test_single_new_point(model, rng):
     """Test the method that draw one point within the prior bounds"""
     model.names = ["x", "y"]
     model.bounds = {"x": [-1, 1], "y": [-2, 2]}
@@ -349,6 +353,7 @@ def test_single_new_point(model):
     model.upper_bounds = np.array([1, 2])
     model.log_prior = MagicMock(return_value=0)
     model.dims = 2
+    model.rng = rng
     x = Model._single_new_point(model)
     assert (x["x"] >= -1) & (x["x"] <= 1)
     assert (x["y"] >= -2) & (x["y"] <= 2)
@@ -361,7 +366,7 @@ def test_new_point_multiple(model):
     model._multiple_new_points.assert_called_once_with(10)
 
 
-def test_multiple_new_points(model):
+def test_multiple_new_points(model, rng):
     """Test the method that draws multiple points within the prior bounds"""
     n = 10
     model.names = ["x", "y"]
@@ -370,13 +375,14 @@ def test_multiple_new_points(model):
     model.upper_bounds = np.array([1, 2])
     model.log_prior = MagicMock(return_value=np.zeros(10))
     model.dims = 2
+    model.rng = rng
     x = Model._multiple_new_points(model, N=n)
     assert x.size == n
     assert ((x["x"] >= -1) & (x["x"] <= 1)).all()
     assert ((x["y"] >= -2) & (x["y"] <= 2)).all()
 
 
-def test_multiple_new_points_reject(model):
+def test_multiple_new_points_reject(model, rng):
     """Assert the correct number of points are returned in some are rejected"""
     n = 3
     model.names = ["x", "y"]
@@ -386,6 +392,7 @@ def test_multiple_new_points_reject(model):
     model.log_prior = MagicMock(
         side_effect=2 * [np.array([-np.inf, 0.0, 0.0])]
     )
+    model.rng = rng
     model.dims = 2
     x = Model._multiple_new_points(model, N=n)
     assert x.size == n
@@ -393,7 +400,7 @@ def test_multiple_new_points_reject(model):
     assert ((x["y"] >= -2) & (x["y"] <= 2)).all()
 
 
-def test_multiple_new_points_reject_batch(model):
+def test_multiple_new_points_reject_batch(model, rng):
     """Assert rejecting an entire batch does not raise an error"""
     n = 3
     model.names = ["x", "y"]
@@ -407,6 +414,7 @@ def test_multiple_new_points_reject_batch(model):
         ]
     )
     model.dims = 2
+    model.rng = rng
     x = Model._multiple_new_points(model, N=n)
     assert x.size == n
     assert ((x["x"] >= -1) & (x["x"] <= 1)).all()
@@ -570,7 +578,7 @@ def test_model_1d_error():
     )
 
 
-def test_verify_new_point():
+def test_verify_new_point(rng):
     """
     Test `Model.verify_model` and ensure a model with an ill-defined
     prior function raises the correct error
@@ -581,6 +589,7 @@ def test_verify_new_point():
             return -np.inf
 
     model = BrokenModel()
+    model.set_rng(rng)
 
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
@@ -605,7 +614,7 @@ def test_verify_log_prior_finite(log_p):
         model.verify_model()
 
 
-def test_verify_log_prior_none():
+def test_verify_log_prior_none(rng):
     """
     Test `Model.verify_model` and ensure a model with a log-prior that
     only returns None raises an error.
@@ -616,6 +625,7 @@ def test_verify_log_prior_none():
             return None
 
     model = BrokenModel()
+    model.set_rng(rng)
 
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
@@ -623,7 +633,7 @@ def test_verify_log_prior_none():
     assert "Log-prior" in str(excinfo.value)
 
 
-def test_verify_log_likelihood_none():
+def test_verify_log_likelihood_none(rng):
     """
     Test `Model.verify_model` and ensure a model with a log-likelihood that
     only returns None raises an error.
@@ -634,6 +644,7 @@ def test_verify_log_likelihood_none():
             return None
 
     model = BrokenModel()
+    model.set_rng(rng)
 
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
@@ -760,7 +771,7 @@ def test_verify_incomplete_bounds():
         model.verify_model()
 
 
-def test_verify_model_1d():
+def test_verify_model_1d(rng):
     """Assert an error is raised if the model is one dimensional."""
 
     class TestModel(EmptyModel):
@@ -768,6 +779,7 @@ def test_verify_model_1d():
         bounds = {"x": [-5, 5]}
 
     model = TestModel()
+    model.set_rng(rng)
 
     with pytest.raises(OneDimensionalModelError) as excinfo:
         model.verify_model()
@@ -777,7 +789,7 @@ def test_verify_model_1d():
 
 
 @pytest.mark.parametrize("value", [np.log(True), np.float16(5.0)])
-def test_verify_float16(caplog, value):
+def test_verify_float16(caplog, value, rng):
     """
     Test `Model.verify_model` and ensure that a critical warning is raised
     if a float16 array is returned by the prior.
@@ -788,24 +800,26 @@ def test_verify_float16(caplog, value):
             return value
 
     model = BrokenModel()
+    model.set_rng(rng)
 
     model.verify_model()
 
     assert "float16 precision" in caplog.text
 
 
-def test_verify_no_float16(caplog):
+def test_verify_no_float16(caplog, rng):
     """
     Test `Model.verify_model` and ensure that a critical warning is not raised
     if array return by log_prior is not dtype float16.
     """
     model = BasicModel()
+    model.set_rng(rng)
     out = model.verify_model()
     assert out is True
     assert "float16 precision" not in caplog.text
 
 
-def test_unbounded_priors_wo_new_point():
+def test_unbounded_priors_wo_new_point(rng):
     """Test `Model.verify_model` with unbounded priors"""
 
     class TestModel(Model):
@@ -820,13 +834,14 @@ def test_unbounded_priors_wo_new_point():
             return np.ones(x.size)
 
     model = TestModel()
+    model.set_rng(rng)
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
 
     assert "Could not draw a new point" in str(excinfo.value)
 
 
-def test_unbounded_priors_w_new_point():
+def test_unbounded_priors_w_new_point(rng):
     """Test `Model.verify_model` with unbounded priors"""
 
     class TestModel(Model):
@@ -850,10 +865,11 @@ def test_unbounded_priors_w_new_point():
             return np.ones(x.size)
 
     model = TestModel()
+    model.set_rng(rng)
     model.verify_model()
 
 
-def test_verify_model_likelihood_repeated_calls():
+def test_verify_model_likelihood_repeated_calls(rng):
     """Assert that an error is raised if repeated calls with the likelihood
     return different values.
     """
@@ -867,13 +883,14 @@ def test_verify_model_likelihood_repeated_calls():
             return self.count
 
     model = BrokenModel()
+    model.set_rng(rng)
 
     with pytest.raises(RuntimeError) as excinfo:
         model.verify_model()
     assert "Repeated calls" in str(excinfo.value)
 
 
-def test_verify_model_likelihood_repeated_calls_allowed(caplog):
+def test_verify_model_likelihood_repeated_calls_allowed(caplog, rng):
     """Assert allow multi valued likelihood prevents an error from being
     raised.
     """
@@ -885,6 +902,7 @@ def test_verify_model_likelihood_repeated_calls_allowed(caplog):
             return np.random.rand()
 
     model = MultiValuedModel()
+    model.set_rng(rng)
     model.verify_model()
     assert "Multi-valued likelihood is allowed." in str(caplog.text)
 
@@ -1167,9 +1185,9 @@ def test_view_dtype(model):
     assert dtype == expected
 
 
-def test_unstructured_view(model, live_points):
+def test_unstructured_view(model, live_points, rng):
     """Assert the underlying function is called with the correct inputs"""
-    out = np.random.randn(live_points.size, 2)
+    out = rng.standard_normal((live_points.size, 2))
     dtype = np.dtype([("x", "f8"), ("y", "f8")])
     model._view_dtype = dtype
     with patch("nessai.model.unstructured_view", return_value=out) as mock:
@@ -1191,8 +1209,9 @@ def test_get_state(model):
 @pytest.mark.integration_test
 @pytest.mark.parametrize("pickleable", [False, True])
 @pytest.mark.parametrize("init", ["before", "after", "function"])
-def test_pool(integration_model, mp_context, pickleable, init):
+def test_pool(integration_model, mp_context, pickleable, init, rng):
     """Integration test for evaluating the likelihood with a pool"""
+    integration_model.rng = rng
     method = mp_context.get_start_method()
 
     if not pickleable:
@@ -1270,12 +1289,13 @@ def test_pool_ray(integration_model):
 
 
 @pytest.mark.requires("multiprocess")
-def test_pool_multiprocess(integration_model):
+def test_pool_multiprocess(integration_model, rng):
     """Integration test for evaluating the likelihood with a pool from
     multiprocess.
     """
     import multiprocess as mp
 
+    integration_model.rng = rng
     integration_model.fn = lambda x: x
     pool = mp.Pool(
         1,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -433,13 +433,14 @@ def test_new_point_log_prob(model):
 
 
 @pytest.mark.integration_test
-def test_new_point_integration(integration_model):
+def test_new_point_integration(integration_model, rng):
     """
     Test the default method for generating a new point with the bounds.
 
     Uses the model defined in `conftest.py` with bounds [-5, 5] for
     x and y.
     """
+    integration_model.set_rng(rng)
     new_point = integration_model.new_point()
     log_q = integration_model.new_point_log_prob(new_point)
     assert (new_point["x_0"] < 5) & (new_point["x_0"] > -5)
@@ -448,13 +449,14 @@ def test_new_point_integration(integration_model):
 
 
 @pytest.mark.integration_test
-def test_new_point_multiple_integration(integration_model):
+def test_new_point_multiple_integration(integration_model, rng):
     """
     Test drawing multiple new points from the model
 
     Uses the model defined in `conftest.py` with bounds [-5, 5] for
     x_0 and x_1.
     """
+    integration_model.set_rng(rng)
     new_points = integration_model.new_point(N=100)
     log_q = integration_model.new_point_log_prob(new_points)
     assert new_points.size == 100
@@ -1258,12 +1260,14 @@ def test_pool(integration_model, mp_context, pickleable, init, rng):
 @pytest.mark.requires("ray")
 @pytest.mark.integration_test
 @pytest.mark.flaky(reruns=3)
-def test_pool_ray(integration_model):
+def test_pool_ray(integration_model, rng):
     """Integration test for evaluating the likelihood with a pool from ray.
 
     This will break if the class for integration_model is defined globally.
     """
     from ray.util.multiprocessing import Pool
+
+    integration_model.set_rng(rng)
 
     # Cannot pickle lambda functions
     integration_model.fn = lambda x: x
@@ -1321,8 +1325,9 @@ def test_pool_multiprocess(integration_model, rng):
 
 @pytest.mark.integration_test
 @pytest.mark.parametrize("pickleable", [False, True])
-def test_n_pool(integration_model, mp_context, pickleable):
+def test_n_pool(integration_model, mp_context, pickleable, rng):
     """Integration test for evaluating the likelihood with n_pool"""
+    integration_model.set_rng(rng)
     if not pickleable:
         # Cannot pickle lambda functions
         integration_model.fn = lambda x: x
@@ -1362,8 +1367,9 @@ def test_unstructured_view_integration(integration_model, live_points):
 
 
 @pytest.mark.integration_test
-def test_in_bounds_integration_values(integration_model):
+def test_in_bounds_integration_values(integration_model, rng):
     """Assert the correct booleans are returned"""
+    integration_model.set_rng(rng)
     x = integration_model.new_point(3)
     names = integration_model.names
     x[names[0]][0] = integration_model.bounds[names[0]][1] + 1.0
@@ -1376,10 +1382,12 @@ def test_in_bounds_integration_values(integration_model):
 
 @pytest.mark.parametrize("n", [1, 10])
 @pytest.mark.integration_test
-def test_in_bounds_integration_n_samples(integration_model, n):
+def test_in_bounds_integration_n_samples(integration_model, n, rng):
     """Assert single and multiple samples work"""
+    integration_model.set_rng(rng)
     x = numpy_array_to_live_points(
-        np.random.randn(n, integration_model.dims), integration_model.names
+        rng.standard_normal((n, integration_model.dims)),
+        integration_model.names,
     )
     flags = integration_model.in_bounds(x)
     assert len(flags) == n

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1408,6 +1408,20 @@ def test_rng_not_set_multiple(model):
         Model._multiple_new_points(model, 10)
 
 
+def test_rng_not_set_verify_model(model):
+    model.rng = None
+    model.names = ["x", "y"]
+    model.bounds = {"x": [-1, 1], "y": [-2, 2]}
+    with pytest.raises(RNGNotSetError):
+        Model.verify_model(model)
+
+
+def test_rng_not_set_sample_unit_hypercube(model):
+    model.rng = None
+    with pytest.raises(RNGNotSetError):
+        Model.sample_unit_hypercube(model)
+
+
 def test_set_rng(model, rng):
     model.rng = None
     Model.set_rng(model, rng)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -287,7 +287,7 @@ def test_plot_1d_comparison_colours(colours, live_points, live_points_1):
     plt.close()
 
 
-def test_plot_1d_comparison_more_colours(model):
+def test_plot_1d_comparison_more_colours(model, rng):
     """Test generating a 1d comparirson when comparing more than 10 sets
     of live points.
 

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -125,7 +125,7 @@ def test_draw_posterior_unknown_method(ns):
 
 
 @pytest.mark.slow_integration_test
-def test_compute_weights_vs_log_posterior_weights(model, tmp_path):
+def test_compute_weights_vs_log_posterior_weights(integration_model, tmp_path):
     """Test the two different methods for computing posterior weights and
     assert they return the sames value.
 
@@ -136,7 +136,11 @@ def test_compute_weights_vs_log_posterior_weights(model, tmp_path):
     output = tmp_path / "posterior_comparison"
     output.mkdir()
     fs = FlowSampler(
-        model, output=output, nlive=100, checkpointing=False, plot=False
+        integration_model,
+        output=output,
+        nlive=100,
+        checkpointing=False,
+        plot=False,
     )
     fs.run(save=False, plot=False)
 

--- a/tests/test_proposal/test_analytic.py
+++ b/tests/test_proposal/test_analytic.py
@@ -14,8 +14,8 @@ from nessai.proposal import AnalyticProposal
 
 
 @pytest.fixture
-def proposal():
-    return create_autospec(AnalyticProposal)
+def proposal(rng):
+    return create_autospec(AnalyticProposal, rng=rng)
 
 
 def test_init(proposal):
@@ -35,7 +35,7 @@ def test_poolsize(proposal):
 
 
 @pytest.mark.parametrize("N", [None, 5])
-def test_populate(proposal, N):
+def test_populate(proposal, N, rng):
     """Test the populate process"""
     poolsize = 10
     if N is None:
@@ -46,7 +46,7 @@ def test_populate(proposal, N):
     else:
         samples = numpy_array_to_live_points(np.arange(N)[:, np.newaxis], "x")
         log_p = np.arange(N, 2 * N)
-    log_l = np.random.rand(samples.size)
+    log_l = rng.random(samples.size)
     proposal.poolsize = poolsize
     proposal.model = Mock()
     proposal.model.new_point = Mock(return_value=samples)

--- a/tests/test_proposal/test_flowproposal/test_base/conftest.py
+++ b/tests/test_proposal/test_flowproposal/test_base/conftest.py
@@ -12,8 +12,8 @@ def map_to_unit_hypercube(request):
 
 
 @pytest.fixture()
-def proposal():
-    proposal = create_autospec(BaseFlowProposal)
+def proposal(rng):
+    proposal = create_autospec(BaseFlowProposal, rng=rng)
     proposal._initialised = False
     proposal.map_to_unit_hypercube = False
     return proposal

--- a/tests/test_proposal/test_flowproposal/test_base/test_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_init_resume.py
@@ -44,6 +44,7 @@ def test_initialise(tmpdir, proposal):
         flow_config=proposal.flow_config,
         training_config=proposal.training_config,
         output=proposal.output,
+        rng=proposal.rng,
     )
     proposal.flow.initialise.assert_called_once()
     assert proposal.populated is False

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
@@ -12,9 +12,10 @@ def map_to_unit_hypercube(request):
 
 
 @pytest.fixture()
-def proposal():
+def proposal(rng):
     proposal = create_autospec(FlowProposal)
     proposal._initialised = False
     proposal.accumulate_weights = False
     proposal.map_to_unit_hypercube = False
+    proposal.rng = rng
     return proposal

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -158,6 +158,7 @@ def test_reset_integration(tmpdir, model, latent_prior):
     ignore = [
         "population_time",
         "_reparameterisation",
+        "rng",
     ]
 
     d1 = proposal.__getstate__()

--- a/tests/test_proposal/test_importance/conftest.py
+++ b/tests/test_proposal/test_importance/conftest.py
@@ -13,8 +13,8 @@ NSAMPLES = 10
 
 
 @pytest.fixture()
-def ifp():
-    obj = create_autospec(ImportanceFlowProposal)
+def ifp(rng):
+    obj = create_autospec(ImportanceFlowProposal, rng=rng)
     obj.model = MagicMock(spec=Model)
     return obj
 

--- a/tests/test_reparameterisations/test_discrete.py
+++ b/tests/test_reparameterisations/test_discrete.py
@@ -1,8 +1,16 @@
+from unittest.mock import create_autospec
+
 import numpy as np
+import pytest
 
 from nessai.livepoint import dict_to_live_points, empty_structured_array
 from nessai.reparameterisations.discrete import Dequantise
 from nessai.utils.testing import assert_structured_arrays_equal
+
+
+@pytest.fixture
+def reparam(rng):
+    return create_autospec(Dequantise, rng=rng)
 
 
 def test_dequantise_init():
@@ -15,17 +23,17 @@ def test_dequantise_init():
     assert reparam.bounds["a"][1] == 11
 
 
-def test_pre_rescaling():
+def test_pre_rescaling(reparam):
     x = np.array([0, 0, 0, 1, 1, 1])
-    out, log_j = Dequantise.pre_rescaling(x)
+    out, log_j = Dequantise.pre_rescaling(reparam, x)
     assert all((out[:3] > 0) & (out[:3] < 1))
     assert all((out[3:] > 1) & (out[3:] < 2))
     np.testing.assert_equal(log_j, 0.0)
 
 
-def test_pre_rescaling_inv():
+def test_pre_rescaling_inv(reparam):
     x = np.array([0.5, 1.1, 2.3])
-    out, log_j = Dequantise.pre_rescaling_inv(x)
+    out, log_j = Dequantise.pre_rescaling_inv(reparam, x)
     np.testing.assert_array_equal(out, np.array([0, 1, 2]))
     np.testing.assert_equal(log_j, 0.0)
 

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -22,8 +22,8 @@ rtol = 1e-15
 
 
 @pytest.fixture
-def reparam():
-    return create_autospec(RescaleToBounds)
+def reparam(rng):
+    return create_autospec(RescaleToBounds, rng=rng)
 
 
 @pytest.fixture()
@@ -677,9 +677,10 @@ def test_apply_inversion_split(reparam):
     x_prime = numpy_array_to_live_points(x_val, ["x_prime"])
     x = numpy_array_to_live_points(np.array([3, 4]), ["x"])
     log_j = np.zeros(2)
+    reparam.rng = MagicMock()
+    reparam.rng.choice.return_value = np.array([1])
 
     with (
-        patch("numpy.random.choice", return_value=np.array([1])) as rnd,
         patch(
             "nessai.reparameterisations.rescale.rescale_zero_to_one",
             side_effect=lambda x, *args: (x, np.array([5, 6])),
@@ -695,7 +696,7 @@ def test_apply_inversion_split(reparam):
             False,
         )
 
-    rnd.assert_called_once_with(2, 1, replace=False)
+    reparam.rng.choice.assert_called_once_with(2, 1, replace=False)
     assert f.call_args_list[0][0][1] == 0.0
     assert f.call_args_list[0][0][2] == 5.0
     # Output should be x_val minus offset

--- a/tests/test_reparameterisations/test_to_cartesian.py
+++ b/tests/test_reparameterisations/test_to_cartesian.py
@@ -14,8 +14,8 @@ from nessai.utils.testing import assert_structured_arrays_equal
 
 
 @pytest.fixture
-def reparam():
-    return create_autospec(ToCartesian)
+def reparam(rng):
+    return create_autospec(ToCartesian, rng=rng)
 
 
 @pytest.fixture

--- a/tests/test_samplers/test_importance_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_importance_nested_sampler/conftest.py
@@ -19,12 +19,13 @@ def iid(request):
 
 
 @pytest.fixture
-def ins():
+def ins(rng):
     obj = create_autospec(ImportanceNestedSampler)
     obj.model = create_autospec(Model)
     obj.training_samples = create_autospec(OrderedSamples)
     obj.training_samples.state = create_autospec(_INSIntegralState)
     obj.iid_samples = None
+    obj.rng = rng
     return obj
 
 

--- a/tests/test_samplers/test_importance_nested_sampler/test_config.py
+++ b/tests/test_samplers/test_importance_nested_sampler/test_config.py
@@ -12,6 +12,8 @@ from nessai.samplers.importancesampler import ImportanceNestedSampler as INS
 
 @pytest.mark.parametrize("save_log_q", [False, True])
 def test_init(ins, model, save_log_q):
+    ins.rng = None
+    model.rng = None
     ins.add_fields = MagicMock()
     INS.__init__(ins, model, save_log_q=save_log_q, draw_iid_live=True)
     ins.add_fields.assert_called_once()

--- a/tests/test_samplers/test_nested_sampler/conftest.py
+++ b/tests/test_samplers/test_nested_sampler/conftest.py
@@ -6,9 +6,10 @@ from nessai.samplers.nestedsampler import NestedSampler
 
 
 @pytest.fixture(scope="function")
-def sampler(model):
+def sampler(model, rng):
     s = create_autospec(NestedSampler)
     s.nlive = 100
     s.model = model
     s.store_live_points = False
+    s.rng = rng
     return s

--- a/tests/test_samplers/test_nested_sampler/test_general_config.py
+++ b/tests/test_samplers/test_nested_sampler/test_general_config.py
@@ -133,3 +133,19 @@ def test_training_frequency_on_empty(sampler, f):
     """Test the values that should give 'train on empty'"""
     NestedSampler.configure_training_frequency(sampler, f)
     assert sampler.training_frequency == np.inf
+
+
+def test_initialise_history(sampler):
+    sampler.history = None
+
+    def fn():
+        sampler.history = {"acceptance": []}
+
+    with patch(
+        "nessai.samplers.nestedsampler.BaseNestedSampler.initialise_history",
+        side_effect=fn,
+    ) as mock_parent:
+        NestedSampler.initialise_history(sampler)
+
+    mock_parent.assert_called_once()
+    assert "rolling_p" in sampler.history

--- a/tests/test_samplers/test_nested_sampler/test_proposal_config.py
+++ b/tests/test_samplers/test_nested_sampler/test_proposal_config.py
@@ -111,9 +111,10 @@ def test_uninformed_proposal_class(sampler):
         sampler, TestProposal, False, None, None
     )
     assert isinstance(sampler._uninformed_proposal, TestProposal)
+    assert sampler._uninformed_proposal.rng is sampler.rng
 
 
-def test_configure_flow_proposal(sampler):
+def test_configure_flow_proposal(sampler, rng):
     fake_class = MagicMock()
     fake_class.__name__ = "fake_class"
     flow_config = dict(patience=10)
@@ -145,6 +146,7 @@ def test_configure_flow_proposal(sampler):
         flow_config=flow_config,
         output=os.path.join(sampler.output, "proposal", ""),
         plot=False,
+        rng=rng,
         **expected_kwargs,
     )
 

--- a/tests/test_samplers/test_nested_sampler/test_resume.py
+++ b/tests/test_samplers/test_nested_sampler/test_resume.py
@@ -12,10 +12,10 @@ from nessai.samplers.nestedsampler import NestedSampler
 
 
 @pytest.fixture
-def complete_sampler(model, tmpdir):
+def complete_sampler(integration_model, tmpdir):
     """Complete instance of NestedSampler"""
     output = tmpdir.mkdir("output")
-    ns = NestedSampler(model, output=output, poolsize=10)
+    ns = NestedSampler(integration_model, output=output, poolsize=10)
     ns.initialise()
     return ns
 

--- a/tests/test_sampling/test_ins_sampling.py
+++ b/tests/test_sampling/test_ins_sampling.py
@@ -12,11 +12,11 @@ from nessai.flowsampler import FlowSampler
 @pytest.mark.slow_integration_test
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("save_log_q", [False, True])
-def test_ins_resume(tmp_path, model, flow_config, save_log_q):
+def test_ins_resume(tmp_path, integration_model, flow_config, save_log_q):
     """Assert the INS sampler resumes correctly"""
     output = tmp_path / "test_ins_resume"
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=500,
@@ -34,8 +34,10 @@ def test_ins_resume(tmp_path, model, flow_config, save_log_q):
     assert fp.ns.iteration == 2
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
+    integration_model.rng = None
+
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -50,7 +52,7 @@ def test_ins_resume(tmp_path, model, flow_config, save_log_q):
 
 
 @pytest.mark.slow_integration_test
-def test_ins_checkpoint_callback(tmp_path, model, flow_config):
+def test_ins_checkpoint_callback(tmp_path, integration_model, flow_config):
     output = tmp_path / "test_ins_checkpoint_callback"
 
     filename = os.path.join(output, "test.pkl")
@@ -61,7 +63,7 @@ def test_ins_checkpoint_callback(tmp_path, model, flow_config):
             pickle.dump(state, f)
 
     fs = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=500,
@@ -87,8 +89,10 @@ def test_ins_checkpoint_callback(tmp_path, model, flow_config):
 
     resume_data.test_variable = "abc"
 
+    integration_model.rng = None
+
     fs = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=500,

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -54,13 +54,14 @@ def test_sampling_with_reparameterisation(
     assert fp.ns.proposal.training_count == 1
 
 
-def test_sampling_regex_reparams(model, flow_config, tmp_path):
+@pytest.mark.integration_test
+def test_sampling_regex_reparams(integration_model, flow_config, tmp_path):
     """Test using regex to specify reparameterisations"""
-    model._names = ["x_0", "x_1"]
-    model._bounds = {"x_0": [-5, 5], "x_1": [-5, 5]}
+    integration_model._names = ["x_0", "x_1"]
+    integration_model._bounds = {"x_0": [-5, 5], "x_1": [-5, 5]}
 
     fs = FlowSampler(
-        model,
+        integration_model,
         nlive=100,
         output=tmp_path / "test_regex",
         flow_config=flow_config,
@@ -194,13 +195,13 @@ def test_sampling_with_n_pool(
 
 
 @pytest.mark.slow_integration_test
-def test_sampling_resume(model, flow_config, tmpdir):
+def test_sampling_resume(integration_model, flow_config, tmpdir):
     """
     Test resuming the sampler.
     """
     output = str(tmpdir.mkdir("resume"))
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=100,
@@ -217,8 +218,10 @@ def test_sampling_resume(model, flow_config, tmpdir):
     fp.run()
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
+    integration_model.rng = None
+
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -339,7 +342,9 @@ def test_sampling_resume_no_max_uninformed(
 
 
 @pytest.mark.slow_integration_test
-def test_resume_fallback_reparameterisation(tmpdir, model, flow_config):
+def test_resume_fallback_reparameterisation(
+    tmpdir, integration_model, flow_config
+):
     """
     Test resuming the sampler with the default reparameterisations disabled
     and the fallback set.
@@ -350,7 +355,7 @@ def test_resume_fallback_reparameterisation(tmpdir, model, flow_config):
 
     output = str(tmpdir.mkdir("resume"))
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=100,
@@ -373,8 +378,10 @@ def test_resume_fallback_reparameterisation(tmpdir, model, flow_config):
     assert isinstance(reparam, ScaleAndShift)
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
+    integration_model.rng = None
+
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -391,7 +398,9 @@ def test_resume_fallback_reparameterisation(tmpdir, model, flow_config):
 
 
 @pytest.mark.slow_integration_test
-def test_resume_reparameterisation_values(tmpdir, model, flow_config):
+def test_resume_reparameterisation_values(
+    tmpdir, integration_model, flow_config
+):
     """
     Assert the scale and shift values are correct.
     """
@@ -399,7 +408,7 @@ def test_resume_reparameterisation_values(tmpdir, model, flow_config):
 
     output = str(tmpdir.mkdir("resume"))
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=100,
@@ -423,8 +432,10 @@ def test_resume_reparameterisation_values(tmpdir, model, flow_config):
     original_shift = reparam.shift
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
+    integration_model.rng = None
+
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -443,13 +454,13 @@ def test_resume_reparameterisation_values(tmpdir, model, flow_config):
 
 
 @pytest.mark.slow_integration_test
-def test_sampling_resume_move_files(model, flow_config, tmp_path):
+def test_sampling_resume_move_files(integration_model, flow_config, tmp_path):
     """
     Test resuming the sampler after moving the resume files.
     """
     output = tmp_path / "resume"
     fp = FlowSampler(
-        model,
+        integration_model,
         output=output,
         resume=True,
         nlive=100,
@@ -471,8 +482,10 @@ def test_sampling_resume_move_files(model, flow_config, tmp_path):
     shutil.move(output, new_output)
     assert not os.path.exists(output)
 
+    integration_model.rng = None
+
     fp = FlowSampler(
-        model,
+        integration_model,
         output=new_output,
         resume=True,
         flow_config=flow_config,

--- a/tests/test_utils/test_testing_utils.py
+++ b/tests/test_utils/test_testing_utils.py
@@ -13,9 +13,10 @@ from nessai.utils.testing import (
 
 @pytest.mark.parametrize("n", [1, 10])
 @pytest.mark.parametrize("dims", [2, 4])
-def test_integration_test_model(n, dims):
+def test_integration_test_model(n, dims, rng):
     """Assert the model is valid"""
     model = IntegrationTestModel(dims)
+    model.set_rng(rng)
     model.verify_model()
     x = model.new_point(n)
     log_p = model.log_prior(x)


### PR DESCRIPTION
I decided to bite the bullet and migrated the RNG to the new generator format in numpy.

I chose to pass an `rng` object around rather than have a global object.

At the moment, the only issue I can see is what happens in the RNG object in an instance of a model is called in a pool. Given we only call the log-likelihood and log-prior in the pool, this should be okay but it might be something to think about in future