### PR TITLE
ENH: improve error handling for dyamic range issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ cython_debug/
 
 # Project specific
 outdir/
+autoapi/

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -48,3 +48,37 @@ One common cause of this error is the use of :code:`numpy.nan_to_num` to convert
 :code:`-numpy.inf` values and treat them as invalid regions of the parameter space.
 It is therefore not recommended to use :code:`numpy.nan_to_num` in the
 log-likelihood function.
+
+
+Large dynamic range
+-------------------
+
+If you see an error such as:
+
+.. code-block:: text
+
+    Rescaling is not invertible for x! This may be due to the large dynamic range (log10 dynamic range=18.0, min=1.0377468396342845e-09, max=950413414.495942).
+
+This may an indication that the dynamic range of the parameter is too large for the default floating point precession (float64).
+In this case, it may be beneficial to apply a log transformation to the parameter before applying a reparameterisation such as :code:`scaleandshift` or :code:`rescaletobounds`.
+
+This can be done using the `reparameterisations` keyword argument when calling the sampler. For example:
+
+.. code-block:: python
+
+    fs = FlowSampler(
+        model=model,
+        ...,
+        reparameterisations={
+            'x': {'reparameterisation': "default", "pre_rescaling": "log"}
+        }
+    )
+
+
+``x`` should match the name of the parameter and `reparameterisation` should be a reparameterisation that supports pre-rescaling.
+This will apply a log transformation to the `x` parameter, before applying the default (``scaleandshift``).
+See :ref:`Configuring reparameterisations<Configuring reparameterisations>` for more details.
+
+.. note::
+
+    Only the ``scaleandshift`` and ``rescaletobounds`` reparameterisations currently support pre-rescaling transformations.

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -70,15 +70,11 @@ This can be done using the `reparameterisations` keyword argument when calling t
         model=model,
         ...,
         reparameterisations={
-            'x': {'reparameterisation': "default", "pre_rescaling": "log"}
+            'log-standardise': ["x"],
         }
     )
 
 
-``x`` should match the name of the parameter and `reparameterisation` should be a reparameterisation that supports pre-rescaling.
-This will apply a log transformation to the `x` parameter, before applying the default (``scaleandshift``).
+The list should contain the name of the parameter(s) which large dynamic ranges.
+This will apply a log transformation to the `x` parameter, before standardising the samples.
 See :ref:`Configuring reparameterisations<Configuring reparameterisations>` for more details.
-
-.. note::
-
-    Only the ``scaleandshift`` and ``rescaletobounds`` reparameterisations currently support pre-rescaling transformations.

--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -40,9 +40,10 @@ Available reparameterisations
 
 There are a number of pre-configured reparameterisations included in ``nessai``:
 
-- ``default``: Default rescaling which rescales to [-1, 1] and has :code`update_bounds=True`
-- ``rescaletobounds``: Alias for default
-- ``inversion``:  Default rescaling but with inversion and :code:`detect_edges` enabled for the parameter, uses :code:`split` inversion.
+- ``default``: See ``scaleandshift`` (Changed in version `0.13.0`)
+- ``scaleandshift``/``z-score``: Standardize the parameter to have zero mean and unit variance.
+- ``rescaletobounds``: Rescaling which rescale to [-1, 1] and has :code:`update_bounds=True`
+- ``inversion``:  ``rescaletobounds`` rescaling but with inversion and :code:`detect_edges` enabled for the parameter, uses :code:`split` inversion.
 - ``inversion-duplicate``: Same as :code:`inversion` but uses :code:`duplicate` inversion
 - ``offset``: Equivalent to :code:`default` but includes an offset before rescaling. This is usual when dealing with parameters which have small prior ranges but are offset from zero by some large constant. For example time, which is typically of order :math:`10^{9}`
 - ``logit``: Parameters are rescaled to [0, 1] and a logit is applied. A sigmoid is used for the inverse. **Note:** :code:`update_bounds` is disabled by default.

--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -41,7 +41,7 @@ Available reparameterisations
 There are a number of pre-configured reparameterisations included in ``nessai``:
 
 - ``default``: See ``scaleandshift`` (Changed in version `0.13.0`)
