### PR TITLE
ENH: add live point ordering warning

### DIFF
--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -1,0 +1,50 @@
+====
+FAQs
+====
+
+
+When should I use :code:`allow_multi_valued_likelihood`?
+--------------------------------------------------------
+
+:code:`allow_multi_valued_likelihood` is a flag that can be set to `True` to allow
+sampling with likelihood functions that are not deterministic, i.e. they do not
+return the same value when called twice with the same point.
+
+By default, :code:`allow_multi_valued_likelihood` is set to `False`. This means
+that :code:`nessai` will raise an error if the likelihood function returns
+different values for the same point:
+
+.. code-block:: text
+
+    Repeated calls to the log-likelihood with the same parameters returned different values.
+
+Setting this flag to :code:`True` can be useful when using likelihood functions
+that include, for example, a Monte Carlo integration step. However, it is
+important to note that this can lead to incorrect results if the scale of the
+variance on the likelihood for a single sample is comparable to the width
+of the likelihood distribution for the posterior samples.
+
+.. warning ::
+    This flag should be used with caution and only when necessary. It can
+    lead to very inefficient sampling and results that are entirely incorrect.
+
+
+Why am I getting warnings about repeated log-likelihood values?
+---------------------------------------------------------------
+
+I you see the following warning:
+
+.. code-block:: text
+
+    Initial live points contain repeated log-likelihood values!
+    This will likely lead to issues in the sampling process.
+
+then it is likely that the log-likelihood function is returning the same value
+for multiple points. This is not allowed in the standard nested sampling algorithm
+and can lead to incorrect results.
+
+One common cause of this error is the use of :code:`numpy.nan_to_num` to convert
+:code:`-numpy.inf` to a finite value. :code:`nessai` is designed to handle
+:code:`-numpy.inf` values and treat them as invalid regions of the parameter space.
+It is therefore not recommended to use :code:`numpy.nan_to_num` in the
+log-likelihood function.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ For questions or other support, please either use our `gitter room <https://app.
    discrete-parameters
    plugins
    further-details
+   faqs
    API reference </autoapi/nessai/index>
 
 .. toctree::

--- a/src/nessai/samplers/nestedsampler.py
+++ b/src/nessai/samplers/nestedsampler.py
@@ -771,6 +771,16 @@ class NestedSampler(BaseNestedSampler):
                 logger.info(f"Populated {accepted} / {self.nlive} live points")
 
         self.live_points = np.sort(live_points, order="logL")
+
+        _, logl_counts = np.unique(
+            self.live_points["logL"], return_counts=True
+        )
+        if np.any(logl_counts > 1):
+            logger.warning(
+                "Initial live points contain repeated log-likelihood values! "
+                "This will likely lead to issues in the sampling process. "
+                "See the FAQs for more information."
+            )
         self.live_points["it"] = 0
 
     def initialise(self, live_points=True):


### PR DESCRIPTION
This PR adds a warning to `populate_live_points` for cases where there are duplicated log-likelihood values in the initial live points.

I've also added an FAQ page with some details relating to this.