### PR TITLE
BUG: fix AugmentedFlowproposal

### DIFF
--- a/src/nessai/proposal/augmented.py
+++ b/src/nessai/proposal/augmented.py
@@ -240,7 +240,7 @@ class AugmentedFlowProposal(FlowProposal):
                 f"Error: {e}"
             )
             if return_z:
-                return np.array([]), np.array([]), np.array
+                return np.array([]), np.array([]), np.array([])
             else:
                 return np.array([]), np.array([])
 

--- a/tests/test_proposal/test_augmented.py
+++ b/tests/test_proposal/test_augmented.py
@@ -122,17 +122,24 @@ def test_rescaling_generate_unknown(proposal, x):
 
 
 @pytest.mark.parametrize("marg", [False, True])
-@patch("scipy.stats.norm.logpdf")
-def test_augmented_prior(mock, marg, proposal, x):
+def test_augmented_prior(marg, proposal, x):
     """Test the augmented prior with and without marginalistion"""
+    log_prob = np.ones(len(x))
     proposal.marginalise_augment = marg
+    proposal.augment_dist = MagicMock()
+    proposal.augment_dist.logpdf = MagicMock(return_value=log_prob)
     proposal.augment_parameters = ["e_1", "e_2"]
-    log_prior = AugmentedFlowProposal.augmented_prior(proposal, x)
+    out = AugmentedFlowProposal.augmented_prior(proposal, x)
     if marg:
-        assert log_prior == 0
+        np.testing.assert_array_equal(np.zeros(len(x)), out)
+        proposal.augment_dist.logpdf.assert_not_called()
     else:
-        np.testing.assert_array_equal(x["e_1"], mock.call_args_list[0][0][0])
-        np.testing.assert_array_equal(x["e_2"], mock.call_args_list[1][0][0])
+        assert out is log_prob
+        proposal.augment_dist.logpdf.assert_called_once()
+        np.testing.assert_array_equal(
+            np.array([x["e_1"], x["e_2"]]).T,
+            proposal.augment_dist.logpdf.call_args_list[0][0][0],
+        )
 
 
 @patch("nessai.proposal.flowproposal.FlowProposal.log_prior", return_value=1)
@@ -186,11 +193,13 @@ def test_backward_pass(proposal, model, log_p, marg, rng):
     z = rng.standard_normal((n, model.dims))
     proposal._marginalise_augment = MagicMock(return_value=log_p)
     proposal.inverse_rescale = MagicMock(
-        side_effect=lambda a: (a, np.ones(a.size))
+        side_effect=lambda a, return_unit_hypercube: (a, np.ones(a.size))
     )
     proposal.prime_parameters = model.names
     proposal.alt_dist = None
-    proposal.check_prior_bounds = MagicMock(side_effect=lambda a, b: (a, b))
+    proposal.check_prior_bounds = MagicMock(
+        side_effect=lambda a, b, c: (a, b, c)
+    )
     proposal.flow = MagicMock()
     proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
 

--- a/tests/test_proposal/test_augmented.py
+++ b/tests/test_proposal/test_augmented.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, create_autospec, patch
 import numpy as np
 import pytest
 
-from nessai.livepoint import numpy_array_to_live_points
+from nessai.livepoint import empty_structured_array, numpy_array_to_live_points
 from nessai.proposal import AugmentedFlowProposal
 
 
@@ -21,6 +21,14 @@ def x(rng):
         [rng.standard_normal((10, 2)), rng.standard_normal((10, 2))], axis=1
     )
     return numpy_array_to_live_points(_x, ["x", "y", "e_1", "e_2"])
+
+
+@pytest.fixture
+def x_prime(rng):
+    _x = np.concatenate(
+        [rng.standard_normal((10, 2)), rng.standard_normal((10, 2))], axis=1
+    )
+    return numpy_array_to_live_points(_x, ["x_prime", "y_prime", "e_1", "e_2"])
 
 
 def test_init(model):
@@ -121,6 +129,34 @@ def test_rescaling_generate_unknown(proposal, x):
     assert "Unknown method" in str(excinfo.value)
 
 
+def test_inverse_rescale(proposal, x_prime):
+    proposal.augment_parameters = ["e_1", "e_2"]
+    x = empty_structured_array(len(x_prime), ["x", "y", "e_1", "e_2"])
+    x["x"] = x_prime["x_prime"].copy()
+    x["y"] = x_prime["y_prime"].copy()
+    proposal._base_inverse_rescale = MagicMock(
+        return_value=[x, np.ones(x.size)]
+    )
+    x, log_J = AugmentedFlowProposal._augmented_inverse_rescale(
+        proposal, x_prime
+    )
+    proposal._base_inverse_rescale.assert_called_once_with(
+        x_prime, return_unit_hypercube=False
+    )
+    np.testing.assert_array_equal(x["e_1"], x_prime["e_1"])
+    np.testing.assert_array_equal(x["e_2"], x_prime["e_2"])
+
+
+def test_inverse_rescale_hypercube_error(proposal, x_prime):
+    with pytest.raises(
+        RuntimeError,
+        match="Inverse rescaling with augmented parameters is not supported",
+    ):
+        AugmentedFlowProposal._augmented_inverse_rescale(
+            proposal, x_prime, True
+        )
+
+
 @pytest.mark.parametrize("marg", [False, True])
 def test_augmented_prior(marg, proposal, x):
     """Test the augmented prior with and without marginalistion"""
@@ -185,7 +221,8 @@ def test_marginalise_augment(proposal, rng):
 
 @pytest.mark.parametrize("log_p", [np.ones(2), np.array([-1, np.inf])])
 @pytest.mark.parametrize("marg", [False, True])
-def test_backward_pass(proposal, model, log_p, marg, rng):
+@pytest.mark.parametrize("return_z", [False, True])
+def test_backward_pass(proposal, model, log_p, marg, rng, return_z):
     """Test the backward pass method"""
     n = 2
     acc = int(np.isfinite(log_p).sum())
@@ -205,15 +242,34 @@ def test_backward_pass(proposal, model, log_p, marg, rng):
 
     proposal.marginalise_augment = marg
 
-    x_out, log_p = AugmentedFlowProposal.backward_pass(proposal, z)
+    out = AugmentedFlowProposal.backward_pass(proposal, z, return_z=return_z)
 
-    assert len(x_out) == acc
+    if return_z:
+        assert len(out) == 3
+    else:
+        assert len(out) == 2
+
+    assert len(out[0]) == acc
     proposal.inverse_rescale.assert_called_once()
     proposal.flow.sample_and_log_prob.assert_called_once_with(
         z=z, alt_dist=None
     )
 
     assert proposal._marginalise_augment.called is marg
+
+
+@pytest.mark.parametrize("return_z", [False, True])
+def test_backward_pass_assertion_error(proposal, return_z):
+    proposal.flow = MagicMock()
+    proposal.flow.sample_and_log_prob = MagicMock(side_effect=AssertionError)
+    z = np.ones((10, 2))
+    out = AugmentedFlowProposal.backward_pass(proposal, z, return_z=return_z)
+    if return_z:
+        assert len(out) == 3
+    else:
+        assert len(out) == 2
+    for a in out:
+        assert len(a) == 0
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
`AugmentedFlowproposal` was broken after the reparametrisation changes; the augment parameters were not being included in the inverse rescaling. This PR fixes that and also updates the `backward_pass` method to handle new keyword arguments that have been added.

Closes https://github.com/mj-will/nessai/issues/421