### PR TITLE
MAINT: ignore `outdir/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+
+# Project specific
+outdir/


### PR DESCRIPTION
Ignore the `outdir` directory produced when running examples.