### PR TITLE
BUG: set model RNG when resuming

### DIFF
--- a/src/nessai/samplers/base.py
+++ b/src/nessai/samplers/base.py
@@ -396,6 +396,7 @@ class BaseNestedSampler(ABC):
         Instance of BaseNestedSampler
         """
         logger.info(f"Resuming instance of {cls.__name__}")
+        model.set_rng(sampler.rng)
         model.likelihood_evaluations += (
             sampler._previous_likelihood_evaluations
         )

--- a/src/nessai/samplers/base.py
+++ b/src/nessai/samplers/base.py
@@ -396,7 +396,8 @@ class BaseNestedSampler(ABC):
         Instance of BaseNestedSampler
         """
         logger.info(f"Resuming instance of {cls.__name__}")
-        model.set_rng(sampler.rng)
+        if model.rng is None:
+            model.set_rng(sampler.rng)
         model.likelihood_evaluations += (
             sampler._previous_likelihood_evaluations
         )

--- a/tests/test_samplers/test_base_sampler.py
+++ b/tests/test_samplers/test_base_sampler.py
@@ -470,14 +470,17 @@ def test_close_pool(sampler):
 
 
 @pytest.mark.parametrize("output", [None, "orig", "new"])
-def test_resume_from_pickled_sampler(model, output):
+def test_resume_from_pickled_sampler(model, output, rng):
     """Test the resume from pickled sampler method"""
     obj = MagicMock()
     obj.model = None
     obj.output = "orig"
+    obj.rng = rng
     obj._previous_likelihood_evaluations = 3
     obj._previous_likelihood_evaluation_time = 4.0
 
+    model.rng = None
+    model.set_rng = MagicMock()
     model.likelihood_evaluations = 1
     model.likelihood_evaluation_time = datetime.timedelta(seconds=2)
 
@@ -488,6 +491,7 @@ def test_resume_from_pickled_sampler(model, output):
     assert out.model == model
     assert out.model.likelihood_evaluations == 4
     assert out.model.likelihood_evaluation_time.total_seconds() == 6
+    model.set_rng.assert_called_once_with(rng)
 
     if output == "new":
         obj.update_output.assert_called_once_with("new")

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -218,10 +218,11 @@ def test_sampling_resume(integration_model, flow_config, tmpdir):
     fp.run()
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
-    integration_model.rng = None
+    # Use a new instance of the integration model to emulate a new run
+    new_integration_model = IntegrationTestModel()
 
     fp = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -272,6 +273,8 @@ def test_sampling_resume_w_pool(
     # Make sure the pool is already closed
     integration_model.close_pool()
 
+    new_integration_model = IntegrationTestModel()
+
     with (
         patch("multiprocessing.Pool", mp_context.Pool),
         patch(
@@ -280,7 +283,7 @@ def test_sampling_resume_w_pool(
         ),
     ):
         fp = FlowSampler(
-            integration_model,
+            new_integration_model,
             output=output,
             resume=True,
             flow_config=flow_config,
@@ -326,8 +329,13 @@ def test_sampling_resume_no_max_uninformed(
     fp.run()
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
+    new_integration_model = IntegrationTestModel()
+
     fp = FlowSampler(
-        integration_model, output=output, resume=True, flow_config=flow_config
+        new_integration_model,
+        output=output,
+        resume=True,
+        flow_config=flow_config,
     )
     assert fp.ns.iteration == 11
     fp.ns.maximum_uninformed = np.inf
@@ -378,10 +386,10 @@ def test_resume_fallback_reparameterisation(
     assert isinstance(reparam, ScaleAndShift)
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
-    integration_model.rng = None
+    new_integration_model = IntegrationTestModel()
 
     fp = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -432,10 +440,10 @@ def test_resume_reparameterisation_values(
     original_shift = reparam.shift
     assert os.path.exists(os.path.join(output, "nested_sampler_resume.pkl"))
 
-    integration_model.rng = None
+    new_integration_model = IntegrationTestModel()
 
     fp = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=output,
         resume=True,
         flow_config=flow_config,
@@ -482,10 +490,10 @@ def test_sampling_resume_move_files(integration_model, flow_config, tmp_path):
     shutil.move(output, new_output)
     assert not os.path.exists(output)
 
-    integration_model.rng = None
+    new_integration_model = IntegrationTestModel()
 
     fp = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=new_output,
         resume=True,
         flow_config=flow_config,
@@ -618,8 +626,10 @@ def test_sampling_resume_finalised(integration_model, tmp_path):
     assert fs.ns.live_points is None
     assert os.path.exists(fs.ns.resume_file)
 
+    new_integration_model = IntegrationTestModel()
+
     fs = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=output,
         nlive=100,
         plot=False,
@@ -787,8 +797,10 @@ def test_sampling_with_checkpoint_callback(integration_model, tmp_path):
     with open(checkpoint_file, "rb") as f:
         resume_data = pickle.load(f)
 
+    new_integration_model = IntegrationTestModel()
+
     fs = FlowSampler(
-        integration_model,
+        new_integration_model,
         output=output,
         nlive=100,
         plot=False,


### PR DESCRIPTION
The RNG for the model should be set when resuming.

The tests don't identify this because the model isn't reset and the RNG is therefore not called.