### PR TITLE
BUG: ensure reparameterisations are seeded

### DIFF
--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 from abc import abstractmethod
+from inspect import signature
 from typing import Optional
 from warnings import warn
 
@@ -507,6 +508,9 @@ class BaseFlowProposal(RejectionProposal):
                         default_config["parameters"]
                     ]
                 }
+            sig = signature(rc.__init__)
+            if "rng" in sig.parameters:
+                default_config["rng"] = self.rng
 
             logger.info(f"Adding {rc.__name__} with config: {default_config}")
             r = rc(prior_bounds=prior_bounds, **default_config)

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -162,8 +162,8 @@ class Angle(Reparameterisation):
 class ToCartesian(Angle):
     """Convert a parameter to Cartesian coordinates"""
 
-    def __init__(self, mode="split", scale=np.pi, **kwargs):
-        super().__init__(scale=scale, **kwargs)
+    def __init__(self, mode="split", scale=np.pi, rng=None, **kwargs):
+        super().__init__(scale=scale, rng=rng, **kwargs)
 
         self.mode = mode
         if self.mode not in ["duplicate", "split", "half"]:
@@ -235,14 +235,21 @@ class AnglePair(Reparameterisation):
     _conventions = {"az-zen": [0, np.pi], "ra-dec": [-np.pi / 2, np.pi / 2]}
 
     def __init__(
-        self, parameters=None, prior_bounds=None, prior=None, convention=None
+        self,
+        parameters=None,
+        prior_bounds=None,
+        prior=None,
+        convention=None,
+        rng=None,
     ):
         if len(parameters) not in [2, 3]:
             raise RuntimeError(
                 "Must use a pair of angles or a pair plus a radius"
             )
 
-        super().__init__(parameters=parameters, prior_bounds=prior_bounds)
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
 
         # Determine which parameter is for the horizontal plane
         # and which is for the vertical plane

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -10,6 +10,7 @@ from nessai.model import Model
 from nessai.proposal.flowproposal.base import BaseFlowProposal
 from nessai.reparameterisations import (
     NullReparameterisation,
+    Reparameterisation,
     ReparameterisationError,
     RescaleToBounds,
     get_reparameterisation,
@@ -386,6 +387,26 @@ def test_configure_reparameterisation_no_parameters(proposal, dummy_rc):
             proposal, {"default": {"update_bounds": True}}
         )
     assert "No parameters key" in str(excinfo.value)
+
+
+def test_configure_reparameterisation_with_rng(proposal, rng):
+    """Test that the rng is correctly passed to the reparameterisation if it is
+    in the signature."""
+    proposal.model.names = ["x"]
+    proposal.model.bounds = {"x": [-1, 1]}
+    proposal.get_reparameterisation = MagicMock(
+        return_value=(
+            Reparameterisation,
+            {},
+        )
+    )
+    proposal.rng = rng
+    with patch("numpy.random.default_rng") as mocked_rng:
+        BaseFlowProposal.configure_reparameterisations(
+            proposal, {"default": {"parameters": ["x"]}}
+        )
+    mocked_rng.assert_not_called()
+    assert proposal._reparameterisation["reparameterisation_x"].rng is rng
 
 
 def test_set_rescaling_with_model(proposal, model):

--- a/tests/test_reparameterisations/test_all_reparams.py
+++ b/tests/test_reparameterisations/test_all_reparams.py
@@ -1,0 +1,19 @@
+from inspect import signature
+
+import pytest
+
+from nessai.reparameterisations import (
+    default_reparameterisations,
+)
+
+
+@pytest.fixture(params=default_reparameterisations.values())
+def reparameterisation(request):
+    """Fixture to test all reparameterisations."""
+    return request.param
+
+
+def test_reparams_rng(reparameterisation):
+    """Test that all reparameterisations can be initialised with an rng"""
+    sig = signature(reparameterisation.class_fn)
+    assert "rng" in sig.parameters

--- a/tests/test_reparameterisations/test_to_cartesian.py
+++ b/tests/test_reparameterisations/test_to_cartesian.py
@@ -29,10 +29,11 @@ def test_init(reparam, mode, scale):
     prior_bounds = {"x": [0.0, 1.0]}
     """Test the init method"""
 
-    def side_effect(scale, prior_bounds=None):
+    def side_effect(scale, prior_bounds=None, rng=None):
         reparam.scale = scale
         reparam.parameters = ["x", "y"]
         reparam.prior_bounds = prior_bounds
+        reparam.rng = rng or np.random.default_rng()
 
     with patch(
         "nessai.reparameterisations.Angle.__init__", side_effect=side_effect
@@ -43,7 +44,9 @@ def test_init(reparam, mode, scale):
     assert reparam.mode == mode
     assert reparam._zero_bound is False
     assert reparam._k == 1.0
-    super_init.assert_called_once_with(scale=scale, prior_bounds=prior_bounds)
+    super_init.assert_called_once_with(
+        scale=scale, prior_bounds=prior_bounds, rng=None
+    )
 
 
 def test_init_invalid_mode(reparam):


### PR DESCRIPTION
Following https://github.com/mj-will/nessai/pull/435, reparameterisation were not being seed since `rng` was not included in the config.