### PR TITLE
BLD: add `importlib-metadata` dependency for python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "scipy>0.16",
     "seaborn",
     "torch>=1.11.0",
+    "importlib-metadata; python_version < '3.10'",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
When adding support for entry points, I forgot to add `importlib-metadata` as an explicit dependency for Python < 3.10.
This PR adds that dependency.

Once this is merged, I'll backport this to v0.14.0 and make a post-release.