### PR TITLE
MAINT: specify `weights_only=True` in `load.torch`

### DIFF
--- a/src/nessai/flowmodel/base.py
+++ b/src/nessai/flowmodel/base.py
@@ -726,7 +726,7 @@ class FlowModel:
         # TODO: these two methods are basically the same
         if not self.initialised:
             self.initialise()
-        self.model.load_state_dict(torch.load(weights_file))
+        self.model.load_state_dict(torch.load(weights_file, weights_only=True))
         self.model.eval()
         self.weights_file = weights_file
 

--- a/src/nessai/flowmodel/importance.py
+++ b/src/nessai/flowmodel/importance.py
@@ -160,7 +160,7 @@ class ImportanceFlowModel(FlowModel):
         for wf in self.weights_files:
             new_flow = configure_model(self.flow_config)
             new_flow.device = self.device
-            new_flow.load_state_dict(torch.load(wf))
+            new_flow.load_state_dict(torch.load(wf, weights_only=True))
             self.models.append(new_flow)
         self.models.eval()
 

--- a/tests/test_flowmodel/test_flowmodel_base.py
+++ b/tests/test_flowmodel/test_flowmodel_base.py
@@ -726,7 +726,7 @@ def test_load_weights(model, initialised):
         model.initialise.assert_not_called()
     else:
         model.initialise.assert_called_once()
-    mock_load.assert_called_once_with(weights_file)
+    mock_load.assert_called_once_with(weights_file, weights_only=True)
     model.model.load_state_dict.assert_called_once_with(d)
     model.model.eval.assert_called_once()
     assert model.weights_file == weights_file


### PR DESCRIPTION
Recent versions of torch print this warning when resuming runs:

```
FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
```

Following what is suggested here, I've updated all calls to `torch.load` to include `weights_only=True`.