### PR TITLE
MAINT: add warning about nessai.gw

### DIFF
--- a/src/nessai/gw/__init__.py
+++ b/src/nessai/gw/__init__.py
@@ -3,6 +3,18 @@
 Functions and classes for using nessai for gravitational-wave inference.
 """
 
+import warnings
+
 from .proposal import GWFlowProposal
 
 __all__ = ["GWFlowProposal"]
+
+warnings.warn(
+    (
+        "The `nessai.gw` module will be deprecated in the next release in "
+        "favour of the nessai-gw package. This packages provides the same "
+        "functionality as`nessai.gw` via the plugin interface."
+        "For more details, see: https://github.com/mj-will/nessai-gw"
+    ),
+    FutureWarning,
+)


### PR DESCRIPTION
Now that first release of `nessai-gw` is out, it's time to add a warning about the `gw` submodule.