### PR TITLE
MAINT: logging tweaks

### DIFF
--- a/examples/2d_gaussian.py
+++ b/examples/2d_gaussian.py
@@ -7,13 +7,13 @@ from scipy.stats import norm
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 # Setup the logger - credit to the Bilby team for this neat function!
 # see: https://git.ligo.org/lscsoft/bilby
 
 output = "./outdir/2d_gaussian_example/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 # Define the model, in this case we use a simple 2D gaussian
 # The model must contain names for each of the parameters and their bounds

--- a/examples/augmented_example.py
+++ b/examples/augmented_example.py
@@ -8,10 +8,10 @@ from scipy.stats import norm
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/augmented_example/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output, log_level="DEBUG")
 
 
 class MultimodalModel(Model):

--- a/examples/bilby_example.py
+++ b/examples/bilby_example.py
@@ -13,7 +13,7 @@ outdir = "./outdir/"
 label = "bilby_example"
 
 # Setup the bilby logger this will also configure the nessai logger.
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 # Define a likelihood using Bilby
 

--- a/examples/bilby_unbounded_priors.py
+++ b/examples/bilby_unbounded_priors.py
@@ -10,7 +10,7 @@ outdir = "./outdir/"
 label = "bilby_unbounded_priors"
 
 # Setup the bilby logger
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 # Define a likelihood using Bilby
 

--- a/examples/corner_plot_example.py
+++ b/examples/corner_plot_example.py
@@ -14,10 +14,10 @@ import numpy as np
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
 from nessai.plot import corner_plot
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/corner_plot_example/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 # Generate the data

--- a/examples/discrete_parameter.py
+++ b/examples/discrete_parameter.py
@@ -7,11 +7,11 @@ import numpy as np
 from nessai.flowsampler import FlowSampler
 from nessai.livepoint import empty_structured_array
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 # Configure the output directory and logger
 output = "./outdir/discrete_example/"
-logger = setup_logger(output=output, log_level="INFO")
+logger = configure_logger(output=output, log_level="INFO")
 
 # Set the random number generator
 rng = np.random.default_rng(1234)

--- a/examples/eggbox.py
+++ b/examples/eggbox.py
@@ -9,10 +9,10 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/eggbox/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 class EggboxModel(Model):

--- a/examples/gw/basic_gw_example.py
+++ b/examples/gw/basic_gw_example.py
@@ -12,7 +12,7 @@ import bilby
 outdir = "./outdir/"
 label = "basic_gw_example"
 
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 duration = 4.0
 sampling_frequency = 2048.0

--- a/examples/gw/calibration_example.py
+++ b/examples/gw/calibration_example.py
@@ -16,7 +16,7 @@ sampling_frequency = 2048.0
 
 outdir = "./outdir/"
 label = "calibration_example"
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 bilby.core.utils.random.seed(150914)
 

--- a/examples/gw/full_gw_example.py
+++ b/examples/gw/full_gw_example.py
@@ -13,7 +13,7 @@ import bilby
 outdir = "./outdir/"
 label = "full_gw_example"
 
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 duration = 4.0
 sampling_frequency = 2048.0

--- a/examples/gw/ins_gw_example.py
+++ b/examples/gw/ins_gw_example.py
@@ -13,7 +13,7 @@ import bilby
 outdir = "./outdir/"
 label = "ins_gw_example_full"
 
-bilby.core.utils.setup_logger(outdir=outdir, label=label)
+bilby.core.utils.configure_logger(outdir=outdir, label=label)
 
 duration = 4.0
 sampling_frequency = 2048.0

--- a/examples/half_gaussian.py
+++ b/examples/half_gaussian.py
@@ -8,10 +8,10 @@ from scipy.stats import norm
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/half_gaussian/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 class HalfGaussian(Model):

--- a/examples/importance_nested_sampler/basic_ins_example.py
+++ b/examples/importance_nested_sampler/basic_ins_example.py
@@ -8,10 +8,10 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = os.path.join("outdir", "basic_ins_example")
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 # Define the model. For the importance nested sampler we must define mappings
 # to and from the unit hyper-cube.

