### PR TITLE
DOC: add details about key settings

### DIFF
--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -2,6 +2,17 @@
 FAQs
 ====
 
+My runs show signs of over-constraining. What can I do?
+-------------------------------------------------------
+
+If your runs show signs of over-constraining, we suggest starting with the settings
+described in :ref:`Standard sampler configuration<Key settings>`: :code:`reset_flow`,
+:code:`volume_fraction`, and :code:`nlive`.
+
+If you continue to see signs of over-constraining, you can also try using different
+reparameterisations, as described in :ref:`Configuring reparameterisations` or
+changing the normalising flow architecture, as described in :ref:`Normalising flows configuration`.
+
 
 When should I use :code:`allow_multi_valued_likelihood`?
 --------------------------------------------------------

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -10,7 +10,7 @@ described in :ref:`Standard sampler configuration<Key settings>`: :code:`reset_f
 :code:`volume_fraction`, and :code:`nlive`.
 
 If you continue to see signs of over-constraining, you can also try using different
-reparameterisations, as described in :ref:`Configuring reparameterisations` or
+reparameterisations, as described in :ref:`Reparameterisations` or
 changing the normalising flow architecture, as described in :ref:`Normalising flows configuration`.
 
 

--- a/docs/sampler-configuration.rst
+++ b/docs/sampler-configuration.rst
@@ -3,7 +3,7 @@ Standard sampler configuration
 ==============================
 
 .. important::
-    Some of settings discussed here only apply to standard ``nessai`` not ``i-nessai``. For ``i-nessai`` see :ref:`Importance Nested Sampling`
+    Some of settings discussed here only apply to standard ``nessai`` not ``i-nessai``. For ``i-nessai`` see :ref:`Importance Nested Sampler`
 
 There are various settings in ``nessai`` which can be configured. These can be grouped in to general settings and proposal settings. The former controls general aspects of the sampler such as the model being sampler or how many live points are used. The latter affect the proposal process and how new points are drawn.
 

--- a/docs/sampler-configuration.rst
+++ b/docs/sampler-configuration.rst
@@ -9,6 +9,15 @@ There are various settings in ``nessai`` which can be configured. These can be g
 
 All of the settings are controlled when creating an instance of :py:class:`~nessai.flowsampler.FlowSampler`. The most important settings to consider when using ``nessai`` are the :doc:`reparameterisations<reparameterisations>` used for the proposals.
 
+Key settings
+============
+
+The most important settings to consider when using ``nessai`` with the default :code:`FlowProposal` are:
+
+- :code:`reset_flow` (default :code:`False`): Whether to reset the normalising flow after each time it is trained. If an integer is specified, the flow is reset after every nth time it is trained. This becomes increasingly important for high dimensional problems or problems where the shape of the likelihood changes significantly as the sampling progresses. We recommend trying values between 1 and 16.
+- :code:`volume_fraction` (default :code:`0.95`): Fractional value used to truncated the normalising flow latent space when drawing new samples. Lower values are more prone to over-constraining contours whilst higher values can lead to inefficient sampling. If the diagnostics indicate the results are over-constrained, increasing this value may help. We recommend trying values between 0.95 and 0.99.
+- :code:`nlive` (default :code:`2000`): Number of live points to use. Increasing this value will lead to more accurate evidence estimates and better exploration of complex, high-dimensional posteriors, but will also increase the runtime. It can also reduce over-constraining since the flow has more sample to learn from.
+
 General configuration
 =====================
 


### PR DESCRIPTION
Adds a new section that explicitly mentions `reset_flow` and `volume_fraction`.