### PR TITLE
ENH: add `enforce_likelihood_threshold` to `FlowProposal`

### DIFF
--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -438,7 +438,11 @@ class FlowProposal(BaseFlowProposal):
             min_log_q = None
 
         logger.debug(f"Populating proposal with latent radius: {r:.5}")
-        self.r = r
+        # Radius is not used for the flow or Gaussian latent priors
+        if self.latent_prior in ["flow", "gaussian"]:
+            self.r = np.nan
+        else:
+            self.r = r
 
         self.alt_dist = self.get_alt_distribution()
 

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -485,7 +485,7 @@ class FlowProposal(BaseFlowProposal):
         log_constant = -np.inf
         n_accepted = 0
         accept = None
-        likelihood_threshold = worst_point["logL"]
+        log_likelihood_threshold = worst_point["logL"]
 
         while n_accepted < n_samples:
             z = self.draw_latent_prior(self.drawsize)
@@ -508,7 +508,7 @@ class FlowProposal(BaseFlowProposal):
                 x["logL"] = self.model.batch_evaluate_log_likelihood(
                     x, unit_hypercube=self.map_to_unit_hypercube
                 )
-                above_threshold = x["logL"] > likelihood_threshold
+                above_threshold = x["logL"] > log_likelihood_threshold
                 x, log_q = get_subset_arrays(above_threshold, x, log_q)
                 logger.debug(
                     "Accepting %s / %s samples above logL threshold",

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -505,7 +505,9 @@ class FlowProposal(BaseFlowProposal):
                 x, log_q = get_subset_arrays(above_min_log_q, x, log_q)
 
             if self.enforce_likelihood_threshold:
-                x["logL"] = self.model.batch_evaluate_log_likelihood(x)
+                x["logL"] = self.model.batch_evaluate_log_likelihood(
+                    x, unit_hypercube=self.map_to_unit_hypercube
+                )
                 above_threshold = x["logL"] > likelihood_threshold
                 x, log_q = get_subset_arrays(above_threshold, x, log_q)
                 logger.debug(

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -133,7 +133,7 @@ class FlowProposal(BaseFlowProposal):
         fuzz,
         expansion_fraction,
         latent_prior,
-        latent_temperature,
+        latent_temperature=None,
     ):
         """
         Configure settings related to population
@@ -145,10 +145,13 @@ class FlowProposal(BaseFlowProposal):
         self.fuzz = fuzz
         self.expansion_fraction = expansion_fraction
         self.latent_prior = latent_prior
-        if latent_temperature is not None and latent_prior != "gaussian":
-            raise ValueError(
-                "Latent temperature can only be used with a Gaussian latent prior"
-            )
+        if latent_temperature is not None:
+            if latent_prior != "gaussian":
+                raise ValueError(
+                    "Latent temperature can only be used with a Gaussian latent prior"
+                )
+            else:
+                logger.warning("`latent_temperature` is experimental!")
         self.latent_temperature = latent_temperature
 
     def configure_latent_prior(self):

--- a/src/nessai/utils/sampling.py
+++ b/src/nessai/utils/sampling.py
@@ -121,7 +121,7 @@ def draw_uniform(dims, r=(1,), N=1000, fuzz=1.0, rng=None):
     return rng.random((N, dims))
 
 
-def draw_gaussian(dims, r=1, N=1000, fuzz=1.0, rng=None):
+def draw_gaussian(dims, r=1, N=1000, fuzz=1.0, rng=None, temperature=1):
     """
     Wrapper for numpy.random.randn that deals with extra input parameters
     r and fuzz
@@ -145,7 +145,7 @@ def draw_gaussian(dims, r=1, N=1000, fuzz=1.0, rng=None):
     if rng is None:
         logger.debug("No rng specified, using the default rng.")
         rng = np.random.default_rng()
-    return rng.standard_normal((N, dims))
+    return np.sqrt(temperature) * rng.standard_normal((N, dims))
 
 
 def draw_truncated_gaussian(dims, r, N=1000, fuzz=1.0, var=1, rng=None):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
@@ -16,6 +16,7 @@ def proposal(rng):
     proposal = create_autospec(FlowProposal)
     proposal._initialised = False
     proposal.accumulate_weights = False
+    proposal.enforce_likelihood_threshold = False
     proposal.map_to_unit_hypercube = False
     proposal.rng = rng
     return proposal

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -16,6 +16,25 @@ def test_config_drawsize_none(proposal):
     assert proposal.drawsize == 2000
 
 
+def test_configure_latent_temperature(proposal):
+    """Test the configuration of the latent temperature"""
+    FlowProposal.configure_population(
+        proposal, 1000, 1.0, 0.0, "gaussian", 0.9
+    )
+    assert proposal.latent_temperature == 0.9
+
+
+def test_configure_latent_temperature_invalid(proposal):
+    """Test the configuration of the latent temperature"""
+    with pytest.raises(
+        ValueError,
+        match="Latent temperature can only be used with a Gaussian latent",
+    ):
+        FlowProposal.configure_population(
+            proposal, 1000, 1.0, 0.0, "truncated_gaussian", 0.9
+        )
+
+
 @pytest.mark.parametrize("fixed_radius", [False, 5.0, 1])
 def test_config_fixed_radius(proposal, fixed_radius):
     """Test the configuration for a fixed radius"""


### PR DESCRIPTION
This PR adds the `enforce_likelihood_threshold` to `FlowProposal` to enable check the likelihood threshold during rejection sampling.

**Motivation** 

In some cases, the increase in log-likelihood evaluations can out-weigh the cost of rejection sampling.

**To-do**

- [x] Add unit tests