--- a/examples/importance_nested_sampler/hypercube_prior.py
+++ b/examples/importance_nested_sampler/hypercube_prior.py
@@ -11,10 +11,10 @@ from scipy.stats import norm, truncnorm
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
 from nessai.plot import corner_plot
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = os.path.join("outdir", "ins_non_uniform_prior")
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 class ModelWithNonUniformPrior(Model):

--- a/examples/importance_nested_sampler/nsf_unit_hypercube.py
+++ b/examples/importance_nested_sampler/nsf_unit_hypercube.py
@@ -11,10 +11,10 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = os.path.join("outdir", "nsf_unit_hypercube")
-logger = setup_logger(output=output, log_level="INFO")
+logger = configure_logger(output=output, log_level="INFO")
 
 # Define the model. For the importance nested sampler we must define mappings
 # to and from the unit hyper-cube.

--- a/examples/mcmc_example.py
+++ b/examples/mcmc_example.py
@@ -6,10 +6,10 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
-output = "./outdir/mcmc_example/"
-logger = setup_logger(output=output)
+output = "./outdir/mcmc_example_cvm_8d_flow_act/"
+logger = configure_logger(output=output)
 
 
 class RosenbrockModel(Model):
@@ -52,12 +52,16 @@ fs = FlowSampler(
     resume=False,
     seed=1234,
     flow_proposal_class="mcmcflowproposal",
-    n_accept=10,
-    n_steps=500,
-    reset_flow=4,
+    plot_history=True,
+    plot_chain=False,
+    step_type="diff",
+    enforce_likelihood_threshold=True,
+    # constant_volume_fraction=0.98,
+    n_steps=5000,
+    reset_flow=16,
     flow_config=dict(
         n_neurons=32,
-        n_blocks=6,
+        n_blocks=8,
         n_layers=2,
         batch_norm_between_layers=True,
         linear_transform=None,

--- a/examples/parallelisation_example.py
+++ b/examples/parallelisation_example.py
@@ -13,11 +13,11 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 from nessai.utils.multiprocessing import initialise_pool_variables
 
 output = "./outdir/parallelisation_example/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 # Generate the data

--- a/examples/reparameterisations_example.py
+++ b/examples/reparameterisations_example.py
@@ -8,10 +8,10 @@ from scipy.stats import norm
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/reparameterisations_example/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 
 
 class HalfGaussian(Model):

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -7,10 +7,10 @@ import numpy as np
 
 from nessai.flowsampler import FlowSampler
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/rosenbrock/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output, include_logger_name=True)
 
 
 class RosenbrockModel(Model):

--- a/examples/unbounded_prior.py
+++ b/examples/unbounded_prior.py
@@ -8,10 +8,10 @@ from scipy.stats import norm
 from nessai.flowsampler import FlowSampler
 from nessai.livepoint import dict_to_live_points
 from nessai.model import Model
-from nessai.utils import setup_logger
+from nessai.utils import configure_logger
 
 output = "./outdir/unbounded_prior/"
-logger = setup_logger(output=output)
+logger = configure_logger(output=output)
 rng = np.random.default_rng(1234)
 
 # We define the model as usual but also need to redefine `new_point` since by

--- a/src/nessai/utils/__init__.py
+++ b/src/nessai/utils/__init__.py
@@ -15,7 +15,7 @@ from .io import (
     save_live_points,
     save_to_json,
 )
-from .logging import setup_logger
+from .logging import configure_logger
 from .rescaling import (
     configure_edge_detection,
     detect_edge,
@@ -50,6 +50,7 @@ __all__ = [
     "compute_minimum_distances",
     "compute_radius",
     "configure_edge_detection",
+    "configure_logger",
     "configure_threads",
     "detect_edge",
     "determine_rescaled_bounds",
@@ -79,7 +80,6 @@ __all__ = [
     "save_dict_to_hdf5",
     "save_live_points",
     "save_to_json",
-    "setup_logger",
     "sigmoid",
     "spatial",
     "structures",

--- a/src/nessai/utils/__init__.py
+++ b/src/nessai/utils/__init__.py
@@ -15,7 +15,7 @@ from .io import (
     save_live_points,
     save_to_json,
 )
-from .logging import configure_logger
+from .logging import configure_logger, setup_logger
 from .rescaling import (
     configure_edge_detection,
     detect_edge,
@@ -80,6 +80,7 @@ __all__ = [
     "save_dict_to_hdf5",
     "save_live_points",
     "save_to_json",
+    "setup_logger",
     "sigmoid",
     "spatial",
     "structures",

--- a/src/nessai/utils/logging.py
+++ b/src/nessai/utils/logging.py
@@ -8,18 +8,25 @@ import os
 import sys
 
 
-def setup_logger(
+def configure_logger(
     output=None,
     label="nessai",
     log_level="INFO",
     filehandler_kwargs=None,
+    include_logger_name=False,
     stream=None,
 ):
     """
-    Setup the logger.
+    Configure the logger.
 
     Based on the implementation in Bilby:
-    https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/core/utils/log.py
+    https://github.com/bilby-dev/bilby/blob/main/bilby/core/utils/log.py
+
+    .. versionchanged:: 0.14.0
+        Renamed :code:`setup_logger` to :code:`configure_logger`.
+
+    .. versionadded:: 0.14.0
+        Added :code:`include_logger_name` argument.
 
     Parameters
     ----------
@@ -32,6 +39,9 @@ def setup_logger(
     filehandler_kwargs : dict, optional
         Keyword arguments for configuring the FileHandler. See logging
         documentation for details.
+    include_logger_name : bool, optional
+        If true, include the logger name in the log output. If false, only
+        the name will be replaced with 'nessai'.
     stream : str, file-object, optional
         Stream passes to :code:`logging.StreamHandler` to set the stream. See
         logging documentation for more details.
@@ -68,12 +78,19 @@ def setup_logger(
                     f"Unknown stream: {stream}. Choose from: [stderr, stdout]"
                 )
         stream_handler = logging.StreamHandler(stream)
-        stream_handler.setFormatter(
-            logging.Formatter(
+
+        if include_logger_name:
+            formatter = logging.Formatter(
                 "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
                 datefmt="%m-%d %H:%M",
             )
-        )
+        else:
+            formatter = logging.Formatter(
+                "%(asctime)s nessai %(levelname)-8s: %(message)s",
+                datefmt="%m-%d %H:%M",
+            )
+
+        stream_handler.setFormatter(formatter)
         stream_handler.setLevel(level)
         logger.addHandler(stream_handler)
 
@@ -106,3 +123,19 @@ def setup_logger(
     logger.info(f"Running Nessai version {version}")
 
     return logger
+
+
+def setup_logger(*args, **kwargs):
+    """
+    Wrapper for configure_logger to maintain backwards compatibility.
+
+    .. deprecated:: 0.14.0
+        Use :func:`configure_logger` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "setup_logger is deprecated, use configure_logger instead",
+        DeprecationWarning,
+    )
+    return configure_logger(*args, **kwargs)

--- a/src/nessai/utils/logging.py
+++ b/src/nessai/utils/logging.py
@@ -132,6 +132,6 @@ def setup_logger(*args, **kwargs):
 
     warnings.warn(
         "setup_logger is deprecated, use configure_logger instead",
-        DeprecationWarning,
+        FutureWarning,
     )
     return configure_logger(*args, **kwargs)

--- a/src/nessai/utils/logging.py
+++ b/src/nessai/utils/logging.py
@@ -64,6 +64,17 @@ def configure_logger(
     logger = logging.getLogger("nessai")
     logger.setLevel(level)
 
+    if include_logger_name:
+        formatter = logging.Formatter(
+            "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
+            datefmt="%m-%d %H:%M",
+        )
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s nessai %(levelname)-8s: %(message)s",
+            datefmt="%m-%d %H:%M",
+        )
+
     if (
         any([isinstance(h, logging.StreamHandler) for h in logger.handlers])
         is False
@@ -78,17 +89,6 @@ def configure_logger(
                     f"Unknown stream: {stream}. Choose from: [stderr, stdout]"
                 )
         stream_handler = logging.StreamHandler(stream)
-
-        if include_logger_name:
-            formatter = logging.Formatter(
-                "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
-                datefmt="%m-%d %H:%M",
-            )
-        else:
-            formatter = logging.Formatter(
-                "%(asctime)s nessai %(levelname)-8s: %(message)s",
-                datefmt="%m-%d %H:%M",
-            )
 
         stream_handler.setFormatter(formatter)
         stream_handler.setLevel(level)
@@ -108,11 +108,7 @@ def configure_logger(
             if filehandler_kwargs is None:
                 filehandler_kwargs = {}
             file_handler = logging.FileHandler(log_file, **filehandler_kwargs)
-            file_handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s %(levelname)-8s: %(message)s", datefmt="%H:%M"
-                )
-            )
+            file_handler.setFormatter(formatter)
 
             file_handler.setLevel(level)
             logger.addHandler(file_handler)

--- a/src/nessai/utils/logging.py
+++ b/src/nessai/utils/logging.py
@@ -103,7 +103,7 @@ def configure_logger(
                 if not os.path.exists(output):
                     os.makedirs(output, exist_ok=True)
             else:
-                output = "."
+                output = os.getcwd()
             log_file = os.path.join(output, f"{label}.log")
             if filehandler_kwargs is None:
                 filehandler_kwargs = {}

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -80,7 +80,14 @@ def test_configure_random_seed_warning():
 
 
 def test_setup_logger_deprecation():
+    import logging
+
     from nessai.utils.logging import setup_logger
 
     with pytest.warns(FutureWarning, match=r"deprecated"):
-        setup_logger()
+        setup_logger(label=None)
+
+    # Reset the logger
+    logger = logging.getLogger("nessai")
+    logger.handlers = []
+    logger.addHandler(logging.NullHandler())

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -77,3 +77,10 @@ def test_configure_random_seed_warning():
         FutureWarning, match=r"`configure_random_seed` is deprecated"
     ):
         BaseNestedSampler.configure_random_seed(sampler, seed=0)
+
+
+def test_setup_logger_deprecation():
+    from nessai.utils.logging import setup_logger
+
+    with pytest.warns(FutureWarning, match=r"deprecated"):
+        setup_logger()

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -79,15 +79,9 @@ def test_configure_random_seed_warning():
         BaseNestedSampler.configure_random_seed(sampler, seed=0)
 
 
+@pytest.mark.reset_logger
 def test_setup_logger_deprecation():
-    import logging
-
     from nessai.utils.logging import setup_logger
 
     with pytest.warns(FutureWarning, match=r"deprecated"):
         setup_logger(label=None)
-
-    # Reset the logger
-    logger = logging.getLogger("nessai")
-    logger.handlers = []
-    logger.addHandler(logging.NullHandler())

--- a/tests/test_utils/test_logging_utils.py
+++ b/tests/test_utils/test_logging_utils.py
@@ -44,13 +44,13 @@ def test_configure_logger_with_label(tmp_path, output):
     if output:
         output = tmp_path / output
         output.mkdir()
-    logger = configure_logger(label="test", output=output)
+    with patch("os.getcwd", return_value=tmp_path):
+        logger = configure_logger(label="test", output=output)
     if output is None:
-        output = os.getcwd()
+        output = tmp_path
     log_path = os.path.join(output, "test.log")
     assert os.path.exists(log_path)
     assert any([isinstance(h, logging.FileHandler) for h in logger.handlers])
-    os.remove(log_path)
 
 
 @pytest.mark.reset_logger

--- a/tests/test_utils/test_logging_utils.py
+++ b/tests/test_utils/test_logging_utils.py
@@ -3,6 +3,7 @@
 Test utilities related to logging.
 """
 
+import glob
 import logging
 import os
 import sys
@@ -13,34 +14,27 @@ import pytest
 from nessai.utils.logging import configure_logger
 
 
-def teardown_function():
-    """Reset the logger after each test"""
-    logger = logging.getLogger("nessai")
-    logger.handlers = []
-    logger.addHandler(logging.NullHandler())
-    try:
-        os.remove("test.log")
-    except OSError:
-        pass
-
-
 @pytest.fixture(params=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
 def log_level(request):
     """Different log levels to test."""
     return request.param
 
 
-def test_configure_logger_no_label():
+@pytest.mark.reset_logger
+def test_configure_logger_no_label(tmp_path):
     """Test behaviour when label is None.
 
     This should NOT produce a log file.
     """
-    logger = configure_logger(label=None)
+    output = tmp_path / "logger_dir"
+    logger = configure_logger(label=None, output=output)
     assert not any(
         [isinstance(h, logging.FileHandler) for h in logger.handlers]
     )
+    assert not len(glob.glob(os.path.join(output, "*.log")))
 
 
+@pytest.mark.reset_logger
 @pytest.mark.parametrize("output", ["logger_dir", None])
 def test_configure_logger_with_label(tmp_path, output):
     """Test behaviour when label is not None.
@@ -53,17 +47,22 @@ def test_configure_logger_with_label(tmp_path, output):
     logger = configure_logger(label="test", output=output)
     if output is None:
         output = os.getcwd()
-    assert os.path.exists(os.path.join(output, "test.log"))
+    log_path = os.path.join(output, "test.log")
+    assert os.path.exists(log_path)
     assert any([isinstance(h, logging.FileHandler) for h in logger.handlers])
+    os.remove(log_path)
 
 
+@pytest.mark.reset_logger
 def test_configure_logger_with_mkdir(tmp_path):
     """Assert the output directory is created if missing"""
+    logging.getLogger("nessai")
     output = tmp_path / "logger_dir"
     configure_logger(label="test", output=output)
     assert os.path.exists(os.path.join(output, "test.log"))
 
 
+@pytest.mark.reset_logger
 @pytest.mark.parametrize(
     "log_level, value",
     [("ERROR", 40), ("WARNING", 30), ("INFO", 20), ("DEBUG", 10), (15, 15)],
@@ -74,6 +73,7 @@ def test_configure_logger_levels(log_level, value):
     assert all([h.level == value for h in logger.handlers])
 
 
+@pytest.mark.reset_logger
 def test_configure_logger_unknown_level():
     """Verify an error is raised for an unknown level"""
     with pytest.raises(ValueError) as excinfo:
@@ -81,6 +81,7 @@ def test_configure_logger_unknown_level():
     assert "log_level test not understood" in str(excinfo.value)
 
 
+@pytest.mark.reset_logger
 def test_filehandler_kwargs(tmp_path, log_level):
     """Assert filehandler kwargs are passed to the handler."""
     output = tmp_path / "logger_dir"
@@ -104,6 +105,7 @@ def test_filehandler_kwargs(tmp_path, log_level):
     )
 
 
+@pytest.mark.reset_logger
 def test_filehandler_no_kwargs(tmp_path, log_level):
     """Assert case of no kwargs for the file handler works as intended."""
     output = tmp_path / "logger_dir"
@@ -133,6 +135,7 @@ def test_filehandler_no_kwargs(tmp_path, log_level):
         (sys.stderr, sys.stderr),
     ),
 )
+@pytest.mark.reset_logger
 def test_stream_handler_setting(tmp_path, stream, expected, log_level):
     output = tmp_path / "logger_dir"
     handler = MagicMock(spec=logging.StreamHandler)
@@ -150,6 +153,7 @@ def test_stream_handler_setting(tmp_path, stream, expected, log_level):
     handler.assert_called_with(expected)
 
 
+@pytest.mark.reset_logger
 def test_stream_handler_error(tmp_path):
     """Assert an error is raised if an invalid string is passes"""
     output = tmp_path / "logger_dir"
@@ -157,12 +161,13 @@ def test_stream_handler_error(tmp_path):
         configure_logger(output=output, stream="not_a_stream")
 
 
+@pytest.mark.reset_logger
 @pytest.mark.parametrize("include_logger_name", [True, False])
 def test_configure_logger_include_logger_name(tmp_path, include_logger_name):
     output = tmp_path / "logger_dir"
-    configure_logger(output=output, include_logger_name=include_logger_name)
-
-    logger = logging.getLogger("nessai")
+    logger = configure_logger(
+        output=output, include_logger_name=include_logger_name
+    )
     if include_logger_name:
         assert all(
             [


### PR DESCRIPTION
This PR renames `setup_logger` to `configure_logger` (the verb is set up not setup) and adds a new argument, `include_logger_name`.

**`include_logger_name`**

If true, the name of the logger is included in the output, e.g. `nessai.livepoint`, if false, then this is replaced with `nessai`. I've set the default to `False` since I think the information isn't useful to most users.

