### PR TITLE
MAINT: remove deprecated call to `numpy.in1d`

### DIFF
--- a/src/nessai/utils/structures.py
+++ b/src/nessai/utils/structures.py
@@ -105,4 +105,4 @@ def get_inverse_indices(n, indices):
     if indices.max() >= n:
         raise ValueError("Indices contain values that are out of range for n")
     inv = np.arange(n, dtype=int)
-    return inv[~np.in1d(inv, indices)]
+    return inv[~np.isin(inv, indices)]


### PR DESCRIPTION
Replace call to `numpy.in1d` with `numpy.isin`.

As of `numpy` 2.0 `in1d` is deprecated: https://numpy.org/doc/stable/reference/generated/numpy.in1d.html