-- ``scaleandshift``/``z-score``: Standardize the parameter to have zero mean and unit variance.
+- ``standardise``/``z-score``: Standardise the parameter to have zero mean and unit variance. The mean and variance are estimated during sampling.
 - ``rescaletobounds``: Rescaling which rescale to [-1, 1] and has :code:`update_bounds=True`
 - ``inversion``:  ``rescaletobounds`` rescaling but with inversion and :code:`detect_edges` enabled for the parameter, uses :code:`split` inversion.
 - ``inversion-duplicate``: Same as :code:`inversion` but uses :code:`duplicate` inversion

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -654,7 +654,7 @@ class BaseFlowProposal(RejectionProposal):
                     elif not np.allclose(block, target, equal_nan=False):
                         msg = f"Rescaling is not invertible for {f}! "
                         if ratio > 1:
-                            msg = f"(block {count}) "
+                            msg += f"(block {count}) "
                         log_dynamic_range = (
                             np.log10(block).max() - np.log10(block).min()
                         )

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -455,6 +455,9 @@ class BaseFlowProposal(RejectionProposal):
                 logger.debug(f"Assuming {k} is a reparameterisation")
                 try:
                     rc, default_config = self.get_reparameterisation(k)
+                    if isinstance(cfg, list):
+                        logger.debug("Assuming list of patterns")
+                        cfg = {"parameters": cfg}
                     default_config.update(cfg)
                     parameters = default_config.get("parameters")
 

--- a/src/nessai/reparameterisations/__init__.py
+++ b/src/nessai/reparameterisations/__init__.py
@@ -18,6 +18,7 @@ from .rescale import Rescale, RescaleToBounds, ScaleAndShift
 from .utils import (
     KnownReparameterisation,
     ReparameterisationDict,
+    ReparameterisationError,
     get_reparameterisation,
 )
 
