### PR TITLE
Add new point check

### DIFF
--- a/examples/unbounded_prior.py
+++ b/examples/unbounded_prior.py
@@ -3,7 +3,7 @@
 # Example of using nessai with an unbounded prior.
 
 import numpy as np
-from scipy.stats import norm
+from scipy.stats import multivariate_normal, norm
 
 from nessai.flowsampler import FlowSampler
 from nessai.livepoint import dict_to_live_points
@@ -17,12 +17,14 @@ rng = np.random.default_rng(1234)
 # We define the model as usual but also need to redefine `new_point` since by
 # default this tries to draw from within the prior bounds which will fail if
 # the bounds are +/- inf.
+# We also need to redefine `new_point_log_prob` since this is used to calculate
+# the log-probability of the new points.
 
 
 class GaussianModel(Model):
     """A simple two-dimensional Gaussian Model.
 
-    The prior is Uniform[-10, 10] on x and a unit-Gaussian on y.
+    The prior is Uniform[-10, 10] on x and a Gaussian on y.
     """
 
     def __init__(self):
@@ -30,6 +32,14 @@ class GaussianModel(Model):
         self.names = ["x", "y"]
         # Prior bounds for each parameter
         self.bounds = {"x": [-10, 10], "y": [-np.inf, np.inf]}
+        # Scipy distribution for the prior on y
+        self._prior_y_dist = norm(scale=5)
+        # Distribution for the log-likelihood
+        # This is a simple Gaussian with mean 0 and unit covariance
+        self._likelihood_dist = multivariate_normal(
+            mean=np.zeros(len(self.names)),
+            cov=np.eye(len(self.names)),
+        )
 
     def log_prior(self, x):
         """
@@ -42,35 +52,46 @@ class GaussianModel(Model):
         # Uniform on x
         log_p -= np.log(self.bounds["x"][1] - self.bounds["x"][0])
         # Gaussian on y
-        log_p += norm(scale=5).logpdf(x["y"])
+        log_p += self._prior_y_dist.logpdf(x["y"])
         return log_p
 
     def new_point(self, N=1):
         """Draw n points.
 
         This is used for the initial sampling. Points do not need to be drawn
