### PR TITLE
MAINT: cherry pick build fix from 5da3e50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "scipy>0.16",
     "seaborn",
     "torch>=1.11.0",
+    "importlib-metadata; python_version < '3.10'",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
Backport the change from https://github.com/mj-will/nessai/pull/450 to the latest release to fix the installation process.

Once this is merged, I'll tag the commit as v0.14.0.post0 and make a post-release