@@ -194,6 +195,7 @@ __all__ = [
     "KnownReparameterisation",
     "NullReparameterisation",
     "Reparameterisation",
+    "ReparameterisationError",
     "Rescale",
     "RescaleToBounds",
     "ToCartesian",

--- a/src/nessai/reparameterisations/__init__.py
+++ b/src/nessai/reparameterisations/__init__.py
@@ -86,6 +86,11 @@ default_reparameterisations.add_reparameterisation(
     {"estimate_scale": True, "estimate_shift": True},
 )
 default_reparameterisations.add_reparameterisation(
+    "standardize",
+    ScaleAndShift,
+    {"estimate_scale": True, "estimate_shift": True},
+)
+default_reparameterisations.add_reparameterisation(
     "z-score",
     ScaleAndShift,
     {"estimate_scale": True, "estimate_shift": True},
@@ -143,6 +148,16 @@ default_reparameterisations.add_reparameterisation(
         "estimate_shift": True,
         "pre_rescaling": "inv_gaussian_cdf",
     },
+)
+default_reparameterisations.add_reparameterisation(
+    "log-z-score",
+    ScaleAndShift,
+    {"estimate_scale": True, "estimate_shift": True, "pre_rescaling": "log"},
+)
+default_reparameterisations.add_reparameterisation(
+    "log-standardise",
+    ScaleAndShift,
+    {"estimate_scale": True, "estimate_shift": True, "pre_rescaling": "log"},
 )
 default_reparameterisations.add_reparameterisation("angle", Angle, {})
 default_reparameterisations.add_reparameterisation(

--- a/src/nessai/reparameterisations/utils.py
+++ b/src/nessai/reparameterisations/utils.py
@@ -15,6 +15,10 @@ from .null import NullReparameterisation
 logger = logging.getLogger(__name__)
 
 
+class ReparameterisationError(RuntimeError):
+    """Exception for reparameterisation errors"""
+
+
 @dataclass(frozen=True)
 class KnownReparameterisation:
     """Dataclass to store the reparameterisation class and keyword arguments"""

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -10,6 +10,7 @@ from nessai.model import Model
 from nessai.proposal.flowproposal.base import BaseFlowProposal
 from nessai.reparameterisations import (
     NullReparameterisation,
+    ReparameterisationError,
     RescaleToBounds,
     get_reparameterisation,
 )
@@ -625,9 +626,29 @@ def test_verify_rescaling_invertible_error(proposal, has_inversion):
     proposal._reparameterisation = MagicMock()
     proposal._reparameterisation.one_to_one = True
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(
+        ReparameterisationError, match=r"Rescaling is not invertible .*"
+    ):
         BaseFlowProposal.verify_rescaling(proposal)
-    assert "Rescaling is not invertible for x" in str(excinfo.value)
+
+
+def test_verify_rescaling_invertible_error_dynamic_range(proposal):
+    """Assert an error is raised if the rescaling is not invertible"""
+    x = np.array([[1e-15], [1e15]], dtype=[("x", "f8")])
+    x_prime = x["x"] / 2
+    log_j = np.array([-2, -2])
+    x_out = x.copy()[::-1]
+    log_j_inv = np.array([2, 2])
+
+    proposal.model.new_point = MagicMock(return_value=x)
+    proposal.rescale = MagicMock(return_value=(x_prime, log_j))
+    proposal.inverse_rescale = MagicMock(return_value=(x_out, log_j_inv))
+    proposal.rescaling_set = True
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.one_to_one = True
+
+    with pytest.raises(ReparameterisationError, match=r"dynamic range"):
+        BaseFlowProposal.verify_rescaling(proposal)
 
 
 @pytest.mark.parametrize("has_inversion", [False, True])

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -294,6 +294,26 @@ def test_configure_reparameterisations_dict_reparam(proposal):
     assert proposal._reparameterisation.prime_parameters == ["x_prime", "y"]
 
 
+def test_configure_reparameterisations_dict_reparam_list(proposal):
+    """Test configuration for reparameterisations dictionary"""
+    proposal.add_default_reparameterisations = MagicMock()
+    proposal.get_reparameterisation = get_reparameterisation
+    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
+    proposal.model.names = ["x", "y"]
+    proposal.fallback_reparameterisation = None
+    BaseFlowProposal.configure_reparameterisations(
+        proposal, {"default": ["x", "y"]}
+    )
+
+    proposal.add_default_reparameterisations.assert_not_called()
+    assert proposal.prime_parameters == ["x_prime", "y_prime"]
+    assert proposal._reparameterisation.parameters == ["x", "y"]
+    assert proposal._reparameterisation.prime_parameters == [
+        "x_prime",
+        "y_prime",
+    ]
+
+
 @pytest.mark.parametrize(
     "parameters",
     [

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -1071,7 +1071,8 @@ def test_is_invertible_dynamic_range(is_invertible, rng):
             )
             return np.array(a, dtype=[("a_1", "f8")])
 
-    assert is_invertible(reparam, model=MockModel(), decimal=12) is False
+    with pytest.raises(AssertionError):
+        is_invertible(reparam, model=MockModel(), decimal=12)
 
     reparam = RescaleToBounds(
         parameters=["a_1"],

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -1063,7 +1063,7 @@ def test_is_invertible_dynamic_range(is_invertible, rng):
             return numpy_array_to_live_points(a, ["a_1"])
 
     with pytest.raises(AssertionError):
-        is_invertible(reparam, model=MockModel(), atol=1e-14, rtol=1e-14)
+        is_invertible(reparam, model=MockModel(), atol=1e-11, rtol=1e-11)
 
     reparam = RescaleToBounds(
         parameters=["a_1"],
@@ -1071,4 +1071,4 @@ def test_is_invertible_dynamic_range(is_invertible, rng):
         pre_rescaling="log",
     )
 
-    assert is_invertible(reparam, model=MockModel(), atol=1e-14, rtol=1e-14)
+    assert is_invertible(reparam, model=MockModel(), atol=1e-11, rtol=1e-11)

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -1063,7 +1063,7 @@ def test_is_invertible_dynamic_range(is_invertible, rng):
             return numpy_array_to_live_points(a, ["a_1"])
 
     with pytest.raises(AssertionError):
-        is_invertible(reparam, model=MockModel(), atol=1e-15, rtol=1e-15)
+        is_invertible(reparam, model=MockModel(), atol=1e-14, rtol=1e-14)
 
     reparam = RescaleToBounds(
         parameters=["a_1"],
@@ -1071,4 +1071,4 @@ def test_is_invertible_dynamic_range(is_invertible, rng):
         pre_rescaling="log",
     )
 
-    assert is_invertible(reparam, model=MockModel(), atol=1e-15, rtol=1e-15)
+    assert is_invertible(reparam, model=MockModel(), atol=1e-14, rtol=1e-14)


### PR DESCRIPTION
This PR improves the `verify_rescaling` method to make the error message highlight if there may be issues relating to dynamic range.

I've also added an FAQ which the error mentions.