-        from the exact prior but algorithm will be more efficient if they are.
+        from the exact prior but the initial sampling will be more efficient
+        if they are.
         """
         # There are various ways to create live points in nessai, such as
         # from dictionaries and numpy arrays. See nessai.livepoint for options
         d = {
             "x": rng.uniform(self.bounds["x"][0], self.bounds["x"][1], N),
-            "y": norm(scale=5).rvs(size=N, random_state=rng),
+            "y": self._prior_y_dist.rvs(size=N, random_state=rng),
         }
         return dict_to_live_points(d)
+
+    def new_point_log_prob(self, x):
+        """Returns the log-probability for a new point.
+
+        Since we have redefined `new_point` we also need to redefine this
+        function.
+        """
+        return self.log_prior(x)
 
     def log_likelihood(self, x):
         """Returns the log-likelihood.
 
         In this example we use a simple Gaussian likelihood.
         """
-        log_l = np.zeros(x.size)
-        for n in self.names:
-            log_l += norm.logpdf(x[n])
-        return log_l
+        # Unstructured view returns a view of the inputs as a "normal" numpy
+        # array without any fields. It will included the parameters listed in
+        # names and in the same order. This is faster then converting from
+        # live points to an array.
+        x = self.unstructured_view(x)
+        return self._likelihood_dist.logpdf(x)
 
 
-# The sampler can then be configure as usual
+# The sampler can then be configured as usual
 fs = FlowSampler(
     GaussianModel(),
     output=output,

--- a/src/nessai/model.py
+++ b/src/nessai/model.py
@@ -31,8 +31,21 @@ from .utils.multiprocessing import (
 logger = logging.getLogger(__name__)
 
 
-class OneDimensionalModelError(Exception):
-    """Exception raised when the model is one-dimensional"""
+class ModelError(Exception):
+    """Exception raised when the model is not configured correctly.
+
+    .. versionadded:: 0.15.0
+    """
+
+    pass
+
+
+class OneDimensionalModelError(ModelError):
+    """Exception raised when the model is one-dimensional.
+
+    .. versionchanged:: 0.15.0
+        Changed to inherit from ModelError.
+    """
 
     pass
 
@@ -805,8 +818,8 @@ class Model(ABC):
                 logP = self.log_prior(x)
                 counter += 1
                 if counter == 1000:
-                    raise RuntimeError(
-                        "Could not draw valid point from within the prior "
+                    raise ModelError(
+                        "Could not draw a valid point from within the prior "
                         "after 10000 tries, check the log prior function."
                     )
         else:
@@ -818,17 +831,15 @@ class Model(ABC):
                 x = self.new_point(1)
                 logP = self.log_prior(x)
             except Exception as e:
-                raise RuntimeError(
+                raise ModelError(
                     "Could not draw a new point and compute the log prior "
                     f"with error: {e}. \n Check the prior bounds."
                 )
 
         if self.log_prior(x) is None:
-            raise RuntimeError(
-                "Log-prior function did not return a prior value"
-            )
+            raise ModelError("Log-prior function did not return a prior value")
         if self.log_likelihood(x) is None:
-            raise RuntimeError(
+            raise ModelError(
                 "Log-likelihood function did not return a likelihood value"
             )
 
@@ -840,7 +851,7 @@ class Model(ABC):
         else:
             logl = np.array([self.log_likelihood(x) for _ in range(16)])
             if not all(logl == logl[0]):
-                raise RuntimeError(
+                raise ModelError(
                     "Repeated calls to the log-likelihood with the same "
                     "parameters return different values."
                 )

--- a/src/nessai/model.py
+++ b/src/nessai/model.py
@@ -761,6 +761,32 @@ class Model(ABC):
         """
         return unstructured_view(x, dtype=self._view_dtype)
 
+    @classmethod
+    def check_new_point_methods(cls):
+        """Check if the new_point methods have been redefined.
+
+        .. versionadded:: 0.15.0
+
+        Raises
+        ------
+        ModelError
+            If the new_point methods have been redefined but not both.
+        """
+        if cls.new_point != Model.new_point:
+            logger.debug("`new_point` method has been redefined.")
+            if cls.new_point_log_prob == Model.new_point_log_prob:
+                raise ModelError(
+                    "`new_point` method has been redefined but "
+                    "`new_point_log_prob` has not."
+                )
+        if cls.new_point_log_prob != Model.new_point_log_prob:
+            logger.debug("`new_point_log_prob` method has been redefined.")
+            if cls.new_point == Model.new_point:
+                raise ModelError(
+                    "`new_point_log_prob` method has been redefined but "
+                    "`new_point` has not."
+                )
+
     def verify_model(self):
         """
         Verify that the model is correctly setup. This includes checking
@@ -797,6 +823,8 @@ class Model(ABC):
                 "proposals it uses. Consider using other methods instead of "
                 "nessai."
             )
+
+        self.check_new_point_methods()
 
         for n in self.names:
             if n not in self.bounds.keys():

--- a/tests/test_sampling/test_standard_sampling.py
+++ b/tests/test_sampling/test_standard_sampling.py
@@ -526,6 +526,9 @@ def test_sampling_with_infinite_prior_bounds(tmpdir):
             )
             return numpy_array_to_live_points(x, self.names)
 
+        def new_point_log_prob(self, x):
+            return self.log_prior(x)
+
         def log_prior(self, x):
             log_p = np.log(self.in_bounds(x))
             log_p += norm.logpdf(x["y"])


### PR DESCRIPTION
Add `check_new_point_methods` classmethod to `Model`.

This method raises an error if the user redefines one of `new_point` or `new_point_log_prob` but not the other. This avoids situations where the new new samples are drawn incorrectly.

I've also updated the `unbounded_priors.py` example to address this. I've also updated the example to use some of the newer functionality in `nessai`.

Thanks @chrismessenger for highlighting this issue