### PR TITLE
ENH: add support for chained reparameterisatons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `prime_dims` to `FlowProposal` (https://github.com/mj-will/nessai/pull/483)
+- Add support for chaining reparameterisations (https://github.com/mj-will/nessai/pull/480)
+
 ### Fixed
 
 - Fix a bug with parameter ordering in reparameterisations with multiple parameters (https://github.com/mj-will/nessai/pull/479)
+- Fix bug with dimensionality of flow latent space when using reparameterisations that add prime parameters (https://github.com/mj-will/nessai/pull/483)
+
+### Deprecated
+
+- `rescaled_dims` is now replaced by `prime_dims`
 
 ### Removed
 

--- a/docs/reparameterisations.rst
+++ b/docs/reparameterisations.rst
@@ -35,6 +35,49 @@ The following key-value pairs are understood:
 See the `examples directory <https://github.com/mj-will/nessai/tree/master/examples>`_ for an example of using this method of defining the reparmeterisations.
 
 
+Chaining reparameterisations
+----------------------------
+
+It is possible to apply multiple reparameterisations in sequence.
+This is done by specifying a **list of reparameterisation specifications**
+for a parameter key. Each entry in the list corresponds to one stage in the
+chain and the stages are applied in the order given.
+
+For example, the following configuration first rescales ``y`` to
+``y_01`` and then applies a z-score reparameterisation to produce
+``y_prime``:
+
+.. code-block:: python
+
+    reparameterisations = {
+        "x": "default",
+        "y": [
+            {
+                "reparameterisation": "rescaletobounds",
+                "output_parameters": ["y_01"],
+            },
+            {
+                "reparameterisation": "z-score",
+                "input_parameters": ["y_01"],
+                "output_parameters": ["y_prime"],
+            },
+        ],
+    }
+
+In this example:
+
+- the first stage consumes ``y`` from :math:`\mathcal{X}` and produces
+  ``y_01`` in :math:`\mathcal{X}'`;
+- the second stage consumes ``y_01`` from :math:`\mathcal{X}'` and produces
+  ``y_prime``.
+
+Any intermediate prime-space outputs, such as ``y_01`` in the example above,
+are retained internally so the inverse reparameterisation can be applied, but
+they are hidden from the flow by default once a later stage replaces them.
+If an intermediate prime-space parameter should remain visible to the flow, it
+can be listed in :code:`persistent_parameters`.
+
+
 Available reparameterisations
 =============================
 

--- a/src/nessai/proposal/augmented.py
+++ b/src/nessai/proposal/augmented.py
@@ -73,6 +73,13 @@ class AugmentedFlowProposal(FlowProposal):
         self.augment_parameters = [f"e_{i}" for i in range(self.augment_dims)]
         self.parameters += self.augment_parameters
         self.prime_parameters += self.augment_parameters
+        if getattr(self, "_prime_parameters_internal", None) is None:
+            self._prime_parameters_internal = self.prime_parameters.copy()
+        else:
+            self._prime_parameters_internal += self.augment_parameters
+        self._x_dtype = None
+        self._x_prime_dtype = None
+        self._x_prime_internal_dtype = None
         logger.info(f"augmented x space parameters: {self.parameters}")
         logger.info(
             f"Augmented x prime space parameters: {self.prime_parameters}"

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -400,18 +400,14 @@ class BaseFlowProposal(RejectionProposal):
 
     def _get_prior_bounds_for_parameters(self, parameters):
         """Get prior bounds for parameters that are model parameters."""
-        prior_bounds_lookup = getattr(self, "prior_bounds", None)
-        if not isinstance(prior_bounds_lookup, dict):
-            prior_bounds_lookup = self.model.bounds
-
         if isinstance(parameters, list):
             prior_bounds = {
-                p: prior_bounds_lookup[p]
+                p: self.prior_bounds[p]
                 for p in parameters
-                if p in prior_bounds_lookup
+                if p in self.prior_bounds
             }
-        elif parameters in prior_bounds_lookup:
-            prior_bounds = {parameters: prior_bounds_lookup[parameters]}
+        elif parameters in self.prior_bounds:
+            prior_bounds = {parameters: self.prior_bounds[parameters]}
         else:
             prior_bounds = {}
 

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -18,7 +18,6 @@ from ...livepoint import (
     empty_structured_array,
     get_dtype,
     live_points_to_array,
-    numpy_array_to_live_points,
 )
 from ...plot import nessai_style, plot_1d_comparison, plot_live_points
 from ...reparameterisations.combined import (
@@ -143,6 +142,7 @@ class BaseFlowProposal(RejectionProposal):
         self.x = None
         self.samples = None
         self.prime_parameters = None
+        self._prime_parameters_internal = None
         self.acceptance = []
         self._reparameterisation = None
         self.rescaling_set = False
@@ -241,9 +241,31 @@ class BaseFlowProposal(RejectionProposal):
         """Return the dtype for the x prime space"""
         if self._x_prime_dtype is None:
             self._x_prime_dtype = get_dtype(
-                self.prime_parameters, config.livepoints.default_float_dtype
+                self.prime_parameters,
+                config.livepoints.default_float_dtype,
             )
         return self._x_prime_dtype
+
+    @property
+    def internal_prime_parameters(self):
+        """List of prime parameters, including intermediate parameters that are
+        not visible to the flow.
+        """
+        return self._prime_parameters_internal
+
+    @property
+    def x_prime_internal_dtype(self):
+        """Return the dtype for the internal x prime space.
+
+        This includes intermediate prime parameters that are not visible to the
+        flow.
+        """
+        if self._x_prime_internal_dtype is None:
+            self._x_prime_internal_dtype = get_dtype(
+                self._prime_parameters_internal or self.prime_parameters,
+                config.livepoints.default_float_dtype,
+            )
+        return self._x_prime_internal_dtype
 
     @property
     def population_dtype(self):
@@ -431,33 +453,34 @@ class BaseFlowProposal(RejectionProposal):
         config.update(spec.kwargs)
 
         if spec.source_is_parameter:
-            config["parameters"] = spec.parameters
+            config["input_parameters"] = spec.input_parameters
         else:
             parameters = resolve_reparameterisation_parameters(
-                spec.parameters,
+                spec.input_parameters,
                 available_parameters=list(
                     dict.fromkeys(
                         list(self.model.names)
                         + list(self._reparameterisation.parameters)
+                        + list(self._reparameterisation.prime_parameters)
                     )
                 ),
             )
             if parameters is not None:
-                config["parameters"] = parameters
+                config["input_parameters"] = parameters
             else:
                 logger.warning(
-                    "Reparameterisation might be missing parameters!"
+                    "Reparameterisation might be missing input parameters!"
                 )
 
-        if "parameters" not in config:
+        if "input_parameters" not in config:
             raise RuntimeError(
-                "No parameters key in the config! "
+                "No input_parameters key in the config! "
                 "Check reparameterisations, setting logging"
                 " level to DEBUG can be helpful"
             )
-        if not config["parameters"] and not config.get("prime_requires"):
+        if not config["input_parameters"]:
             raise RuntimeError(
-                "No parameters key in the config! "
+                "No input_parameters key in the config! "
                 "Check reparameterisations, setting logging"
                 " level to DEBUG can be helpful"
             )
@@ -469,7 +492,7 @@ class BaseFlowProposal(RejectionProposal):
         rc, config = self.get_reparameterisation_from_spec(spec)
 
         prior_bounds = self._get_prior_bounds_for_parameters(
-            config["parameters"]
+            config["input_parameters"]
         )
         sig = signature(rc.__init__)
         if "rng" in sig.parameters:
@@ -487,60 +510,48 @@ class BaseFlowProposal(RejectionProposal):
         the reparameterisations.
 
         The prime parameters are ordered such that any prime parameters that
-        correspond to model parameters are in the same order as the model
-        parameters, followed by any additional prime parameters.
+        are produced by the reparameterisations appear in reparameterisation
+        order. Public flow-facing prime parameters exclude intermediate prime
+        inputs unless they are explicitly marked as persistent.
         """
         model_parameters = list(self.model.names)
 
+        # x-space order is given by the model parameters
         self.parameters = model_parameters + [
             parameter
             for parameter in self._reparameterisation.parameters
             if parameter not in model_parameters
         ]
 
-        # Dictionary of parameter -> prime parameter for parameters that have a
-        # one-to-one mapping to a prime parameter
-        parameter_to_prime = {}
-        # Dictionary of parameter -> list of prime parameters for parameters
-        # that have a one-to-many mapping to prime parameters.
-        grouped_prime_parameters = {
-            parameter: [] for parameter in model_parameters
-        }
-        # Prime parameters that are derived from other prime parameters
-        auxiliary_prime_parameters = []
+        # x-prime parameters are ordering by the reparameterisation order
+        # the 'visible' prime parameters are those that are not intermediate
+        # inputs and are visible to the flow
+        all_prime_parameters = []
+        visible_prime_parameters = []
 
         for reparameterisation in self._reparameterisation.values():
-            owned_model_parameters = [
-                parameter
-                for parameter in reparameterisation.parameters
-                if parameter in model_parameters
-            ]
+            # Remove any intermediate inputs that are not persistent
+            for parameter in reparameterisation.x_prime_input_parameters:
+                if (
+                    parameter
+                    in reparameterisation.x_prime_persistent_parameters
+                ):
+                    continue
+                if parameter in visible_prime_parameters:
+                    visible_prime_parameters.remove(parameter)
+            for parameter in reparameterisation.output_parameters:
+                if parameter not in all_prime_parameters:
+                    all_prime_parameters.append(parameter)
+                if parameter not in visible_prime_parameters:
+                    visible_prime_parameters.append(parameter)
 
-            if owned_model_parameters and len(owned_model_parameters) == len(
-                reparameterisation.prime_parameters
-            ):
-                parameter_to_prime.update(
-                    zip(
-                        owned_model_parameters,
-                        reparameterisation.prime_parameters,
-                    )
-                )
-            elif owned_model_parameters:
-                grouped_prime_parameters[owned_model_parameters[0]].extend(
-                    reparameterisation.prime_parameters
-                )
-            else:
-                auxiliary_prime_parameters.extend(
-                    reparameterisation.prime_parameters
-                )
-
-        self.prime_parameters = []
-        for parameter in model_parameters:
-            self.prime_parameters.extend(grouped_prime_parameters[parameter])
-            if parameter in parameter_to_prime:
-                self.prime_parameters.append(parameter_to_prime[parameter])
-
-        self.prime_parameters.extend(auxiliary_prime_parameters)
+        # The inverse pass still needs access to every produced prime
+        # parameter, even if some of them are hidden from the flow-facing
+        # training space.
+        self._prime_parameters_internal = all_prime_parameters
+        self.prime_parameters = visible_prime_parameters
+        self._x_prime_dtype = None
+        self._x_prime_internal_dtype = None
 
     def configure_reparameterisations(self, reparameterisations):
         """Configure the reparameterisations.
@@ -587,7 +598,7 @@ class BaseFlowProposal(RejectionProposal):
                 f"({FallbackClass.__name__}) for {other_params} with kwargs: "
                 f"{fallback_kwargs}."
             )
-            r = FallbackClass(parameters=other_params, **fallback_kwargs)
+            r = FallbackClass(input_parameters=other_params, **fallback_kwargs)
             self._reparameterisation.add_reparameterisations(r)
 
         if any(r._update for r in self._reparameterisation.values()):
@@ -610,6 +621,13 @@ class BaseFlowProposal(RejectionProposal):
 
         logger.info(f"x space parameters: {self.parameters}")
         logger.info(f"x prime space parameters: {self.prime_parameters}")
+        if self._prime_parameters_internal != self.prime_parameters:
+            intermediate = [
+                p
+                for p in self._prime_parameters_internal
+                if p not in self.prime_parameters
+            ]
+            logger.info(f"Intermediate parameters: {intermediate}")
         self.rescaling_set = True
 
     def verify_rescaling(self):
@@ -693,7 +711,9 @@ class BaseFlowProposal(RejectionProposal):
         array
             Array of log det|J|
         """
-        x_prime = empty_structured_array(x.size, dtype=self.x_prime_dtype)
+        x_prime = empty_structured_array(
+            x.size, dtype=self.x_prime_internal_dtype
+        )
         log_J = np.zeros(x_prime.size)
 
         if x.size == 1:
@@ -972,10 +992,14 @@ class BaseFlowProposal(RejectionProposal):
         # Compute the log probability
         x, log_j = self.flow.inverse(z)
 
-        x = numpy_array_to_live_points(
-            x.astype(config.livepoints.default_float_dtype),
-            self.prime_parameters,
+        x_array = np.asarray(x, dtype=config.livepoints.default_float_dtype)
+        if x_array.ndim == 1:
+            x_array = x_array[np.newaxis, :]
+        x = empty_structured_array(
+            x_array.shape[0], dtype=self.x_prime_internal_dtype
         )
+        for i, parameter in enumerate(self.prime_parameters):
+            x[parameter] = x_array[:, i]
         # Apply rescaling in rescale=True
         if rescale:
             x, log_j_rescale = self.inverse_rescale(x, **kwargs)

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -396,6 +396,52 @@ class BaseFlowProposal(RejectionProposal):
         """Get the reparameterisation from the name"""
         return get_reparameterisation(name)
 
+    def _resolve_reparameterisation_parameters(self, parameters):
+        """Resolve parameter names or regex patterns for reparameterisations."""
+        if parameters is None:
+            return None
+
+        if isinstance(parameters, str):
+            patterns = [parameters]
+        else:
+            patterns = list(parameters)
+
+        known_parameters = set(
+            self.model.names + self._reparameterisation.parameters
+        )
+
+        matches = []
+        for pattern in patterns:
+            if pattern in known_parameters:
+                matches.append(pattern)
+                continue
+
+            r = re.compile(pattern)
+            pattern_matches = list(filter(r.fullmatch, known_parameters))
+            if pattern_matches:
+                matches.extend(pattern_matches)
+            else:
+                matches.append(pattern)
+
+        return list(dict.fromkeys(matches))
+
+    def _get_prior_bounds_for_parameters(self, parameters):
+        """Get prior bounds for parameters that are model parameters."""
+        if isinstance(parameters, list):
+            prior_bounds = {
+                p: self.prior_bounds[p]
+                for p in parameters
+                if p in self.prior_bounds
+            }
+        elif parameters in self.prior_bounds:
+            prior_bounds = {parameters: self.prior_bounds[parameters]}
+        else:
+            prior_bounds = {}
+
+        if prior_bounds:
+            return prior_bounds
+        return None
+
     def _set_parameter_order(self):
         """Set stable proposal-facing parameter orders.
 
@@ -478,7 +524,8 @@ class BaseFlowProposal(RejectionProposal):
             _reparameterisations = copy.deepcopy(reparameterisations)
         logger.info(f"Adding reparameterisations from: {_reparameterisations}")
         self._reparameterisation = CombinedReparameterisation(
-            reverse_order=self.reverse_reparameterisations
+            reverse_order=self.reverse_reparameterisations,
+            initial_parameters=list(self.model.names),
         )
         if isinstance(_reparameterisations, str):
             _reparameterisations = {
@@ -534,23 +581,12 @@ class BaseFlowProposal(RejectionProposal):
                         logger.debug("Assuming list of patterns")
                         cfg = {"parameters": cfg}
                     default_config.update(cfg)
-                    parameters = default_config.get("parameters")
+                    parameters = self._resolve_reparameterisation_parameters(
+                        default_config.get("parameters")
+                    )
 
                     if parameters is not None:
-                        if not isinstance(parameters, list):
-                            if isinstance(parameters, str):
-                                patterns = [parameters]
-                            else:
-                                patterns = list(parameters)
-                        else:
-                            patterns = parameters.copy()
-                        matches = []
-                        for pattern in patterns:
-                            r = re.compile(pattern)
-                            matches += list(
-                                filter(r.fullmatch, self.model.names)
-                            )
-                        default_config["parameters"] = matches
+                        default_config["parameters"] = parameters
                     else:
                         logger.warning(
                             "Reparameterisation might be missing parameters!"
@@ -575,17 +611,9 @@ class BaseFlowProposal(RejectionProposal):
             ):
                 self.boundary_inversion = True
 
-            if isinstance(default_config["parameters"], list):
-                prior_bounds = {
-                    p: self.prior_bounds[p]
-                    for p in default_config["parameters"]
-                }
-            else:
-                prior_bounds = {
-                    default_config["parameters"]: self.prior_bounds[
-                        default_config["parameters"]
-                    ]
-                }
+            prior_bounds = self._get_prior_bounds_for_parameters(
+                default_config["parameters"]
+            )
             sig = signature(rc.__init__)
             if "rng" in sig.parameters:
                 default_config["rng"] = self.rng

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -1,9 +1,7 @@
 """Base proposal class that contains common methods."""
 
-import copy
 import logging
 import os
-import re
 from abc import abstractmethod
 from inspect import signature
 from typing import Optional
@@ -23,10 +21,14 @@ from ...livepoint import (
     numpy_array_to_live_points,
 )
 from ...plot import nessai_style, plot_1d_comparison, plot_live_points
-from ...reparameterisations import (
+from ...reparameterisations.combined import (
     CombinedReparameterisation,
+)
+from ...reparameterisations.utils import (
     ReparameterisationError,
     get_reparameterisation,
+    parse_reparameterisations,
+    resolve_reparameterisation_parameters,
 )
 from ...utils import (
     save_live_points,
@@ -396,51 +398,90 @@ class BaseFlowProposal(RejectionProposal):
         """Get the reparameterisation from the name"""
         return get_reparameterisation(name)
 
-    def _resolve_reparameterisation_parameters(self, parameters):
-        """Resolve parameter names or regex patterns for reparameterisations."""
-        if parameters is None:
-            return None
-
-        if isinstance(parameters, str):
-            patterns = [parameters]
-        else:
-            patterns = list(parameters)
-
-        known_parameters = set(
-            self.model.names + self._reparameterisation.parameters
-        )
-
-        matches = []
-        for pattern in patterns:
-            if pattern in known_parameters:
-                matches.append(pattern)
-                continue
-
-            r = re.compile(pattern)
-            pattern_matches = list(filter(r.fullmatch, known_parameters))
-            if pattern_matches:
-                matches.extend(pattern_matches)
-            else:
-                matches.append(pattern)
-
-        return list(dict.fromkeys(matches))
-
     def _get_prior_bounds_for_parameters(self, parameters):
         """Get prior bounds for parameters that are model parameters."""
+        prior_bounds_lookup = getattr(self, "prior_bounds", None)
+        if not isinstance(prior_bounds_lookup, dict):
+            prior_bounds_lookup = self.model.bounds
+
         if isinstance(parameters, list):
             prior_bounds = {
-                p: self.prior_bounds[p]
+                p: prior_bounds_lookup[p]
                 for p in parameters
-                if p in self.prior_bounds
+                if p in prior_bounds_lookup
             }
-        elif parameters in self.prior_bounds:
-            prior_bounds = {parameters: self.prior_bounds[parameters]}
+        elif parameters in prior_bounds_lookup:
+            prior_bounds = {parameters: prior_bounds_lookup[parameters]}
         else:
             prior_bounds = {}
 
         if prior_bounds:
             return prior_bounds
         return None
+
+    def get_reparameterisation_from_spec(self, spec):
+        """Get the reparameterisation class and config from a reparameterisation spec."""
+        try:
+            rc, default_config = self.get_reparameterisation(
+                spec.reparameterisation
+            )
+        except ValueError:
+            raise RuntimeError(
+                f"{spec.source_key} is not a parameter in the model or a known "
+                "reparameterisation"
+            )
+
+        config = default_config.copy()
+        config.update(spec.kwargs)
+
+        if spec.source_is_parameter:
+            config["parameters"] = spec.parameters
+        else:
+            parameters = resolve_reparameterisation_parameters(
+                spec.parameters,
+                available_parameters=list(
+                    dict.fromkeys(
+                        list(self.model.names)
+                        + list(self._reparameterisation.parameters)
+                    )
+                ),
+            )
+            if parameters is not None:
+                config["parameters"] = parameters
+            else:
+                logger.warning(
+                    "Reparameterisation might be missing parameters!"
+                )
+
+        if "parameters" not in config:
+            raise RuntimeError(
+                "No parameters key in the config! "
+                "Check reparameterisations, setting logging"
+                " level to DEBUG can be helpful"
+            )
+        if not config["parameters"] and not config.get("prime_requires"):
+            raise RuntimeError(
+                "No parameters key in the config! "
+                "Check reparameterisations, setting logging"
+                " level to DEBUG can be helpful"
+            )
+
+        return rc, config
+
+    def instantiate_reparameterisation_from_spec(self, spec):
+        """Instantiate a reparameterisation from a spec."""
+        rc, config = self.get_reparameterisation_from_spec(spec)
+
+        prior_bounds = self._get_prior_bounds_for_parameters(
+            config["parameters"]
+        )
+        sig = signature(rc.__init__)
+        if "rng" in sig.parameters:
+            config["rng"] = self.rng
+
+        logger.info(f"Instantiating {rc.__name__} with config: {config}")
+        reparameterisation = rc(prior_bounds=prior_bounds, **config)
+        return reparameterisation
 
     def _set_parameter_order(self):
         """Set stable proposal-facing parameter orders.
@@ -514,113 +555,20 @@ class BaseFlowProposal(RejectionProposal):
             Dictionary of reparameterisations. If None, then the defaults
             from :py:func`get_default_reparameterisations` are used.
         """
-        if reparameterisations is None:
-            logger.info(
-                "No reparameterisations provided, using default "
-                f"reparameterisations included in {self.__class__.__name__}"
-            )
-            _reparameterisations = {}
-        else:
-            _reparameterisations = copy.deepcopy(reparameterisations)
-        logger.info(f"Adding reparameterisations from: {_reparameterisations}")
+        logger.info(f"Adding reparameterisations from: {reparameterisations}")
         self._reparameterisation = CombinedReparameterisation(
             reverse_order=self.reverse_reparameterisations,
             initial_parameters=list(self.model.names),
         )
-        if isinstance(_reparameterisations, str):
-            _reparameterisations = {
-                _reparameterisations: {"parameters": self.model.names}
-            }
-        elif not isinstance(_reparameterisations, dict):
-            raise TypeError(
-                "Reparameterisations must be a dictionary, string or None, "
-                f"received {type(_reparameterisations).__name__}"
-            )
 
-        for k, cfg in _reparameterisations.items():
-            if k in self.model.names:
-                logger.debug(
-                    f"Found parameter {k} in model, assuming it is a parameter"
-                )
-                if isinstance(cfg, str) or cfg is None:
-                    rc, default_config = self.get_reparameterisation(cfg)
-                    default_config["parameters"] = k
-                elif isinstance(cfg, dict):
-                    if cfg.get("reparameterisation", None) is None:
-                        raise RuntimeError(
-                            f"No reparameterisation found for {k}. "
-                            "Check inputs (and their spelling :)). "
-                            f"Current keys: {list(cfg.keys())}"
-                        )
-                    rc, default_config = self.get_reparameterisation(
-                        cfg["reparameterisation"]
-                    )
-                    cfg.pop("reparameterisation")
-
-                    if cfg.get("parameters", False):
-                        parameters = cfg.pop("parameters")
-                        if isinstance(parameters, str):
-                            parameters = [parameters]
-                        default_config["parameters"] = list(
-                            dict.fromkeys([k, *parameters])
-                        )
-                    else:
-                        default_config["parameters"] = k
-
-                    default_config.update(cfg)
-                else:
-                    raise TypeError(
-                        f"Unknown config type for: {k}. Expected str or dict, "
-                        f"received instance of {type(cfg)}."
-                    )
-            else:
-                logger.debug(f"Assuming {k} is a reparameterisation")
-                try:
-                    rc, default_config = self.get_reparameterisation(k)
-                    if isinstance(cfg, list):
-                        logger.debug("Assuming list of patterns")
-                        cfg = {"parameters": cfg}
-                    default_config.update(cfg)
-                    parameters = self._resolve_reparameterisation_parameters(
-                        default_config.get("parameters")
-                    )
-
-                    if parameters is not None:
-                        default_config["parameters"] = parameters
-                    else:
-                        logger.warning(
-                            "Reparameterisation might be missing parameters!"
-                        )
-
-                except ValueError:
-                    raise RuntimeError(
-                        f"{k} is not a parameter in the model or a known "
-                        "reparameterisation"
-                    )
-
-            if not default_config.get("parameters", False):
-                raise RuntimeError(
-                    "No parameters key in the config! "
-                    "Check reparameterisations, setting logging"
-                    " level to DEBUG can be helpful"
-                )
-
-            if (
-                "boundary_inversion" in default_config
-                and default_config["boundary_inversion"]
-            ):
-                self.boundary_inversion = True
-
-            prior_bounds = self._get_prior_bounds_for_parameters(
-                default_config["parameters"]
-            )
-            sig = signature(rc.__init__)
-            if "rng" in sig.parameters:
-                default_config["rng"] = self.rng
-
-            logger.info(f"Adding {rc.__name__} with config: {default_config}")
-            r = rc(prior_bounds=prior_bounds, **default_config)
-            self._reparameterisation.add_reparameterisations(r)
+        specs = parse_reparameterisations(
+            reparameterisations,
+            model_names=list(self.model.names),
+            class_name=self.__class__.__name__,
+        )
+        for spec in specs:
+            reparam = self.instantiate_reparameterisation_from_spec(spec)
+            self._reparameterisation.add_reparameterisations(reparam)
 
         if self.use_default_reparameterisations:
             self.add_default_reparameterisations()
@@ -635,8 +583,13 @@ class BaseFlowProposal(RejectionProposal):
             FallbackClass, fallback_kwargs = self.get_reparameterisation(
                 self.fallback_reparameterisation
             )
+            prior_bounds_lookup = getattr(self, "prior_bounds", None)
+            if not isinstance(prior_bounds_lookup, dict) or any(
+                p not in prior_bounds_lookup for p in other_params
+            ):
+                prior_bounds_lookup = self.model.bounds
             fallback_kwargs["prior_bounds"] = {
-                p: self.prior_bounds[p] for p in other_params
+                p: prior_bounds_lookup[p] for p in other_params
             }
             logger.info(
                 f"Assuming fallback reparameterisation "

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -583,14 +583,9 @@ class BaseFlowProposal(RejectionProposal):
             FallbackClass, fallback_kwargs = self.get_reparameterisation(
                 self.fallback_reparameterisation
             )
-            prior_bounds_lookup = getattr(self, "prior_bounds", None)
-            if not isinstance(prior_bounds_lookup, dict) or any(
-                p not in prior_bounds_lookup for p in other_params
-            ):
-                prior_bounds_lookup = self.model.bounds
-            fallback_kwargs["prior_bounds"] = {
-                p: prior_bounds_lookup[p] for p in other_params
-            }
+            fallback_kwargs["prior_bounds"] = (
+                self._get_prior_bounds_for_parameters(other_params)
+            )
             logger.info(
                 f"Assuming fallback reparameterisation "
                 f"({FallbackClass.__name__}) for {other_params} with kwargs: "

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -13,7 +13,6 @@ from scipy.special import logsumexp
 from ... import config
 from ...livepoint import (
     empty_structured_array,
-    numpy_array_to_live_points,
 )
 from ...utils import (
     compute_radius,
@@ -378,10 +377,14 @@ class FlowProposal(BaseFlowProposal):
         if discard_nans:
             valid = np.isfinite(log_prob)
             x, log_prob, z = get_subset_arrays(valid, x, log_prob, z)
-        x = numpy_array_to_live_points(
-            x.astype(config.livepoints.default_float_dtype),
-            self.prime_parameters,
+        x_array = np.asarray(x, dtype=config.livepoints.default_float_dtype)
+        if x_array.ndim == 1:
+            x_array = x_array[np.newaxis, :]
+        x = empty_structured_array(
+            x_array.shape[0], dtype=self.x_prime_internal_dtype
         )
+        for i, parameter in enumerate(self.prime_parameters):
+            x[parameter] = x_array[:, i]
         # Apply rescaling in rescale=True
         if rescale:
             x, log_J = self.inverse_rescale(

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -39,25 +39,25 @@ class Angle(Reparameterisation):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         scale=1.0,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        inverse_input_parameters=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            inverse_input_parameters=inverse_input_parameters,
+            parameters=parameters,
         )
 
         if len(self.parameters) == 1:
@@ -81,8 +81,8 @@ class Angle(Reparameterisation):
             self._zero_bound = False
 
         # overwrite the prime parameters if not specified
-        if prime_parameters is None:
-            self.prime_parameters = [self.angle + "_x", self.angle + "_y"]
+        if output_parameters is None:
+            self.output_parameters = [self.angle + "_x", self.angle + "_y"]
 
     @property
     def angle(self):
@@ -104,18 +104,28 @@ class Angle(Reparameterisation):
     @property
     def x(self):
         """The name of x coordinate"""
-        return self.prime_parameters[0]
+        return self.output_parameters[0]
 
     @property
     def y(self):
         """The name of y coordinate"""
-        return self.prime_parameters[1]
+        return self.output_parameters[1]
 
     def _rescale_radial(self, x, x_prime, log_j, **kwargs):
-        return x[self.radial], x, x_prime, log_j
+        return (
+            self.get_value(self.radial, x, x_prime),
+            x,
+            x_prime,
+            log_j,
+        )
 
     def _rescale_angle(self, x, x_prime, log_j, **kwargs):
-        return x[self.angle] * self.scale, x, x_prime, log_j
+        return (
+            self.get_value(self.angle, x, x_prime) * self.scale,
+            x,
+            x_prime,
+            log_j,
+        )
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
         return x, x_prime, log_j
@@ -135,36 +145,38 @@ class Angle(Reparameterisation):
         if any(r < 0):
             raise RuntimeError("Radius cannot be negative.")
 
-        x_prime[self.prime_parameters[0]] = r * np.cos(angle)
-        x_prime[self.prime_parameters[1]] = r * np.sin(angle)
+        x_prime[self.output_parameters[0]] = r * np.cos(angle)
+        x_prime[self.output_parameters[1]] = r * np.sin(angle)
         log_j += np.log(r)
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
         """Convert from Cartesian to an angle and radial component"""
-        x[self.radial] = np.sqrt(
-            x_prime[self.prime_parameters[0]] ** 2
-            + x_prime[self.prime_parameters[1]] ** 2
+        radial = np.sqrt(
+            x_prime[self.output_parameters[0]] ** 2
+            + x_prime[self.output_parameters[1]] ** 2
         )
         if self._zero_bound:
-            x[self.angle] = (
+            angle = (
                 np.arctan2(
-                    x_prime[self.prime_parameters[1]],
-                    x_prime[self.prime_parameters[0]],
+                    x_prime[self.output_parameters[1]],
+                    x_prime[self.output_parameters[0]],
                 )
                 % (2.0 * np.pi)
                 / self.scale
             )
         else:
-            x[self.angle] = (
+            angle = (
                 np.arctan2(
-                    x_prime[self.prime_parameters[1]],
-                    x_prime[self.prime_parameters[0]],
+                    x_prime[self.output_parameters[1]],
+                    x_prime[self.output_parameters[0]],
                 )
                 / self.scale
             )
 
-        log_j -= np.log(x[self.radial])
+        log_j -= np.log(radial)
+        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
+        x, x_prime = self._set_value(self.angle, angle, x, x_prime)
         x, x_prime, log_j = self._inverse_rescale_angle(x, x_prime, log_j)
 
         return x, x_prime, log_j
@@ -192,7 +204,8 @@ class ToCartesian(Angle):
         self, x, x_prime, log_j, compute_radius=False, **kwargs
     ):
         angle, lj = rescale_zero_to_one(
-            x[self.parameters[0]], *self.prior_bounds[self.parameters[0]]
+            self.get_value(self.parameters[0], x, x_prime),
+            *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
         if self.mode == "duplicate" or compute_radius:
@@ -208,11 +221,12 @@ class ToCartesian(Angle):
         return angle, x, x_prime, log_j
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
-        x[self.parameters[0]], lj = inverse_rescale_zero_to_one(
-            np.abs(x[self.parameters[0]]),
+        angle, lj = inverse_rescale_zero_to_one(
+            np.abs(self.get_value(self.parameters[0], x, x_prime)),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
+        x, x_prime = self._set_value(self.parameters[0], angle, x, x_prime)
         return x, x_prime, log_j
 
 
@@ -248,35 +262,39 @@ class AnglePair(Reparameterisation):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         convention=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        inverse_input_parameters=None,
+        parameters=None,
     ):
-        if len(parameters) not in [2, 3]:
+        inputs = (
+            input_parameters if input_parameters is not None else parameters
+        )
+        if len(inputs) not in [2, 3]:
             raise RuntimeError(
                 "Must use a pair of angles or a pair plus a radius"
             )
 
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            inverse_input_parameters=inverse_input_parameters,
+            parameters=parameters,
         )
 
         # Determine which parameter is for the horizontal plane
         # and which is for the vertical plane
         logger.debug("Checking order of parameters")
+        parameters = self.input_parameters.copy()
         b = np.ptp([prior_bounds[p] for p in parameters], axis=1)
         try:
             hz = np.where(b == (2 * np.pi))[0][0]
@@ -318,9 +336,9 @@ class AnglePair(Reparameterisation):
                 f"[-pi, pi]. Received: {self.prior_bounds[parameters[0]]}"
             )
 
-        self.parameters = parameters
+        self.input_parameters = parameters
         self.auxiliary_parameters = auxiliary_parameters
-        self.prime_parameters = [f"{m}_{x}" for x in ["x", "y", "z"]]
+        self.output_parameters = [f"{m}_{x}" for x in ["x", "y", "z"]]
 
         if convention is None:
             logger.debug("Trying to determine convention")
@@ -334,7 +352,7 @@ class AnglePair(Reparameterisation):
                 self.convention = "ra-dec"
             else:
                 raise RuntimeError(
-                    f"Could not determine convention for: {self.parameters}!"
+                    f"Could not determine convention for: {self.input_parameters}!"
                 )
         elif convention in self._conventions.keys():
             self.convention = convention
@@ -355,7 +373,7 @@ class AnglePair(Reparameterisation):
 
         logger.debug(f"Using convention: {self.convention}")
 
-        self.requires = []
+        self._resolved_forward_inputs = False
 
     @property
     def angles(self):
@@ -375,99 +393,109 @@ class AnglePair(Reparameterisation):
     @property
     def x(self):
         """Name of the first Cartesian coordinate"""
-        return self.prime_parameters[0]
+        return self.output_parameters[0]
 
     @property
     def y(self):
         """Name of the second Cartesian coordinate"""
-        return self.prime_parameters[1]
+        return self.output_parameters[1]
 
     @property
     def z(self):
         """Name of the third Cartesian coordinate"""
-        return self.prime_parameters[2]
+        return self.output_parameters[2]
 
     def _az_zen(self, x, x_prime, log_j, r):
-        x_prime[self.prime_parameters[0]] = (
-            r * np.sin(x[self.parameters[1]]) * np.cos(x[self.parameters[0]])
+        horizontal = self.get_value(self.parameters[0], x, x_prime)
+        vertical = self.get_value(self.parameters[1], x, x_prime)
+        x_prime[self.output_parameters[0]] = (
+            r * np.sin(vertical) * np.cos(horizontal)
         )
-        x_prime[self.prime_parameters[1]] = (
-            r * np.sin(x[self.parameters[1]]) * np.sin(x[self.parameters[0]])
+        x_prime[self.output_parameters[1]] = (
+            r * np.sin(vertical) * np.sin(horizontal)
         )
-        x_prime[self.prime_parameters[2]] = r * np.cos(x[self.parameters[1]])
-        log_j += 2 * np.log(r) + np.log(np.sin(x[self.parameters[1]]))
+        x_prime[self.output_parameters[2]] = r * np.cos(vertical)
+        log_j += 2 * np.log(r) + np.log(np.sin(vertical))
         return x, x_prime, log_j
 
     def _ra_dec(self, x, x_prime, log_j, r):
-        x_prime[self.prime_parameters[0]] = (
-            r * np.cos(x[self.parameters[1]]) * np.cos(x[self.parameters[0]])
+        horizontal = self.get_value(self.parameters[0], x, x_prime)
+        vertical = self.get_value(self.parameters[1], x, x_prime)
+        x_prime[self.output_parameters[0]] = (
+            r * np.cos(vertical) * np.cos(horizontal)
         )
-        x_prime[self.prime_parameters[1]] = (
-            r * np.cos(x[self.parameters[1]]) * np.sin(x[self.parameters[0]])
+        x_prime[self.output_parameters[1]] = (
+            r * np.cos(vertical) * np.sin(horizontal)
         )
-        x_prime[self.prime_parameters[2]] = r * np.sin(x[self.parameters[1]])
-        log_j += 2 * np.log(r) + np.log(np.cos(x[self.parameters[1]]))
+        x_prime[self.output_parameters[2]] = r * np.sin(vertical)
+        log_j += 2 * np.log(r) + np.log(np.cos(vertical))
         return x, x_prime, log_j
 
     def _inv_az_zen(self, x, x_prime, log_j):
-        x[self.radial] = np.sqrt(
-            x_prime[self.prime_parameters[0]] ** 2.0
-            + x_prime[self.prime_parameters[1]] ** 2.0
-            + x_prime[self.prime_parameters[2]] ** 2.0
+        radial = np.sqrt(
+            x_prime[self.output_parameters[0]] ** 2.0
+            + x_prime[self.output_parameters[1]] ** 2.0
+            + x_prime[self.output_parameters[2]] ** 2.0
         )
 
         if self._modulo_2pi:
-            x[self.parameters[0]] = np.arctan2(
-                x_prime[self.prime_parameters[1]],
-                x_prime[self.prime_parameters[0]],
+            horizontal = np.arctan2(
+                x_prime[self.output_parameters[1]],
+                x_prime[self.output_parameters[0]],
             ) % (2.0 * np.pi)
         else:
-            x[self.parameters[0]] = np.arctan2(
-                x_prime[self.prime_parameters[1]],
-                x_prime[self.prime_parameters[0]],
+            horizontal = np.arctan2(
+                x_prime[self.output_parameters[1]],
+                x_prime[self.output_parameters[0]],
             )
-        x[self.parameters[1]] = np.arctan2(
+        vertical = np.arctan2(
             np.sqrt(
-                x_prime[self.prime_parameters[0]] ** 2.0
-                + x_prime[self.prime_parameters[1]] ** 2.0
+                x_prime[self.output_parameters[0]] ** 2.0
+                + x_prime[self.output_parameters[1]] ** 2.0
             ),
-            x_prime[self.prime_parameters[2]],
+            x_prime[self.output_parameters[2]],
         )
-        log_j += -2 * np.log(x[self.radial]) - np.log(
-            np.sin(x[self.parameters[1]])
+        log_j += -2 * np.log(radial) - np.log(np.sin(vertical))
+        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
+        x, x_prime = self._set_value(
+            self.parameters[0], horizontal, x, x_prime
         )
+        x, x_prime = self._set_value(self.parameters[1], vertical, x, x_prime)
 
         return x, x_prime, log_j
 
     def _inv_ra_dec(self, x, x_prime, log_j):
-        x[self.radial] = np.sqrt(
-            x_prime[self.prime_parameters[0]] ** 2.0
-            + x_prime[self.prime_parameters[1]] ** 2.0
-            + x_prime[self.prime_parameters[2]] ** 2.0
+        radial = np.sqrt(
+            x_prime[self.output_parameters[0]] ** 2.0
+            + x_prime[self.output_parameters[1]] ** 2.0
+            + x_prime[self.output_parameters[2]] ** 2.0
         )
 
         if self._modulo_2pi:
-            x[self.parameters[0]] = np.arctan2(
-                x_prime[self.prime_parameters[1]],
-                x_prime[self.prime_parameters[0]],
+            horizontal = np.arctan2(
+                x_prime[self.output_parameters[1]],
+                x_prime[self.output_parameters[0]],
             ) % (2.0 * np.pi)
         else:
-            x[self.parameters[0]] = np.arctan2(
-                x_prime[self.prime_parameters[1]],
-                x_prime[self.prime_parameters[0]],
+            horizontal = np.arctan2(
+                x_prime[self.output_parameters[1]],
+                x_prime[self.output_parameters[0]],
             )
 
-        x[self.parameters[1]] = np.arctan2(
-            x_prime[self.prime_parameters[2]],
+        vertical = np.arctan2(
+            x_prime[self.output_parameters[2]],
             np.sqrt(
-                x_prime[self.prime_parameters[0]] ** 2.0
-                + x_prime[self.prime_parameters[1]] ** 2.0
+                x_prime[self.output_parameters[0]] ** 2.0
+                + x_prime[self.output_parameters[1]] ** 2.0
             ),
         )
 
-        log_j += -2 * np.log(x[self.radial]) - np.log(
-            np.cos(x[self.parameters[1]])
+        log_j += -2 * np.log(radial) - np.log(np.cos(vertical))
+        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
+        x, x_prime = self._set_value(
+            self.parameters[0], horizontal, x, x_prime
         )
+        x, x_prime = self._set_value(self.parameters[1], vertical, x, x_prime)
         return x, x_prime, log_j
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -477,7 +505,7 @@ class AnglePair(Reparameterisation):
         if self.chi:
             r = self.chi.rvs(size=x.size, random_state=self.rng)
         else:
-            r = x[self.radial]
+            r = self.get_value(self.radial, x, x_prime)
         if any(r < 0):
             raise RuntimeError("Radius cannot be negative.")
 

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -113,7 +113,7 @@ class Angle(Reparameterisation):
 
     def _rescale_radial(self, x, x_prime, log_j, **kwargs):
         return (
-            self.get_value(self.radial, x, x_prime),
+            self._get_value(self.radial, x, x_prime),
             x,
             x_prime,
             log_j,
@@ -121,7 +121,7 @@ class Angle(Reparameterisation):
 
     def _rescale_angle(self, x, x_prime, log_j, **kwargs):
         return (
-            self.get_value(self.angle, x, x_prime) * self.scale,
+            self._get_value(self.angle, x, x_prime) * self.scale,
             x,
             x_prime,
             log_j,
@@ -204,7 +204,7 @@ class ToCartesian(Angle):
         self, x, x_prime, log_j, compute_radius=False, **kwargs
     ):
         angle, lj = rescale_zero_to_one(
-            self.get_value(self.parameters[0], x, x_prime),
+            self._get_value(self.parameters[0], x, x_prime),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
@@ -222,7 +222,7 @@ class ToCartesian(Angle):
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
         angle, lj = inverse_rescale_zero_to_one(
-            np.abs(self.get_value(self.parameters[0], x, x_prime)),
+            np.abs(self._get_value(self.parameters[0], x, x_prime)),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
@@ -406,8 +406,8 @@ class AnglePair(Reparameterisation):
         return self.output_parameters[2]
 
     def _az_zen(self, x, x_prime, log_j, r):
-        horizontal = self.get_value(self.parameters[0], x, x_prime)
-        vertical = self.get_value(self.parameters[1], x, x_prime)
+        horizontal = self._get_value(self.parameters[0], x, x_prime)
+        vertical = self._get_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.sin(vertical) * np.cos(horizontal)
         )
@@ -419,8 +419,8 @@ class AnglePair(Reparameterisation):
         return x, x_prime, log_j
 
     def _ra_dec(self, x, x_prime, log_j, r):
-        horizontal = self.get_value(self.parameters[0], x, x_prime)
-        vertical = self.get_value(self.parameters[1], x, x_prime)
+        horizontal = self._get_value(self.parameters[0], x, x_prime)
+        vertical = self._get_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.cos(vertical) * np.cos(horizontal)
         )
@@ -505,7 +505,7 @@ class AnglePair(Reparameterisation):
         if self.chi:
             r = self.chi.rvs(size=x.size, random_state=self.rng)
         else:
-            r = self.get_value(self.radial, x, x_prime)
+            r = self._get_value(self.radial, x, x_prime)
         if any(r < 0):
             raise RuntimeError("Radius cannot be negative.")
 

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -237,8 +237,6 @@ class AnglePair(Reparameterisation):
         optionally, also a radial component.
     prior_bounds : dict
         Dictionary of prior bounds for each parameter
-    prior : str, {'isotropic', None}
-        Type of prior, used to enable use of the prime prior.
     convention : str, {'ra-dec', 'az-zen'}
         Convention used for defining the spherical polar coordinates. If not
         set, it will be guessed based on either dec or zen. Where it is assumed
@@ -251,9 +249,14 @@ class AnglePair(Reparameterisation):
     def __init__(
         self,
         parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
         prior_bounds=None,
         convention=None,
         rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
     ):
         if len(parameters) not in [2, 3]:
             raise RuntimeError(
@@ -261,7 +264,14 @@ class AnglePair(Reparameterisation):
             )
 
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
 
         # Determine which parameter is for the horizontal plane

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -113,7 +113,7 @@ class Angle(Reparameterisation):
 
     def _rescale_radial(self, x, x_prime, log_j, **kwargs):
         return (
-            self._get_value(self.radial, x, x_prime),
+            self.get_parameters_value(self.radial, x, x_prime),
             x,
             x_prime,
             log_j,
@@ -121,7 +121,7 @@ class Angle(Reparameterisation):
 
     def _rescale_angle(self, x, x_prime, log_j, **kwargs):
         return (
-            self._get_value(self.angle, x, x_prime) * self.scale,
+            self.get_parameters_value(self.angle, x, x_prime) * self.scale,
             x,
             x_prime,
             log_j,
@@ -175,8 +175,8 @@ class Angle(Reparameterisation):
             )
 
         log_j -= np.log(radial)
-        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
-        x, x_prime = self._set_value(self.angle, angle, x, x_prime)
+        x, x_prime = self.set_parameter_value(self.radial, radial, x, x_prime)
+        x, x_prime = self.set_parameter_value(self.angle, angle, x, x_prime)
         x, x_prime, log_j = self._inverse_rescale_angle(x, x_prime, log_j)
 
         return x, x_prime, log_j
@@ -204,7 +204,7 @@ class ToCartesian(Angle):
         self, x, x_prime, log_j, compute_radius=False, **kwargs
     ):
         angle, lj = rescale_zero_to_one(
-            self._get_value(self.parameters[0], x, x_prime),
+            self.get_parameters_value(self.parameters[0], x, x_prime),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
@@ -222,11 +222,13 @@ class ToCartesian(Angle):
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
         angle, lj = inverse_rescale_zero_to_one(
-            np.abs(self._get_value(self.parameters[0], x, x_prime)),
+            np.abs(self.get_parameters_value(self.parameters[0], x, x_prime)),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
-        x, x_prime = self._set_value(self.parameters[0], angle, x, x_prime)
+        x, x_prime = self.set_parameter_value(
+            self.parameters[0], angle, x, x_prime
+        )
         return x, x_prime, log_j
 
 
@@ -406,8 +408,8 @@ class AnglePair(Reparameterisation):
         return self.output_parameters[2]
 
     def _az_zen(self, x, x_prime, log_j, r):
-        horizontal = self._get_value(self.parameters[0], x, x_prime)
-        vertical = self._get_value(self.parameters[1], x, x_prime)
+        horizontal = self.get_parameters_value(self.parameters[0], x, x_prime)
+        vertical = self.get_parameters_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.sin(vertical) * np.cos(horizontal)
         )
@@ -419,8 +421,8 @@ class AnglePair(Reparameterisation):
         return x, x_prime, log_j
 
     def _ra_dec(self, x, x_prime, log_j, r):
-        horizontal = self._get_value(self.parameters[0], x, x_prime)
-        vertical = self._get_value(self.parameters[1], x, x_prime)
+        horizontal = self.get_parameters_value(self.parameters[0], x, x_prime)
+        vertical = self.get_parameters_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.cos(vertical) * np.cos(horizontal)
         )
@@ -456,11 +458,13 @@ class AnglePair(Reparameterisation):
             x_prime[self.output_parameters[2]],
         )
         log_j += -2 * np.log(radial) - np.log(np.sin(vertical))
-        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
-        x, x_prime = self._set_value(
+        x, x_prime = self.set_parameter_value(self.radial, radial, x, x_prime)
+        x, x_prime = self.set_parameter_value(
             self.parameters[0], horizontal, x, x_prime
         )
-        x, x_prime = self._set_value(self.parameters[1], vertical, x, x_prime)
+        x, x_prime = self.set_parameter_value(
+            self.parameters[1], vertical, x, x_prime
+        )
 
         return x, x_prime, log_j
 
@@ -491,11 +495,13 @@ class AnglePair(Reparameterisation):
         )
 
         log_j += -2 * np.log(radial) - np.log(np.cos(vertical))
-        x, x_prime = self._set_value(self.radial, radial, x, x_prime)
-        x, x_prime = self._set_value(
+        x, x_prime = self.set_parameter_value(self.radial, radial, x, x_prime)
+        x, x_prime = self.set_parameter_value(
             self.parameters[0], horizontal, x, x_prime
         )
-        x, x_prime = self._set_value(self.parameters[1], vertical, x, x_prime)
+        x, x_prime = self.set_parameter_value(
+            self.parameters[1], vertical, x, x_prime
+        )
         return x, x_prime, log_j
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -505,7 +511,7 @@ class AnglePair(Reparameterisation):
         if self.chi:
             r = self.chi.rvs(size=x.size, random_state=self.rng)
         else:
-            r = self._get_value(self.radial, x, x_prime)
+            r = self.get_parameters_value(self.radial, x, x_prime)
         if any(r < 0):
             raise RuntimeError("Radius cannot be negative.")
 

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -40,12 +40,24 @@ class Angle(Reparameterisation):
     def __init__(
         self,
         parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
         prior_bounds=None,
         scale=1.0,
         rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
     ):
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
 
         if len(self.parameters) == 1:
@@ -68,8 +80,9 @@ class Angle(Reparameterisation):
         else:
             self._zero_bound = False
 
-        self.prime_parameters = [self.angle + "_x", self.angle + "_y"]
-        self.requires = []
+        # overwrite the prime parameters if not specified
+        if prime_parameters is None:
+            self.prime_parameters = [self.angle + "_x", self.angle + "_y"]
 
     @property
     def angle(self):
@@ -233,14 +246,12 @@ class AnglePair(Reparameterisation):
     """
 
     requires_bounded_prior = True
-    known_priors = ["isotropic", None]
     _conventions = {"az-zen": [0, np.pi], "ra-dec": [-np.pi / 2, np.pi / 2]}
 
     def __init__(
         self,
         parameters=None,
         prior_bounds=None,
-        prior=None,
         convention=None,
         rng=None,
     ):

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -49,7 +49,7 @@ class Angle(Reparameterisation):
         )
 
         if len(self.parameters) == 1:
-            self.parameters.append(self.parameters[0] + "_radial")
+            self.auxiliary_parameters = [self.parameters[0] + "_radial"]
             self.chi = stats.chi(2)
             self.has_prior = True
         elif len(self.parameters) == 2:
@@ -79,12 +79,14 @@ class Angle(Reparameterisation):
     @property
     def radial(self):
         """The name of the radial parameter"""
+        if self.chi:
+            return self.auxiliary_parameters[0]
         return self.parameters[1]
 
     @property
     def radius(self):
         """The name of the radial parameter (equivalent to radial)"""
-        return self.parameters[1]
+        return self.radial
 
     @property
     def x(self):
@@ -97,10 +99,10 @@ class Angle(Reparameterisation):
         return self.prime_parameters[1]
 
     def _rescale_radial(self, x, x_prime, log_j, **kwargs):
-        return x[self.parameters[1]], x, x_prime, log_j
+        return x[self.radial], x, x_prime, log_j
 
     def _rescale_angle(self, x, x_prime, log_j, **kwargs):
-        return x[self.parameters[0]] * self.scale, x, x_prime, log_j
+        return x[self.angle] * self.scale, x, x_prime, log_j
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
         return x, x_prime, log_j
@@ -127,12 +129,12 @@ class Angle(Reparameterisation):
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
         """Convert from Cartesian to an angle and radial component"""
-        x[self.parameters[1]] = np.sqrt(
+        x[self.radial] = np.sqrt(
             x_prime[self.prime_parameters[0]] ** 2
             + x_prime[self.prime_parameters[1]] ** 2
         )
         if self._zero_bound:
-            x[self.parameters[0]] = (
+            x[self.angle] = (
                 np.arctan2(
                     x_prime[self.prime_parameters[1]],
                     x_prime[self.prime_parameters[0]],
@@ -141,7 +143,7 @@ class Angle(Reparameterisation):
                 / self.scale
             )
         else:
-            x[self.parameters[0]] = (
+            x[self.angle] = (
                 np.arctan2(
                     x_prime[self.prime_parameters[1]],
                     x_prime[self.prime_parameters[0]],
@@ -149,14 +151,14 @@ class Angle(Reparameterisation):
                 / self.scale
             )
 
-        log_j -= np.log(x[self.parameters[1]])
+        log_j -= np.log(x[self.radial])
         x, x_prime, log_j = self._inverse_rescale_angle(x, x_prime, log_j)
 
         return x, x_prime, log_j
 
     def log_prior(self, x):
         """Prior for radial parameter"""
-        return self.chi.logpdf(x[self.parameters[1]])
+        return self.chi.logpdf(x[self.radial])
 
 
 class ToCartesian(Angle):
@@ -273,12 +275,13 @@ class AnglePair(Reparameterisation):
             )
             m = "_".join(parameters)
             self.chi = False
+            auxiliary_parameters = []
         else:
             parameters[0], parameters[1] = parameters[hz], parameters[vt]
             m = "_".join(parameters)
-            parameters.append(f"{m}_radial")
             self.chi = stats.chi(3)
             self.has_prior = True
+            auxiliary_parameters = [f"{m}_radial"]
 
         logger.debug(f"Parameters are: {parameters}")
 
@@ -295,6 +298,7 @@ class AnglePair(Reparameterisation):
             )
 
         self.parameters = parameters
+        self.auxiliary_parameters = auxiliary_parameters
         self.prime_parameters = [f"{m}_{x}" for x in ["x", "y", "z"]]
 
         if convention is None:
@@ -343,6 +347,8 @@ class AnglePair(Reparameterisation):
     @property
     def radial(self):
         """Name of the radial parameter"""
+        if self.chi:
+            return self.auxiliary_parameters[0]
         return self.parameters[-1]
 
     @property
@@ -383,7 +389,7 @@ class AnglePair(Reparameterisation):
         return x, x_prime, log_j
 
     def _inv_az_zen(self, x, x_prime, log_j):
-        x[self.parameters[2]] = np.sqrt(
+        x[self.radial] = np.sqrt(
             x_prime[self.prime_parameters[0]] ** 2.0
             + x_prime[self.prime_parameters[1]] ** 2.0
             + x_prime[self.prime_parameters[2]] ** 2.0
@@ -406,14 +412,14 @@ class AnglePair(Reparameterisation):
             ),
             x_prime[self.prime_parameters[2]],
         )
-        log_j += -2 * np.log(x[self.parameters[2]]) - np.log(
+        log_j += -2 * np.log(x[self.radial]) - np.log(
             np.sin(x[self.parameters[1]])
         )
 
         return x, x_prime, log_j
 
     def _inv_ra_dec(self, x, x_prime, log_j):
-        x[self.parameters[2]] = np.sqrt(
+        x[self.radial] = np.sqrt(
             x_prime[self.prime_parameters[0]] ** 2.0
             + x_prime[self.prime_parameters[1]] ** 2.0
             + x_prime[self.prime_parameters[2]] ** 2.0
@@ -438,7 +444,7 @@ class AnglePair(Reparameterisation):
             ),
         )
 
-        log_j += -2 * np.log(x[self.parameters[2]]) - np.log(
+        log_j += -2 * np.log(x[self.radial]) - np.log(
             np.cos(x[self.parameters[1]])
         )
         return x, x_prime, log_j
@@ -469,7 +475,7 @@ class AnglePair(Reparameterisation):
     def log_prior(self, x):
         """Prior for radial parameter"""
         if self.chi and self.has_prior:
-            return self.chi.logpdf(x[self.parameters[2]])
+            return self.chi.logpdf(x[self.radial])
         else:
             raise RuntimeError(
                 "log_prior is not defined when a radial parameter has been "

--- a/src/nessai/reparameterisations/angle.py
+++ b/src/nessai/reparameterisations/angle.py
@@ -113,7 +113,7 @@ class Angle(Reparameterisation):
 
     def _rescale_radial(self, x, x_prime, log_j, **kwargs):
         return (
-            self.get_parameters_value(self.radial, x, x_prime),
+            self.get_parameter_value(self.radial, x, x_prime),
             x,
             x_prime,
             log_j,
@@ -121,7 +121,7 @@ class Angle(Reparameterisation):
 
     def _rescale_angle(self, x, x_prime, log_j, **kwargs):
         return (
-            self.get_parameters_value(self.angle, x, x_prime) * self.scale,
+            self.get_parameter_value(self.angle, x, x_prime) * self.scale,
             x,
             x_prime,
             log_j,
@@ -204,7 +204,7 @@ class ToCartesian(Angle):
         self, x, x_prime, log_j, compute_radius=False, **kwargs
     ):
         angle, lj = rescale_zero_to_one(
-            self.get_parameters_value(self.parameters[0], x, x_prime),
+            self.get_parameter_value(self.parameters[0], x, x_prime),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
@@ -222,7 +222,7 @@ class ToCartesian(Angle):
 
     def _inverse_rescale_angle(self, x, x_prime, log_j):
         angle, lj = inverse_rescale_zero_to_one(
-            np.abs(self.get_parameters_value(self.parameters[0], x, x_prime)),
+            np.abs(self.get_parameter_value(self.parameters[0], x, x_prime)),
             *self.prior_bounds[self.parameters[0]],
         )
         log_j += lj
@@ -408,8 +408,8 @@ class AnglePair(Reparameterisation):
         return self.output_parameters[2]
 
     def _az_zen(self, x, x_prime, log_j, r):
-        horizontal = self.get_parameters_value(self.parameters[0], x, x_prime)
-        vertical = self.get_parameters_value(self.parameters[1], x, x_prime)
+        horizontal = self.get_parameter_value(self.parameters[0], x, x_prime)
+        vertical = self.get_parameter_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.sin(vertical) * np.cos(horizontal)
         )
@@ -421,8 +421,8 @@ class AnglePair(Reparameterisation):
         return x, x_prime, log_j
 
     def _ra_dec(self, x, x_prime, log_j, r):
-        horizontal = self.get_parameters_value(self.parameters[0], x, x_prime)
-        vertical = self.get_parameters_value(self.parameters[1], x, x_prime)
+        horizontal = self.get_parameter_value(self.parameters[0], x, x_prime)
+        vertical = self.get_parameter_value(self.parameters[1], x, x_prime)
         x_prime[self.output_parameters[0]] = (
             r * np.cos(vertical) * np.cos(horizontal)
         )
@@ -511,7 +511,7 @@ class AnglePair(Reparameterisation):
         if self.chi:
             r = self.chi.rvs(size=x.size, random_state=self.rng)
         else:
-            r = self.get_parameters_value(self.radial, x, x_prime)
+            r = self.get_parameter_value(self.radial, x, x_prime)
         if any(r < 0):
             raise RuntimeError("Radius cannot be negative.")
 

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -59,7 +59,8 @@ class Reparameterisation:
             )
 
         if prior_bounds is not None:
-            if set(self.parameters) - set(prior_bounds.keys()):
+            missing_bounds = set(self.parameters) - set(prior_bounds.keys())
+            if missing_bounds and self.requires_bounded_prior:
                 raise RuntimeError(
                     "Mismatch between parameters and prior bounds: "
                     f"{set(self.parameters)}, {set(prior_bounds.keys())}"
@@ -67,6 +68,12 @@ class Reparameterisation:
             self.prior_bounds = {
                 p: np.asarray(b) for p, b in prior_bounds.items()
             }
+            if missing_bounds:
+                logger.debug(
+                    "Missing prior bounds for parameters %s in %s",
+                    sorted(missing_bounds),
+                    self.name,
+                )
         else:
             logger.debug(f"No prior bounds for {self.name}")
 
@@ -81,8 +88,23 @@ class Reparameterisation:
                 )
 
         self.prime_parameters = [p + "_prime" for p in self.parameters]
+        self.auxiliary_parameters = []
         self.requires = []
+        self.prime_requires = []
+        self.inverse_requires = []
         logger.debug(f"Initialised reparameterisation: {self.name}")
+
+    @property
+    def output_parameters(self):
+        """All x-space parameters made available after this reparameterisation."""
+        return self.parameters + self.auxiliary_parameters
+
+    @property
+    def input_parameters(self):
+        """All x-space parameters required for the forward pass."""
+        # self.parameters + self.requires may contain duplicates
+        # we want to preserve the order but remove duplicates
+        return list(dict.fromkeys(self.parameters + self.requires))
 
     @property
     def name(self):

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -220,9 +220,13 @@ class Reparameterisation:
         """Compatibility alias for `input_parameters`."""
         return self.input_parameters
 
-    @parameters.setter
-    def parameters(self, value):
-        self.input_parameters = self._format_parameters(value)
+    @property
+    def input_parameters(self):
+        return self._input_parameters
+
+    @input_parameters.setter
+    def input_parameters(self, value):
+        self._input_parameters = self._format_parameters(value)
         self._resolved_forward_inputs = False
         self._resolved_inverse_inputs = False
 

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -18,8 +18,26 @@ class Reparameterisation:
     ----------
     parameters : str or list
         Name of parameters to reparameterise.
+    prime_parameters : str or list, optional
+        Name of the parameters in the prime space. If None, will be set to
+        the same as `parameters` with '_prime' appended.
+    auxiliary_parameters : str or list, optional
+        Name of any auxiliary parameters that are made available in x-space after
+        the reparameterisation. These parameters are not required for the forward
+        pass but may be used in the inverse pass. Defaults to None.
     prior_bounds : list, dict or None
         Prior bounds for the parameter(s).
+    rng: np.random.Generator, optional
+        Random number generator to use for any random operations in the
+        reparameterisation. If None, a new default_rng will be used.
+    requires : str or list, optional
+        Name of any parameters that are required for the reparameterisation.
+    prime_requires : str or list, optional
+        Name of any parameters in the prime space that are required for the
+        reparameterisation.
+    inverse_requires : str or list, optional
+        Name of any parameters that are required for the inverse
+        reparameterisation.
     """
 
     _update = False
@@ -28,7 +46,17 @@ class Reparameterisation:
     prior_bounds = None
     one_to_one = True
 
-    def __init__(self, parameters=None, prior_bounds=None, rng=None):
+    def __init__(
+        self,
+        parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
+        prior_bounds=None,
+        rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
+    ):
         if rng is None:
             logger.debug("No rng specified, using the default rng.")
             rng = np.random.default_rng()
@@ -36,9 +64,7 @@ class Reparameterisation:
         if not isinstance(parameters, (str, list)):
             raise TypeError("Parameters must be a str or list.")
 
-        self.parameters = (
-            [parameters] if isinstance(parameters, str) else parameters.copy()
-        )
+        self.parameters = self._format_parameters(parameters)
 
         if isinstance(prior_bounds, (list, tuple, np.ndarray)):
             if len(prior_bounds) == 2:
@@ -87,12 +113,30 @@ class Reparameterisation:
                     f"bounds. Received: {self.prior_bounds}"
                 )
 
-        self.prime_parameters = [p + "_prime" for p in self.parameters]
-        self.auxiliary_parameters = []
-        self.requires = []
-        self.prime_requires = []
-        self.inverse_requires = []
+        self.prime_parameters = self._format_parameters(prime_parameters) or [
+            f"{p}_prime" for p in self.parameters
+        ]
+        self.auxiliary_parameters = self._format_parameters(
+            auxiliary_parameters
+        )
+        self.requires = self._format_parameters(requires)
+        self.prime_requires = self._format_parameters(prime_requires)
+        self.inverse_requires = self._format_parameters(inverse_requires)
         logger.debug(f"Initialised reparameterisation: {self.name}")
+
+    @staticmethod
+    def _format_parameters(parameters: str | list[str] | None) -> list[str]:
+        """Format the parameters to be a list of strings."""
+        if isinstance(parameters, str):
+            return [parameters]
+        elif isinstance(parameters, list):
+            return parameters.copy()
+        elif parameters is None:
+            return []
+        else:
+            raise TypeError(
+                "Parameters must be a string or a list of strings."
+            )
 
     @property
     def output_parameters(self):

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -3,6 +3,8 @@
 Base reparameterisation
 """
 
+from __future__ import annotations
+
 import logging
 
 import numpy as np

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -289,7 +289,7 @@ class Reparameterisation:
         self._resolved_inverse_inputs = True
         return missing
 
-    def _get_value(self, parameter, x, x_prime=None):
+    def get_parameter_value(self, parameter, x, x_prime=None):
         """Get the current value for an input parameter.
 
         Returns the value from x or x_prime depending on where the parameter is
@@ -307,7 +307,7 @@ class Reparameterisation:
             return x_prime[parameter]
         return x[parameter]
 
-    def _set_value(self, parameter, value, x, x_prime=None):
+    def set_parameter_value(self, parameter, value, x, x_prime=None):
         """Set the reconstructed value for an input parameter.
 
         Sets the value in x or x_prime depending on where the parameter is
@@ -372,7 +372,7 @@ class Reparameterisation:
         """
         raise NotImplementedError
 
-    def update(self, x):
+    def update(self, x, x_prime=None):
         """Update the reparameterisation given some points.
 
         Does nothing by default.

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -18,11 +18,14 @@ class Reparameterisation:
 
     Parameters
     ----------
-    parameters : str or list
-        Name of parameters to reparameterise.
-    prime_parameters : str or list, optional
-        Name of the parameters in the prime space. If None, will be set to
-        the same as `parameters` with '_prime' appended.
+    input_parameters : str or list
+        Names of the parameters required in the forward direction.
+    output_parameters : str or list, optional
+        Names of the parameters produced in the prime space. If None, will be
+        set to the same as `input_parameters` with '_prime' appended.
+    persistent_parameters : str or list, optional
+        Subset of `input_parameters` that should remain exposed in the
+        flow-facing parameter set after this reparameterisation.
     auxiliary_parameters : str or list, optional
         Name of any auxiliary parameters that are made available in x-space after
         the reparameterisation. These parameters are not required for the forward
@@ -32,14 +35,11 @@ class Reparameterisation:
     rng: np.random.Generator, optional
         Random number generator to use for any random operations in the
         reparameterisation. If None, a new default_rng will be used.
-    requires : str or list, optional
-        Name of any parameters that are required for the reparameterisation.
-    prime_requires : str or list, optional
-        Name of any parameters in the prime space that are required for the
-        reparameterisation.
-    inverse_requires : str or list, optional
+    inverse_input_parameters : str or list, optional
         Name of any parameters that are required for the inverse
         reparameterisation.
+    parameters : str or list, optional
+        Alias for `input_parameters`.
     """
 
     _update = False
@@ -50,27 +50,39 @@ class Reparameterisation:
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        inverse_input_parameters=None,
+        parameters=None,
     ):
         if rng is None:
             logger.debug("No rng specified, using the default rng.")
             rng = np.random.default_rng()
         self.rng = rng
-        if not isinstance(parameters, (str, list)):
+        if parameters is not None and input_parameters is not None:
+            if self._format_parameters(parameters) != self._format_parameters(
+                input_parameters
+            ):
+                raise RuntimeError(
+                    "Received conflicting values for `parameters` and "
+                    "`input_parameters`."
+                )
+        if input_parameters is None:
+            input_parameters = parameters
+        if not isinstance(input_parameters, (str, list)):
             raise TypeError("Parameters must be a str or list.")
 
-        self.parameters = self._format_parameters(parameters)
+        self.input_parameters = self._format_parameters(input_parameters)
 
         if isinstance(prior_bounds, (list, tuple, np.ndarray)):
             if len(prior_bounds) == 2:
-                prior_bounds = {self.parameters[0]: np.asarray(prior_bounds)}
+                prior_bounds = {
+                    self.input_parameters[0]: np.asarray(prior_bounds)
+                }
             else:
                 raise RuntimeError("Prior bounds got a list of len > 2")
         elif prior_bounds is None:
@@ -87,11 +99,13 @@ class Reparameterisation:
             )
 
         if prior_bounds is not None:
-            missing_bounds = set(self.parameters) - set(prior_bounds.keys())
+            missing_bounds = set(self.input_parameters) - set(
+                prior_bounds.keys()
+            )
             if missing_bounds and self.requires_bounded_prior:
                 raise RuntimeError(
                     "Mismatch between parameters and prior bounds: "
-                    f"{set(self.parameters)}, {set(prior_bounds.keys())}"
+                    f"{set(self.input_parameters)}, {set(prior_bounds.keys())}"
                 )
             self.prior_bounds = {
                 p: np.asarray(b) for p, b in prior_bounds.items()
@@ -115,15 +129,32 @@ class Reparameterisation:
                     f"bounds. Received: {self.prior_bounds}"
                 )
 
-        self.prime_parameters = self._format_parameters(prime_parameters) or [
-            f"{p}_prime" for p in self.parameters
-        ]
+        self.output_parameters = self._format_parameters(
+            output_parameters
+        ) or [f"{p}_prime" for p in self.input_parameters]
+        self.persistent_parameters = self._format_parameters(
+            persistent_parameters
+        )
+        if not set(self.persistent_parameters).issubset(self.input_parameters):
+            raise RuntimeError(
+                "Persistent parameters must be a subset of the input "
+                f"parameters. Received {self.persistent_parameters} for "
+                f"{self.input_parameters}."
+            )
         self.auxiliary_parameters = self._format_parameters(
             auxiliary_parameters
         )
-        self.requires = self._format_parameters(requires)
-        self.prime_requires = self._format_parameters(prime_requires)
-        self.inverse_requires = self._format_parameters(inverse_requires)
+        self.inverse_input_parameters = self._format_parameters(
+            inverse_input_parameters
+        )
+        self._x_input_parameters = []
+        self._x_prime_input_parameters = []
+        self._x_persistent_parameters = []
+        self._x_prime_persistent_parameters = []
+        self._x_inverse_input_parameters = []
+        self._x_prime_inverse_input_parameters = []
+        self._resolved_forward_inputs = False
+        self._resolved_inverse_inputs = False
         logger.debug(f"Initialised reparameterisation: {self.name}")
 
     @staticmethod
@@ -141,23 +172,170 @@ class Reparameterisation:
             )
 
     @property
-    def output_parameters(self):
-        """All x-space parameters made available after this reparameterisation."""
-        return self.parameters + self.auxiliary_parameters
+    def x_input_parameters(self):
+        """Resolved x-space forward inputs."""
+        if self._resolved_forward_inputs:
+            return self._x_input_parameters.copy()
+        return self.input_parameters.copy()
 
     @property
-    def input_parameters(self):
-        """All x-space parameters required for the forward pass."""
-        # self.parameters + self.requires may contain duplicates
-        # we want to preserve the order but remove duplicates
-        return list(dict.fromkeys(self.parameters + self.requires))
+    def x_prime_input_parameters(self):
+        """Resolved x'-space forward inputs."""
+        return self._x_prime_input_parameters.copy()
+
+    @property
+    def prime_input_parameters(self):
+        """Compatibility alias for `x_prime_input_parameters`."""
+        return self.x_prime_input_parameters
+
+    @property
+    def x_output_parameters(self):
+        """All x-space parameters available after this reparameterisation."""
+        return list(
+            dict.fromkeys(self.x_input_parameters + self.auxiliary_parameters)
+        )
+
+    @property
+    def x_persistent_parameters(self):
+        """Resolved persistent x-space inputs."""
+        return self._x_persistent_parameters.copy()
+
+    @property
+    def x_prime_persistent_parameters(self):
+        """Resolved persistent x'-space inputs."""
+        return self._x_prime_persistent_parameters.copy()
+
+    @property
+    def prime_persistent_parameters(self):
+        """Compatibility alias for `x_prime_persistent_parameters`."""
+        return self.x_prime_persistent_parameters
+
+    @property
+    def x_inverse_input_parameters(self):
+        """Resolved x-space inverse inputs."""
+        return self._x_inverse_input_parameters.copy()
+
+    @property
+    def x_prime_inverse_input_parameters(self):
+        """Resolved x'-space inverse inputs."""
+        return self._x_prime_inverse_input_parameters.copy()
+
+    @property
+    def prime_inverse_input_parameters(self):
+        """Compatibility alias for `x_prime_inverse_input_parameters`."""
+        return self.x_prime_inverse_input_parameters
+
+    @property
+    def parameters(self):
+        """Compatibility alias for `input_parameters`."""
+        return self.input_parameters
+
+    @parameters.setter
+    def parameters(self, value):
+        self.input_parameters = self._format_parameters(value)
+        self._resolved_forward_inputs = False
+        self._resolved_inverse_inputs = False
 
     @property
     def name(self):
         """Unique name of the reparameterisations"""
         return (
-            self.__class__.__name__.lower() + "_" + "_".join(self.parameters)
+            self.__class__.__name__.lower()
+            + "_"
+            + "_".join(self.input_parameters)
         )
+
+    def resolve_forward_input_spaces(
+        self, available_parameters, available_prime_parameters
+    ):
+        """Resolve forward inputs against x and prime namespaces."""
+        x_inputs = []
+        prime_inputs = []
+        missing = []
+        for parameter in self.input_parameters:
+            if parameter in available_parameters:
+                x_inputs.append(parameter)
+            elif parameter in available_prime_parameters:
+                prime_inputs.append(parameter)
+            else:
+                missing.append(parameter)
+
+        x_persistent = [
+            parameter
+            for parameter in self.persistent_parameters
+            if parameter in x_inputs
+        ]
+
+        x_prime_persistent = [
+            parameter
+            for parameter in self.persistent_parameters
+            if parameter in prime_inputs
+        ]
+
+        self._x_input_parameters = x_inputs
+        self._x_prime_input_parameters = prime_inputs
+        self._x_persistent_parameters = x_persistent
+        self._x_prime_persistent_parameters = x_prime_persistent
+        self._resolved_forward_inputs = True
+        return missing
+
+    def resolve_inverse_input_spaces(
+        self, available_parameters, available_prime_parameters
+    ):
+        """Resolve inverse inputs against x and prime namespaces."""
+        x_inputs = []
+        x_prime_inputs = []
+        missing = []
+        for parameter in self.inverse_input_parameters:
+            if parameter in available_parameters:
+                x_inputs.append(parameter)
+            elif parameter in available_prime_parameters:
+                x_prime_inputs.append(parameter)
+            else:
+                missing.append(parameter)
+
+        self._x_inverse_input_parameters = x_inputs
+        self._x_prime_inverse_input_parameters = x_prime_inputs
+        self._resolved_inverse_inputs = True
+        return missing
+
+    def _get_value(self, parameter, x, x_prime=None):
+        """Get the current value for an input parameter.
+
+        Returns the value from x or x_prime depending on where the parameter is
+        defined.
+        """
+        x_prime_inputs = getattr(self, "_x_prime_input_parameters", [])
+        if not isinstance(x_prime_inputs, (list, tuple, set)):
+            x_prime_inputs = []
+        if parameter in x_prime_inputs:
+            if x_prime is None:
+                raise RuntimeError(
+                    f"Prime-space input `{parameter}` requested for "
+                    f"{self.name} but no x_prime array was provided."
+                )
+            return x_prime[parameter]
+        return x[parameter]
+
+    def _set_value(self, parameter, value, x, x_prime=None):
+        """Set the reconstructed value for an input parameter.
+
+        Sets the value in x or x_prime depending on where the parameter is
+        defined.
+        """
+        x_prime_inputs = getattr(self, "_x_prime_input_parameters", [])
+        if not isinstance(x_prime_inputs, (list, tuple, set)):
+            x_prime_inputs = []
+        if parameter in x_prime_inputs:
+            if x_prime is None:
+                raise RuntimeError(
+                    f"Prime-space input `{parameter}` requested for "
+                    f"{self.name} but no x_prime array was provided."
+                )
+            x_prime[parameter] = value
+        else:
+            x[parameter] = value
+        return x, x_prime
 
     def reparameterise(self, x, x_prime, log_j):
         """

--- a/src/nessai/reparameterisations/base.py
+++ b/src/nessai/reparameterisations/base.py
@@ -206,11 +206,6 @@ class Reparameterisation:
         return self._x_prime_persistent_parameters.copy()
 
     @property
-    def prime_persistent_parameters(self):
-        """Compatibility alias for `x_prime_persistent_parameters`."""
-        return self.x_prime_persistent_parameters
-
-    @property
     def x_inverse_input_parameters(self):
         """Resolved x-space inverse inputs."""
         return self._x_inverse_input_parameters.copy()
@@ -219,11 +214,6 @@ class Reparameterisation:
     def x_prime_inverse_input_parameters(self):
         """Resolved x'-space inverse inputs."""
         return self._x_prime_inverse_input_parameters.copy()
-
-    @property
-    def prime_inverse_input_parameters(self):
-        """Compatibility alias for `x_prime_inverse_input_parameters`."""
-        return self.x_prime_inverse_input_parameters
 
     @property
     def parameters(self):

--- a/src/nessai/reparameterisations/combined.py
+++ b/src/nessai/reparameterisations/combined.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ..livepoint import empty_structured_array
 from ..utils.sorting import sort_reparameterisations
 
 if TYPE_CHECKING:
@@ -42,7 +43,6 @@ class CombinedReparameterisation(dict):
         self.reparameterisations = {}
         self.parameters = []
         self.prime_parameters = []
-        self.requires = []
         self.order = []
         self.reverse_order = reverse_order
         self.initial_parameters = (
@@ -74,21 +74,13 @@ class CombinedReparameterisation(dict):
     def _add_reparameterisation(self, reparameterisation):
         available_parameters = self.initial_parameters + self.parameters
         available_prime_parameters = self.prime_parameters
-        missing_parameters = [
-            req
-            for req in reparameterisation.input_parameters
-            if req not in available_parameters
-        ]
-        missing_prime_parameters = [
-            req
-            for req in reparameterisation.prime_requires
-            if req not in available_prime_parameters
-        ]
-        if missing_parameters or missing_prime_parameters:
+        missing_parameters = reparameterisation.resolve_forward_input_spaces(
+            available_parameters, available_prime_parameters
+        )
+        if missing_parameters:
             raise RuntimeError(
                 f"Could not add {reparameterisation}, missing requirement(s): "
-                f"{missing_parameters}. Missing prime requirement(s): "
-                f"{missing_prime_parameters}. Current: {available_parameters}. "
+                f"{missing_parameters}. Current: {available_parameters}. "
                 f"Current prime parameters: {available_prime_parameters}."
             )
 
@@ -96,11 +88,14 @@ class CombinedReparameterisation(dict):
         self.order = list(self.keys())
         self.parameters += [
             p
-            for p in reparameterisation.output_parameters
+            for p in reparameterisation.x_output_parameters
             if p not in self.parameters
         ]
-        self.prime_parameters += reparameterisation.prime_parameters
-        self.requires += reparameterisation.requires
+        self.prime_parameters += [
+            p
+            for p in reparameterisation.output_parameters
+            if p not in self.prime_parameters
+        ]
 
     def add_reparameterisation(self, reparameterisation):
         """Add a reparameterisation"""
@@ -139,15 +134,22 @@ class CombinedReparameterisation(dict):
             Raised if the order is invalid.
         """
         parameters = []
+        prime_parameters = self.prime_parameters.copy()
         for key in self.from_prime_order:
-            if not all([r in parameters for r in self[key].inverse_requires]):
+            missing_parameters = self[key].resolve_inverse_input_spaces(
+                parameters, prime_parameters
+            )
+            if missing_parameters:
                 raise RuntimeError(
                     "Order of reparameterisations is invalid (x' -> x)"
-                    f"{self[key].name} requires {self[key].inverse_requires} but with "
+                    f"{self[key].name} requires "
+                    f"{self[key].inverse_input_parameters} but with "
                     f"the current order only the parameters {parameters} "
                     "would be available."
                 )
-            parameters += self[key].output_parameters
+            parameters += [
+                p for p in self[key].x_output_parameters if p not in parameters
+            ]
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
         """
@@ -193,10 +195,18 @@ class CombinedReparameterisation(dict):
         """
         Update the bounds used for the reparameterisation
         """
-        for r in self.values():
-            if hasattr(r, "update_bounds"):
-                logger.debug(f"Updating bounds for: {r.name}")
-                r.update_bounds(x)
+        x_current = x.copy()
+        x_prime = empty_structured_array(x.size, names=self.prime_parameters)
+        log_j = np.zeros(x.size)
+
+        for key in self.to_prime_order:
+            reparameterisation = self[key]
+            if hasattr(reparameterisation, "update_bounds"):
+                logger.debug(f"Updating bounds for: {reparameterisation.name}")
+                reparameterisation.update_bounds(x_current, x_prime=x_prime)
+            x_current, x_prime, log_j = reparameterisation.reparameterise(
+                x_current, x_prime, log_j
+            )
 
     def reset_inversion(self):
         """
@@ -208,8 +218,16 @@ class CombinedReparameterisation(dict):
 
     def update(self, x):
         """Update the reparameterisations given a set of points."""
-        for r in self.values():
-            r.update(x)
+        x_current = x.copy()
+        x_prime = empty_structured_array(x.size, names=self.prime_parameters)
+        log_j = np.zeros(x.size)
+
+        for key in self.to_prime_order:
+            reparameterisation = self[key]
+            reparameterisation.update(x_current, x_prime=x_prime)
+            x_current, x_prime, log_j = reparameterisation.reparameterise(
+                x_current, x_prime, log_j
+            )
 
     def reset(self):
         """Reset the reparameterisations"""

--- a/src/nessai/reparameterisations/combined.py
+++ b/src/nessai/reparameterisations/combined.py
@@ -3,6 +3,8 @@
 Combined reparameterisation.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/src/nessai/reparameterisations/combined.py
+++ b/src/nessai/reparameterisations/combined.py
@@ -4,10 +4,14 @@ Combined reparameterisation.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from ..utils.sorting import sort_reparameterisations
+
+if TYPE_CHECKING:
+    from . import Reparameterisation
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +30,12 @@ class CombinedReparameterisation(dict):
         to the default ordering.
     """
 
-    def __init__(self, reparameterisations=None, reverse_order=False):
+    def __init__(
+        self,
+        reparameterisations: list["Reparameterisation"] = None,
+        reverse_order: bool = False,
+        initial_parameters: list[str] | None = None,
+    ):
         super().__init__()
         self.reparameterisations = {}
         self.parameters = []
@@ -34,6 +43,9 @@ class CombinedReparameterisation(dict):
         self.requires = []
         self.order = []
         self.reverse_order = reverse_order
+        self.initial_parameters = (
+            initial_parameters.copy() if initial_parameters is not None else []
+        )
         if reparameterisations is not None:
             self.add_reparameterisations(reparameterisations)
 
@@ -58,19 +70,33 @@ class CombinedReparameterisation(dict):
             return reversed(self.order)
 
     def _add_reparameterisation(self, reparameterisation):
-        requires = reparameterisation.requires
-        if requires and (
-            any([req not in self.parameters for req in requires])
-            and any([req not in self.prime_parameters for req in requires])
-        ):
+        available_parameters = self.initial_parameters + self.parameters
+        available_prime_parameters = self.prime_parameters
+        missing_parameters = [
+            req
+            for req in reparameterisation.input_parameters
+            if req not in available_parameters
+        ]
+        missing_prime_parameters = [
+            req
+            for req in reparameterisation.prime_requires
+            if req not in available_prime_parameters
+        ]
+        if missing_parameters or missing_prime_parameters:
             raise RuntimeError(
                 f"Could not add {reparameterisation}, missing requirement(s): "
-                f"{reparameterisation.requires}. Current: {self.parameters}."
+                f"{missing_parameters}. Missing prime requirement(s): "
+                f"{missing_prime_parameters}. Current: {available_parameters}. "
+                f"Current prime parameters: {available_prime_parameters}."
             )
 
         self[reparameterisation.name] = reparameterisation
         self.order = list(self.keys())
-        self.parameters += reparameterisation.parameters
+        self.parameters += [
+            p
+            for p in reparameterisation.output_parameters
+            if p not in self.parameters
+        ]
         self.prime_parameters += reparameterisation.prime_parameters
         self.requires += reparameterisation.requires
 
@@ -90,10 +116,13 @@ class CombinedReparameterisation(dict):
             reparameterisations = [reparameterisations]
 
         logger.debug("Sorting reparameterisations")
-        logger.debug(f"Existing parameters: {self.parameters}")
+        existing_parameters = self.initial_parameters + self.parameters
+        existing_prime_parameters = self.prime_parameters
+        logger.debug(f"Existing parameters: {existing_parameters}")
         reparameterisations = sort_reparameterisations(
             reparameterisations,
-            existing_parameters=self.parameters,
+            existing_parameters=existing_parameters,
+            existing_prime_parameters=existing_prime_parameters,
         )
 
         for r in reparameterisations:
@@ -109,14 +138,14 @@ class CombinedReparameterisation(dict):
         """
         parameters = []
         for key in self.from_prime_order:
-            if not all([r in parameters for r in self[key].requires]):
+            if not all([r in parameters for r in self[key].inverse_requires]):
                 raise RuntimeError(
                     "Order of reparameterisations is invalid (x' -> x)"
-                    f"{self[key].name} requires {self[key].requires} but with "
+                    f"{self[key].name} requires {self[key].inverse_requires} but with "
                     f"the current order only the parameters {parameters} "
                     "would be available."
                 )
-            parameters += self[key].parameters
+            parameters += self[key].output_parameters
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
         """

--- a/src/nessai/reparameterisations/discrete.py
+++ b/src/nessai/reparameterisations/discrete.py
@@ -34,16 +34,22 @@ class Dequantise(RescaleToBounds):
     def __init__(
         self,
         parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
         prior_bounds=None,
         rescale_bounds=None,
         update_bounds=False,
         post_rescaling=None,
         rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
     ):
         super().__init__(
             parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
-            prior=None,
             rescale_bounds=rescale_bounds,
             boundary_inversion=None,
             detect_edges=False,
@@ -52,6 +58,9 @@ class Dequantise(RescaleToBounds):
             pre_rescaling=None,
             post_rescaling=post_rescaling,
             rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
 
         self.has_pre_rescaling = True

--- a/src/nessai/reparameterisations/discrete.py
+++ b/src/nessai/reparameterisations/discrete.py
@@ -33,21 +33,21 @@ class Dequantise(RescaleToBounds):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         rescale_bounds=None,
         update_bounds=False,
         post_rescaling=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rescale_bounds=rescale_bounds,
@@ -58,9 +58,7 @@ class Dequantise(RescaleToBounds):
             pre_rescaling=None,
             post_rescaling=post_rescaling,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            parameters=parameters,
         )
 
         self.has_pre_rescaling = True

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -59,7 +59,7 @@ class IdentityReparameterisation(Reparameterisation):
         for parameter, output_parameter in zip(
             self.parameters, self.output_parameters
         ):
-            x_prime[output_parameter] = self.get_value(parameter, x, x_prime)
+            x_prime[output_parameter] = self._get_value(parameter, x, x_prime)
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -23,26 +23,24 @@ class IdentityReparameterisation(Reparameterisation):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            parameters=parameters,
         )
-        self.prime_parameters = self.parameters
+        self.output_parameters = self.input_parameters
         logger.debug(f"Initialised reparameterisation: {self.name}")
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -58,7 +56,10 @@ class IdentityReparameterisation(Reparameterisation):
             Array to be update
         log_j : Log jacobian to be updated
         """
-        x_prime[self.prime_parameters] = x[self.parameters]
+        for parameter, output_parameter in zip(
+            self.parameters, self.output_parameters
+        ):
+            x_prime[output_parameter] = self.get_value(parameter, x, x_prime)
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -74,7 +75,12 @@ class IdentityReparameterisation(Reparameterisation):
             Array to be update
         log_j : Log jacobian to be updated
         """
-        x[self.parameters] = x_prime[self.prime_parameters]
+        for parameter, output_parameter in zip(
+            self.parameters, self.output_parameters
+        ):
+            x, x_prime = self._set_value(
+                parameter, x_prime[output_parameter], x, x_prime
+            )
         return x, x_prime, log_j
 
 

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -59,7 +59,9 @@ class IdentityReparameterisation(Reparameterisation):
         for parameter, output_parameter in zip(
             self.parameters, self.output_parameters
         ):
-            x_prime[output_parameter] = self._get_value(parameter, x, x_prime)
+            x_prime[output_parameter] = self.get_parameters_value(
+                parameter, x, x_prime
+            )
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
@@ -78,7 +80,7 @@ class IdentityReparameterisation(Reparameterisation):
         for parameter, output_parameter in zip(
             self.parameters, self.output_parameters
         ):
-            x, x_prime = self._set_value(
+            x, x_prime = self.set_parameter_value(
                 parameter, x_prime[output_parameter], x, x_prime
             )
         return x, x_prime, log_j

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -10,7 +10,7 @@ from .base import Reparameterisation
 logger = logging.getLogger(__name__)
 
 
-class NullReparameterisation(Reparameterisation):
+class IdentityReparameterisation(Reparameterisation):
     """Reparameterisation that does not modify the parameters.
 
     Parameters
@@ -21,9 +21,26 @@ class NullReparameterisation(Reparameterisation):
         Prior bounds for parameters. Unused for this reparameterisation.
     """
 
-    def __init__(self, parameters=None, prior_bounds=None, rng=None):
+    def __init__(
+        self,
+        parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
+        prior_bounds=None,
+        rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
+    ):
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
         self.prime_parameters = self.parameters
         logger.debug(f"Initialised reparameterisation: {self.name}")
@@ -59,3 +76,7 @@ class NullReparameterisation(Reparameterisation):
         """
         x[self.parameters] = x_prime[self.prime_parameters]
         return x, x_prime, log_j
+
+
+NullReparameterisation = IdentityReparameterisation
+"""Alias for IdentityReparameterisation."""

--- a/src/nessai/reparameterisations/null.py
+++ b/src/nessai/reparameterisations/null.py
@@ -59,7 +59,7 @@ class IdentityReparameterisation(Reparameterisation):
         for parameter, output_parameter in zip(
             self.parameters, self.output_parameters
         ):
-            x_prime[output_parameter] = self.get_parameters_value(
+            x_prime[output_parameter] = self.get_parameter_value(
                 parameter, x, x_prime
             )
         return x, x_prime, log_j

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -160,6 +160,8 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
     def __init__(
         self,
         parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
         prior_bounds=None,
         scale=None,
         shift=None,
@@ -168,11 +170,21 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         pre_rescaling=None,
         post_rescaling=None,
         rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
     ):
         if scale is None and not estimate_scale:
             raise RuntimeError("Must specify a scale or enable estimate_scale")
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
 
         self.estimate_scale = estimate_scale
@@ -321,8 +333,6 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         Bounds to rescale to.
     update_bounds : bool, optional
         Enable or disable updating bounds.
-    prior : {'uniform', None}
-        Type of prior used, if uniform prime prior is enabled.
     boundary_inversion : bool, list, dict, optional
         Configuration for boundary inversion. If a list, inversion is only
         applied to the parameters in the list based on `inversion_type`. If
@@ -352,8 +362,9 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
     def __init__(
         self,
         parameters=None,
+        prime_parameters=None,
+        auxiliary_parameters=None,
         prior_bounds=None,
-        prior=None,
         rescale_bounds=None,
         boundary_inversion=None,
         detect_edges=False,
@@ -364,9 +375,19 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         pre_rescaling=None,
         post_rescaling=None,
         rng=None,
+        requires=None,
+        prime_requires=None,
+        inverse_requires=None,
     ):
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            parameters=parameters,
+            prime_parameters=prime_parameters,
+            auxiliary_parameters=auxiliary_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            requires=requires,
+            prime_requires=prime_requires,
+            inverse_requires=inverse_requires,
         )
 
         self.bounds = None

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -244,7 +244,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         log_j : Log jacobian to be updated
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self._get_value(p, x, x_prime)
+            x_in = self.get_parameters_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -287,7 +287,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
             if self.has_pre_rescaling:
                 value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
-            x, x_prime = self._set_value(p, value, x, x_prime)
+            x, x_prime = self.set_parameter_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
     def update(self, x, x_prime=None):
@@ -295,7 +295,9 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         if self._update:
             logger.debug("Updating scale and shift")
             for p in self.parameters:
-                x_pre = self.pre_rescaling(self._get_value(p, x, x_prime))[0]
+                x_pre = self.pre_rescaling(
+                    self.get_parameters_value(p, x, x_prime)
+                )[0]
                 if self.estimate_scale:
                     self.scale[p] = np.std(x_pre)
                 if self.estimate_shift:
@@ -581,7 +583,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         return x, x_prime, log_j
 
     def _reverse_inversion(self, x, x_prime, log_j, p, pp):
-        value = self._get_value(p, x, x_prime)
+        value = self.get_parameters_value(p, x, x_prime)
         if self._edges[p]:
             inv = value < 0.0
             value = value.copy()
@@ -598,7 +600,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
             )
             value = value + self.offsets[p]
             log_j += lj
-        x, x_prime = self._set_value(p, value, x, x_prime)
+        x, x_prime = self.set_parameter_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
     def reparameterise(
@@ -619,7 +621,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
             Parsed to inversion function
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self._get_value(p, x, x_prime)
+            x_in = self.get_parameters_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -650,22 +652,22 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
                 log_j += lj
             else:
                 value = x_prime[pp]
-            x, x_prime = self._set_value(p, value, x, x_prime)
+            x, x_prime = self.set_parameter_value(p, value, x, x_prime)
             if self.boundary_inversion and p in self.boundary_inversion:
                 x, x_prime, log_j = self._reverse_inversion(
                     x, x_prime, log_j, p, pp, **kwargs
                 )
             else:
-                value = self._get_value(p, x, x_prime)
+                value = self.get_parameters_value(p, x, x_prime)
                 value, lj = self._inverse_rescale_to_bounds(value, p)
                 value = value + self.offsets[p]
                 log_j += lj
-                x, x_prime = self._set_value(p, value, x, x_prime)
+                x, x_prime = self.set_parameter_value(p, value, x, x_prime)
             if self.has_pre_rescaling:
-                value = self._get_value(p, x, x_prime)
+                value = self.get_parameters_value(p, x, x_prime)
                 value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
-                x, x_prime = self._set_value(p, value, x, x_prime)
+                x, x_prime = self.set_parameter_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
     def reset_inversion(self):
@@ -696,13 +698,13 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         if self._update:
             self.bounds = {
                 p: [
-                    self.pre_rescaling(np.min(self._get_value(p, x, x_prime)))[
-                        0
-                    ]
+                    self.pre_rescaling(
+                        np.min(self.get_parameters_value(p, x, x_prime))
+                    )[0]
                     - self.offsets[p],
-                    self.pre_rescaling(np.max(self._get_value(p, x, x_prime)))[
-                        0
-                    ]
+                    self.pre_rescaling(
+                        np.max(self.get_parameters_value(p, x, x_prime))
+                    )[0]
                     - self.offsets[p],
                 ]
                 for p in self.parameters

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -244,7 +244,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         log_j : Log jacobian to be updated
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self.get_parameters_value(p, x, x_prime)
+            x_in = self.get_parameter_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -296,7 +296,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
             logger.debug("Updating scale and shift")
             for p in self.parameters:
                 x_pre = self.pre_rescaling(
-                    self.get_parameters_value(p, x, x_prime)
+                    self.get_parameter_value(p, x, x_prime)
                 )[0]
                 if self.estimate_scale:
                     self.scale[p] = np.std(x_pre)
@@ -583,7 +583,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         return x, x_prime, log_j
 
     def _reverse_inversion(self, x, x_prime, log_j, p, pp):
-        value = self.get_parameters_value(p, x, x_prime)
+        value = self.get_parameter_value(p, x, x_prime)
         if self._edges[p]:
             inv = value < 0.0
             value = value.copy()
@@ -621,7 +621,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
             Parsed to inversion function
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self.get_parameters_value(p, x, x_prime)
+            x_in = self.get_parameter_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -658,13 +658,13 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
                     x, x_prime, log_j, p, pp, **kwargs
                 )
             else:
-                value = self.get_parameters_value(p, x, x_prime)
+                value = self.get_parameter_value(p, x, x_prime)
                 value, lj = self._inverse_rescale_to_bounds(value, p)
                 value = value + self.offsets[p]
                 log_j += lj
                 x, x_prime = self.set_parameter_value(p, value, x, x_prime)
             if self.has_pre_rescaling:
-                value = self.get_parameters_value(p, x, x_prime)
+                value = self.get_parameter_value(p, x, x_prime)
                 value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
                 x, x_prime = self.set_parameter_value(p, value, x, x_prime)
@@ -699,11 +699,11 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
             self.bounds = {
                 p: [
                     self.pre_rescaling(
-                        np.min(self.get_parameters_value(p, x, x_prime))
+                        np.min(self.get_parameter_value(p, x, x_prime))
                     )[0]
                     - self.offsets[p],
                     self.pre_rescaling(
-                        np.max(self.get_parameters_value(p, x, x_prime))
+                        np.max(self.get_parameter_value(p, x, x_prime))
                     )[0]
                     - self.offsets[p],
                 ]

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -244,7 +244,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         log_j : Log jacobian to be updated
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self.get_value(p, x, x_prime)
+            x_in = self._get_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -295,7 +295,7 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         if self._update:
             logger.debug("Updating scale and shift")
             for p in self.parameters:
-                x_pre = self.pre_rescaling(self.get_value(p, x, x_prime))[0]
+                x_pre = self.pre_rescaling(self._get_value(p, x, x_prime))[0]
                 if self.estimate_scale:
                     self.scale[p] = np.std(x_pre)
                 if self.estimate_shift:
@@ -581,7 +581,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         return x, x_prime, log_j
 
     def _reverse_inversion(self, x, x_prime, log_j, p, pp):
-        value = self.get_value(p, x, x_prime)
+        value = self._get_value(p, x, x_prime)
         if self._edges[p]:
             inv = value < 0.0
             value = value.copy()
@@ -619,7 +619,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
             Parsed to inversion function
         """
         for p, pp in zip(self.parameters, self.output_parameters):
-            x_in = self.get_value(p, x, x_prime)
+            x_in = self._get_value(p, x, x_prime)
             if self.has_pre_rescaling:
                 x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
@@ -656,13 +656,13 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
                     x, x_prime, log_j, p, pp, **kwargs
                 )
             else:
-                value = self.get_value(p, x, x_prime)
+                value = self._get_value(p, x, x_prime)
                 value, lj = self._inverse_rescale_to_bounds(value, p)
                 value = value + self.offsets[p]
                 log_j += lj
                 x, x_prime = self._set_value(p, value, x, x_prime)
             if self.has_pre_rescaling:
-                value = self.get_value(p, x, x_prime)
+                value = self._get_value(p, x, x_prime)
                 value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
                 x, x_prime = self._set_value(p, value, x, x_prime)
@@ -696,11 +696,11 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         if self._update:
             self.bounds = {
                 p: [
-                    self.pre_rescaling(np.min(self.get_value(p, x, x_prime)))[
+                    self.pre_rescaling(np.min(self._get_value(p, x, x_prime)))[
                         0
                     ]
                     - self.offsets[p],
-                    self.pre_rescaling(np.max(self.get_value(p, x, x_prime)))[
+                    self.pre_rescaling(np.max(self._get_value(p, x, x_prime)))[
                         0
                     ]
                     - self.offsets[p],

--- a/src/nessai/reparameterisations/rescale.py
+++ b/src/nessai/reparameterisations/rescale.py
@@ -159,8 +159,9 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         scale=None,
@@ -170,21 +171,20 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
         pre_rescaling=None,
         post_rescaling=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        inverse_input_parameters=None,
+        parameters=None,
     ):
         if scale is None and not estimate_scale:
             raise RuntimeError("Must specify a scale or enable estimate_scale")
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            inverse_input_parameters=inverse_input_parameters,
+            parameters=parameters,
         )
 
         self.estimate_scale = estimate_scale
@@ -196,12 +196,12 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
             self._update = False
 
         if self.estimate_scale:
-            self.scale = {p: 1.0 for p in parameters}
+            self.scale = {p: 1.0 for p in self.input_parameters}
         elif scale:
             self.scale = self._check_value(scale, "scale")
 
         if self.estimate_shift:
-            self.shift = {p: 0.0 for p in parameters}
+            self.shift = {p: 0.0 for p in self.input_parameters}
         elif shift:
             self.shift = self._check_value(shift, "shift")
         else:
@@ -243,12 +243,13 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
             Array to be update
         log_j : Log jacobian to be updated
         """
-        for p, pp in zip(self.parameters, self.prime_parameters):
+        for p, pp in zip(self.parameters, self.output_parameters):
+            x_in = self.get_value(p, x, x_prime)
             if self.has_pre_rescaling:
-                x_prime[pp], lj = self.pre_rescaling(x[p])
+                x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
             else:
-                x_prime[pp] = x[p]
+                x_prime[pp] = x_in
             if self.shift:
                 x_prime[pp] = (x_prime[pp] - self.shift[p]) / self.scale[p]
             else:
@@ -272,28 +273,29 @@ class ScaleAndShift(PrePostRescalingMixin, Reparameterisation):
             Array to be update
         log_j : Log jacobian to be updated
         """
-        for p, pp in zip(self.parameters, self.prime_parameters):
+        for p, pp in zip(self.parameters, self.output_parameters):
             if self.has_post_rescaling:
-                x_in, lj = self.post_rescaling_inv(x_prime[pp])
+                value, lj = self.post_rescaling_inv(x_prime[pp])
                 log_j += lj
             else:
-                x_in = x_prime[pp]
+                value = x_prime[pp]
             if self.shift:
-                x[p] = (x_in * self.scale[p]) + self.shift[p]
+                value = (value * self.scale[p]) + self.shift[p]
             else:
-                x[p] = x_in * self.scale[p]
+                value = value * self.scale[p]
             log_j += np.log(np.abs(self.scale[p]))
             if self.has_pre_rescaling:
-                x[p], lj = self.pre_rescaling_inv(x[p])
+                value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
+            x, x_prime = self._set_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
-    def update(self, x):
+    def update(self, x, x_prime=None):
         """Update the scale and shift parameters if enabled."""
         if self._update:
             logger.debug("Updating scale and shift")
             for p in self.parameters:
-                x_pre = self.pre_rescaling(x[p])[0]
+                x_pre = self.pre_rescaling(self.get_value(p, x, x_prime))[0]
                 if self.estimate_scale:
                     self.scale[p] = np.std(x_pre)
                 if self.estimate_shift:
@@ -361,8 +363,9 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
 
     def __init__(
         self,
-        parameters=None,
-        prime_parameters=None,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
         auxiliary_parameters=None,
         prior_bounds=None,
         rescale_bounds=None,
@@ -375,19 +378,18 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         pre_rescaling=None,
         post_rescaling=None,
         rng=None,
-        requires=None,
-        prime_requires=None,
-        inverse_requires=None,
+        inverse_input_parameters=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters,
-            prime_parameters=prime_parameters,
+            input_parameters=input_parameters,
+            output_parameters=output_parameters,
+            persistent_parameters=persistent_parameters,
             auxiliary_parameters=auxiliary_parameters,
             prior_bounds=prior_bounds,
             rng=rng,
-            requires=requires,
-            prime_requires=prime_requires,
-            inverse_requires=inverse_requires,
+            inverse_input_parameters=inverse_input_parameters,
+            parameters=parameters,
         )
 
         self.bounds = None
@@ -406,7 +408,7 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
                     p: rescale_bounds for p in self.parameters
                 }
             elif isinstance(rescale_bounds, dict):
-                s = set(parameters) - set(rescale_bounds.keys())
+                s = set(self.input_parameters) - set(rescale_bounds.keys())
                 if s:
                     raise RuntimeError(
                         f"Missing rescale bounds for parameters: {s}"
@@ -579,22 +581,24 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         return x, x_prime, log_j
 
     def _reverse_inversion(self, x, x_prime, log_j, p, pp):
+        value = self.get_value(p, x, x_prime)
         if self._edges[p]:
-            inv = x[p] < 0.0
-            x[p][~inv] = x[p][~inv]
-            x[p][inv] = -x[p][inv]
+            inv = value < 0.0
+            value = value.copy()
+            value[inv] = -value[inv]
 
             if self._edges[p] == "upper":
-                x[p] = 1 - x[p]
-            x[p], lj = inverse_rescale_zero_to_one(x[p], *self.bounds[p])
-            x[p] += self.offsets[p]
+                value = 1 - value
+            value, lj = inverse_rescale_zero_to_one(value, *self.bounds[p])
+            value = value + self.offsets[p]
             log_j += lj
         else:
-            x[p], lj = inverse_rescale_minus_one_to_one(
-                x[p], xmin=self.bounds[p][0], xmax=self.bounds[p][1]
+            value, lj = inverse_rescale_minus_one_to_one(
+                value, xmin=self.bounds[p][0], xmax=self.bounds[p][1]
             )
-            x[p] += self.offsets[p]
+            value = value + self.offsets[p]
             log_j += lj
+        x, x_prime = self._set_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
     def reparameterise(
@@ -614,12 +618,13 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         kwargs :
             Parsed to inversion function
         """
-        for p, pp in zip(self.parameters, self.prime_parameters):
+        for p, pp in zip(self.parameters, self.output_parameters):
+            x_in = self.get_value(p, x, x_prime)
             if self.has_pre_rescaling:
-                x_prime[pp], lj = self.pre_rescaling(x[p])
+                x_prime[pp], lj = self.pre_rescaling(x_in)
                 log_j += lj
             else:
-                x_prime[pp] = x[p]
+                x_prime[pp] = x_in
 
             if self.boundary_inversion and p in self.boundary_inversion:
                 x, x_prime, log_j = self._apply_inversion(
@@ -638,24 +643,29 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
         """Map inputs to the physical space from the prime space"""
         for p, pp in zip(
-            reversed(self.parameters), reversed(self.prime_parameters)
+            reversed(self.parameters), reversed(self.output_parameters)
         ):
             if self.has_post_rescaling:
-                x[p], lj = self.post_rescaling_inv(x_prime[pp])
+                value, lj = self.post_rescaling_inv(x_prime[pp])
                 log_j += lj
             else:
-                x[p] = x_prime[pp]
+                value = x_prime[pp]
+            x, x_prime = self._set_value(p, value, x, x_prime)
             if self.boundary_inversion and p in self.boundary_inversion:
                 x, x_prime, log_j = self._reverse_inversion(
                     x, x_prime, log_j, p, pp, **kwargs
                 )
             else:
-                x[p], lj = self._inverse_rescale_to_bounds(x[p], p)
-                x[p] += self.offsets[p]
+                value = self.get_value(p, x, x_prime)
+                value, lj = self._inverse_rescale_to_bounds(value, p)
+                value = value + self.offsets[p]
                 log_j += lj
+                x, x_prime = self._set_value(p, value, x, x_prime)
             if self.has_pre_rescaling:
-                x[p], lj = self.pre_rescaling_inv(x[p])
+                value = self.get_value(p, x, x_prime)
+                value, lj = self.pre_rescaling_inv(value)
                 log_j += lj
+                x, x_prime = self._set_value(p, value, x, x_prime)
         return x, x_prime, log_j
 
     def reset_inversion(self):
@@ -681,13 +691,19 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         }
         logger.debug(f"Initial bounds: {self.bounds}")
 
-    def update_bounds(self, x):
+    def update_bounds(self, x, x_prime=None):
         """Update the bounds used for the reparameterisation"""
         if self._update:
             self.bounds = {
                 p: [
-                    self.pre_rescaling(np.min(x[p]))[0] - self.offsets[p],
-                    self.pre_rescaling(np.max(x[p]))[0] - self.offsets[p],
+                    self.pre_rescaling(np.min(self.get_value(p, x, x_prime)))[
+                        0
+                    ]
+                    - self.offsets[p],
+                    self.pre_rescaling(np.max(self.get_value(p, x, x_prime)))[
+                        0
+                    ]
+                    - self.offsets[p],
                 ]
                 for p in self.parameters
             }
@@ -696,12 +712,12 @@ class RescaleToBounds(PrePostRescalingMixin, Reparameterisation):
         else:
             logger.debug("Update bounds not enabled")
 
-    def update(self, x):
+    def update(self, x, x_prime=None):
         """Update the reparameterisation given some points.
 
         Includes resetting the inversions and updating the bounds.
         """
-        self.update_bounds(x)
+        self.update_bounds(x, x_prime=x_prime)
         self.reset_inversion()
 
     def reset(self):

--- a/src/nessai/reparameterisations/utils.py
+++ b/src/nessai/reparameterisations/utils.py
@@ -39,7 +39,7 @@ class ReparameterisationSpec:
     spec_index: int
     reparameterisation: str | None
     source_is_parameter: bool
-    parameters: list[str] | None
+    input_parameters: list[str] | None
     kwargs: dict[str, Any] = field(default_factory=dict)
 
 
@@ -152,7 +152,7 @@ def normalise_reparameterisation_spec(
         if key in model_names:
             return cfg.copy()
         logger.debug("Assuming list of patterns")
-        return [{"parameters": cfg.copy()}]
+        return [{"input_parameters": cfg.copy()}]
     raise TypeError(
         f"Unknown config type for: {key}. Expected str, dict or list, "
         f"received instance of {type(cfg)}."
@@ -168,7 +168,7 @@ def build_reparameterisation_spec(key, spec_cfg, spec_index, model_names):
                 spec_index=spec_index,
                 reparameterisation=spec_cfg,
                 source_is_parameter=True,
-                parameters=[key],
+                input_parameters=[key],
             )
         if not isinstance(spec_cfg, dict):
             raise TypeError(
@@ -185,35 +185,34 @@ def build_reparameterisation_spec(key, spec_cfg, spec_index, model_names):
             )
         reparameterisation = spec_cfg.pop("reparameterisation")
 
-        if "parameters" in spec_cfg:
-            parameters = spec_cfg.pop("parameters")
-            if isinstance(parameters, str):
-                parameters = [parameters]
-            elif parameters is None:
-                parameters = []
+        if "input_parameters" in spec_cfg or "parameters" in spec_cfg:
+            input_parameters = spec_cfg.pop(
+                "input_parameters", spec_cfg.pop("parameters", None)
+            )
+            if isinstance(input_parameters, str):
+                input_parameters = [input_parameters]
+            elif input_parameters is None:
+                input_parameters = []
             else:
-                parameters = list(parameters)
-
-            if parameters:
-                parameters = list(dict.fromkeys([key, *parameters]))
+                input_parameters = list(input_parameters)
         else:
-            parameters = [key]
+            input_parameters = [key]
 
         return ReparameterisationSpec(
             source_key=key,
             spec_index=spec_index,
             reparameterisation=reparameterisation,
             source_is_parameter=True,
-            parameters=parameters,
+            input_parameters=input_parameters,
             kwargs=spec_cfg,
         )
 
     if isinstance(spec_cfg, str):
         logger.debug("Assuming reparameterisation name and single parameter")
-        spec_cfg = {"parameters": [spec_cfg]}
+        spec_cfg = {"input_parameters": [spec_cfg]}
     elif isinstance(spec_cfg, list):
         logger.debug("Assuming list of patterns")
-        spec_cfg = {"parameters": spec_cfg}
+        spec_cfg = {"input_parameters": spec_cfg}
     elif not isinstance(spec_cfg, dict):
         raise TypeError(
             f"Unknown config type for: {key}. Expected str or dict, "
@@ -227,7 +226,9 @@ def build_reparameterisation_spec(key, spec_cfg, spec_index, model_names):
         spec_index=spec_index,
         reparameterisation=key,
         source_is_parameter=False,
-        parameters=spec_cfg.pop("parameters", None),
+        input_parameters=spec_cfg.pop(
+            "input_parameters", spec_cfg.pop("parameters", None)
+        ),
         kwargs=spec_cfg,
     )
 
@@ -247,7 +248,7 @@ def parse_reparameterisations(
 
     if isinstance(reparameterisations, str):
         reparameterisations = {
-            reparameterisations: {"parameters": model_names}
+            reparameterisations: {"input_parameters": model_names}
         }
     elif not isinstance(reparameterisations, dict):
         raise TypeError(

--- a/src/nessai/reparameterisations/utils.py
+++ b/src/nessai/reparameterisations/utils.py
@@ -5,6 +5,7 @@ Utilities for handling the reparameterisations.
 
 import copy
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -26,6 +27,18 @@ class KnownReparameterisation:
     name: str
     class_fn: Reparameterisation
     keyword_arguments: dict[str:Any] = field(default_factory=dict)
+
+
+@dataclass
+class ReparameterisationSpec:
+    """Normalised representation of a reparameterisation config spec."""
+
+    source_key: str
+    spec_index: int
+    reparameterisation: str | None
+    source_is_parameter: bool
+    parameters: list[str] | None
+    kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 class ReparameterisationDict(dict):
@@ -113,3 +126,171 @@ def get_reparameterisation(reparameterisation, defaults=None):
             "Reparameterisation must be a str, None, or class that "
             "inherits from `Reparameterisation`"
         )
+
+
+def normalise_reparameterisation_spec(
+    key: str, cfg: str | dict | list | None, model_names: list[str]
+) -> list[dict] | list[str] | list[None]:
+    """Normalise a reparameterisation config entry into a list of spec configs.
+
+    Parameters
+    ----------
+    key : str
+        The key of the config entry.
+    cfg : str, dict, list, or None
+        The config entry to normalise.
+    model_names : list of str
+        The names of the model parameters.
+    """
+    if isinstance(cfg, str) or cfg is None:
+        return [cfg]
+    if isinstance(cfg, dict):
+        return [cfg.copy()]
+    if isinstance(cfg, list):
+        if key in model_names:
+            return cfg.copy()
+        logger.debug("Assuming list of patterns")
+        return [{"parameters": cfg.copy()}]
+    raise TypeError(
+        f"Unknown config type for: {key}. Expected str, dict or list, "
+        f"received instance of {type(cfg)}."
+    )
+
+
+def build_reparameterisation_spec(key, spec_cfg, spec_index, model_names):
+    """Build a normalised spec from a single config entry."""
+    if key in model_names:
+        if isinstance(spec_cfg, str) or spec_cfg is None:
+            return ReparameterisationSpec(
+                source_key=key,
+                spec_index=spec_index,
+                reparameterisation=spec_cfg,
+                source_is_parameter=True,
+                parameters=[key],
+            )
+        if not isinstance(spec_cfg, dict):
+            raise TypeError(
+                f"Unknown config type for: {key}. Expected str, dict or list, "
+                f"received instance of {type(spec_cfg)}."
+            )
+
+        spec_cfg = spec_cfg.copy()
+        if spec_cfg.get("reparameterisation", None) is None:
+            raise RuntimeError(
+                f"No reparameterisation found for {key}. "
+                "Check inputs (and their spelling :)). "
+                f"Current keys: {list(spec_cfg.keys())}"
+            )
+        reparameterisation = spec_cfg.pop("reparameterisation")
+
+        if "parameters" in spec_cfg:
+            parameters = spec_cfg.pop("parameters")
+            if isinstance(parameters, str):
+                parameters = [parameters]
+            elif parameters is None:
+                parameters = []
+            else:
+                parameters = list(parameters)
+
+            if parameters:
+                parameters = list(dict.fromkeys([key, *parameters]))
+        else:
+            parameters = [key]
+
+        return ReparameterisationSpec(
+            source_key=key,
+            spec_index=spec_index,
+            reparameterisation=reparameterisation,
+            source_is_parameter=True,
+            parameters=parameters,
+            kwargs=spec_cfg,
+        )
+
+    if isinstance(spec_cfg, str):
+        logger.debug("Assuming reparameterisation name and single parameter")
+        spec_cfg = {"parameters": [spec_cfg]}
+    elif isinstance(spec_cfg, list):
+        logger.debug("Assuming list of patterns")
+        spec_cfg = {"parameters": spec_cfg}
+    elif not isinstance(spec_cfg, dict):
+        raise TypeError(
+            f"Unknown config type for: {key}. Expected str or dict, "
+            f"received instance of {type(spec_cfg)}."
+        )
+
+    spec_cfg = spec_cfg.copy()
+    spec_cfg.pop("reparameterisation", None)
+    return ReparameterisationSpec(
+        source_key=key,
+        spec_index=spec_index,
+        reparameterisation=key,
+        source_is_parameter=False,
+        parameters=spec_cfg.pop("parameters", None),
+        kwargs=spec_cfg,
+    )
+
+
+def parse_reparameterisations(
+    reparameterisations, model_names, class_name=None
+):
+    """Parse user reparameterisation config into ordered specs."""
+    if reparameterisations is None:
+        logger.info(
+            "No reparameterisations provided, using default "
+            f"reparameterisations included in {class_name or 'the proposal class'}"
+        )
+        reparameterisations = {}
+    else:
+        reparameterisations = copy.deepcopy(reparameterisations)
+
+    if isinstance(reparameterisations, str):
+        reparameterisations = {
+            reparameterisations: {"parameters": model_names}
+        }
+    elif not isinstance(reparameterisations, dict):
+        raise TypeError(
+            "Reparameterisations must be a dictionary, string or None, "
+            f"received {type(reparameterisations).__name__}"
+        )
+
+    specs = []
+    for key, cfg in reparameterisations.items():
+        spec_configs = normalise_reparameterisation_spec(key, cfg, model_names)
+        for spec_index, spec_cfg in enumerate(spec_configs):
+            specs.append(
+                build_reparameterisation_spec(
+                    key, spec_cfg, spec_index, model_names
+                )
+            )
+    return specs
+
+
+def resolve_reparameterisation_parameters(parameters, available_parameters):
+    """Resolve parameter names or regex patterns for reparameterisations."""
+    if parameters is None:
+        return None
+
+    if isinstance(parameters, str):
+        patterns = [parameters]
+    else:
+        patterns = list(parameters)
+
+    known_parameters = list(dict.fromkeys(available_parameters))
+
+    matches = []
+    for pattern in patterns:
+        if pattern in known_parameters:
+            matches.append(pattern)
+            continue
+
+        regex = re.compile(pattern)
+        pattern_matches = list(filter(regex.fullmatch, known_parameters))
+        if pattern_matches:
+            matches.extend(pattern_matches)
+        else:
+            logger.warning(
+                f"No matches found for pattern: {pattern}. "
+                f"Known parameters are: {known_parameters}"
+            )
+
+    return list(dict.fromkeys(matches))

--- a/src/nessai/reparameterisations/utils.py
+++ b/src/nessai/reparameterisations/utils.py
@@ -3,6 +3,8 @@
 Utilities for handling the reparameterisations.
 """
 
+from __future__ import annotations
+
 import copy
 import logging
 import re

--- a/src/nessai/utils/sorting.py
+++ b/src/nessai/utils/sorting.py
@@ -56,39 +56,43 @@ def sort_reparameterisations(
     if known_parameters is None:
         known_parameters = parameters.copy()
         for r in reparameterisations:
-            known_parameters += r.output_parameters
+            known_parameters += r.auxiliary_parameters
         known_parameters = list(dict.fromkeys(known_parameters))
 
     if known_prime_parameters is None:
         known_prime_parameters = prime_parameters.copy()
         for r in reparameterisations:
-            known_prime_parameters += r.prime_parameters
+            known_prime_parameters += r.output_parameters
         known_prime_parameters = list(dict.fromkeys(known_prime_parameters))
 
     if initial_sort:
         reparameterisations = sorted(
             reparameterisations,
-            key=lambda r: len(r.requires) + len(r.prime_requires),
+            key=lambda r: len(r.input_parameters),
         )
 
     for r in reparameterisations:
-        if all([req in parameters for req in r.input_parameters]) and all(
-            [req in prime_parameters for req in r.prime_requires]
-        ):
+        missing_inputs = r.resolve_forward_input_spaces(
+            parameters, prime_parameters
+        )
+        if not missing_inputs:
             ordered.append(r)
-            parameters += r.output_parameters
-            prime_parameters += r.prime_parameters
-        elif any([req not in known_parameters for req in r.input_parameters]):
-            raise ValueError(
-                f"{r.name} requires {r.input_parameters} which contains parameters "
-                f"that are not known ({known_parameters})"
-            )
+            parameters += [
+                p for p in r.x_output_parameters if p not in parameters
+            ]
+            prime_parameters += [
+                p for p in r.output_parameters if p not in prime_parameters
+            ]
         elif any(
-            [req not in known_prime_parameters for req in r.prime_requires]
+            [
+                req not in known_parameters
+                and req not in known_prime_parameters
+                for req in missing_inputs
+            ]
         ):
             raise ValueError(
-                f"{r.name} requires prime parameters {r.prime_requires} which "
-                f"are not known ({known_prime_parameters})"
+                f"{r.name} requires inputs {missing_inputs} which are not "
+                f"known (x: {known_parameters}, x': {known_prime_parameters})"
             )
         else:
             skipped.append(r)

--- a/src/nessai/utils/sorting.py
+++ b/src/nessai/utils/sorting.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
 def sort_reparameterisations(
     reparameterisations: List["Reparameterisation"],
     existing_parameters: Optional[List[str]] = None,
+    existing_prime_parameters: Optional[List[str]] = None,
     known_parameters: Optional[List[str]] = None,
+    known_prime_parameters: Optional[List[str]] = None,
     initial_sort: bool = True,
 ) -> List["Reparameterisation"]:
     """Sort reparameterisations based on their parameters and requirements.
@@ -23,9 +25,14 @@ def sort_reparameterisations(
         List of reparameterisations.
     existing_parameters : Optional[List[str]]
         List of parameters that are all included.
+    existing_prime_parameters : Optional[List[str]]
+        List of prime parameters that are all included.
     known_parameters : Optional[List[str]]
         List of all known parameters. If not specified it is inferred from the
         list of reparameterisations.
+    known_prime_parameters : Optional[List[str]]
+        List of all known prime parameters. If not specified it is inferred from
+        the list of reparameterisations.
     initial_sort : bool
         Toggle initial sorting by the number of requirements.
 
@@ -42,35 +49,64 @@ def sort_reparameterisations(
     ordered = []
     skipped = []
     parameters = existing_parameters.copy() if existing_parameters else []
+    prime_parameters = (
+        existing_prime_parameters.copy() if existing_prime_parameters else []
+    )
 
     if known_parameters is None:
         known_parameters = parameters.copy()
         for r in reparameterisations:
-            known_parameters += r.parameters
+            known_parameters += r.output_parameters
+        known_parameters = list(dict.fromkeys(known_parameters))
+
+    if known_prime_parameters is None:
+        known_prime_parameters = prime_parameters.copy()
+        for r in reparameterisations:
+            known_prime_parameters += r.prime_parameters
+        known_prime_parameters = list(dict.fromkeys(known_prime_parameters))
 
     if initial_sort:
         reparameterisations = sorted(
-            reparameterisations, key=lambda r: len(r.requires)
+            reparameterisations,
+            key=lambda r: len(r.requires) + len(r.prime_requires),
         )
 
     for r in reparameterisations:
-        if not r.requires or all([req in parameters for req in r.requires]):
+        if all([req in parameters for req in r.input_parameters]) and all(
+            [req in prime_parameters for req in r.prime_requires]
+        ):
             ordered.append(r)
-            parameters += r.parameters
-        elif any([req not in known_parameters for req in r.requires]):
+            parameters += r.output_parameters
+            prime_parameters += r.prime_parameters
+        elif any([req not in known_parameters for req in r.input_parameters]):
             raise ValueError(
-                f"{r.name} requires {r.requires} which contains parameters "
+                f"{r.name} requires {r.input_parameters} which contains parameters "
                 f"that are not known ({known_parameters})"
+            )
+        elif any(
+            [req not in known_prime_parameters for req in r.prime_requires]
+        ):
+            raise ValueError(
+                f"{r.name} requires prime parameters {r.prime_requires} which "
+                f"are not known ({known_prime_parameters})"
             )
         else:
             skipped.append(r)
 
     if skipped:
+        if not ordered:
+            raise ValueError(
+                "Could not sort reparameterisations, check initial "
+                "parameters and dependencies. Current parameters: "
+                f"{parameters}. Current prime parameters: {prime_parameters}"
+            )
         ordered += skipped
         return sort_reparameterisations(
             ordered,
             existing_parameters=existing_parameters,
+            existing_prime_parameters=existing_prime_parameters,
             known_parameters=known_parameters,
+            known_prime_parameters=known_prime_parameters,
             initial_sort=False,
         )
     return ordered

--- a/tests/test_proposal/test_flowproposal/test_base/test_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_flow.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from nessai.livepoint import numpy_array_to_live_points
+from nessai.livepoint import get_dtype, numpy_array_to_live_points
 from nessai.proposal.flowproposal.base import BaseFlowProposal
 from nessai.utils.testing import assert_structured_arrays_equal
 
@@ -83,15 +83,15 @@ def test_backward_pass(proposal, rescale):
     """Test the backward pass method"""
     z = np.random.randn(10, 2)
     x_prime = np.random.randn(*z.shape)
-    x = numpy_array_to_live_points(
-        np.random.randn(*x_prime.shape),
-        ["x", "y"],
-    )
     log_j = np.random.rand(z.shape[0])
     proposal.flow = MagicMock()
     # log_j has in place operations
     proposal.flow.inverse = MagicMock(return_value=(x_prime, log_j.copy()))
     proposal.prime_parameters = ["x_prime", "y_prime"]
+    proposal._prime_parameters_internal = proposal.prime_parameters
+    proposal.x_prime_internal_dtype = get_dtype(
+        proposal._prime_parameters_internal
+    )
 
     x_rescale = numpy_array_to_live_points(
         np.random.randn(*x_prime.shape),
@@ -102,25 +102,23 @@ def test_backward_pass(proposal, rescale):
         return_value=(x_rescale, log_j_rescale)
     )
 
-    with patch(
-        "nessai.proposal.flowproposal.base.numpy_array_to_live_points",
-        return_value=x,
-    ) as mock:
-        x_out, log_j_out = BaseFlowProposal.backward_pass(
-            proposal, z, rescale=rescale, test=True
-        )
+    x_out, log_j_out = BaseFlowProposal.backward_pass(
+        proposal, z, rescale=rescale, test=True
+    )
 
     proposal.flow.inverse.assert_called_once_with(z)
-    mock.assert_called_once()
-    np.testing.assert_array_equal(mock.call_args[0][0], x_prime)
-    assert mock.call_args[0][1] == proposal.prime_parameters
 
     if not rescale:
         proposal.inverse_rescale.assert_not_called()
-        assert x_out is x
+        np.testing.assert_array_equal(x_out["x_prime"], x_prime[:, 0])
+        np.testing.assert_array_equal(x_out["y_prime"], x_prime[:, 1])
         np.testing.assert_array_equal(log_j_out, log_j)
     else:
-        proposal.inverse_rescale.assert_called_once_with(x, test=True)
+        proposal.inverse_rescale.assert_called_once()
+        x_prime_struct = proposal.inverse_rescale.call_args.args[0]
+        np.testing.assert_array_equal(x_prime_struct["x_prime"], x_prime[:, 0])
+        np.testing.assert_array_equal(x_prime_struct["y_prime"], x_prime[:, 1])
+        assert proposal.inverse_rescale.call_args.kwargs == {"test": True}
         assert x_out is x_rescale
         np.testing.assert_array_equal(log_j_out, log_j_rescale + log_j)
 

--- a/tests/test_proposal/test_flowproposal/test_base/test_properties.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_properties.py
@@ -55,6 +55,27 @@ def test_prime_dtype(proposal):
     )
 
 
+def test_internal_prime_parameters(proposal):
+    """Test the internal prime parameters property."""
+    proposal._prime_parameters_internal = ["x", "y", "z"]
+    assert BaseFlowProposal.internal_prime_parameters.__get__(proposal) == [
+        "x",
+        "y",
+        "z",
+    ]
+
+
+def test_prime_internal_dtype(proposal):
+    """Test the dtype for the full internal x-prime space."""
+    proposal.prime_parameters = ["x", "z"]
+    proposal._prime_parameters_internal = ["x", "y", "z"]
+    proposal._x_prime_internal_dtype = None
+    assert (
+        BaseFlowProposal.x_prime_internal_dtype.__get__(proposal)
+        == [("x", "f8"), ("y", "f8"), ("z", "f8")] + EXTRA_PARAMS_DTYPE
+    )
+
+
 def test_population_dtype(proposal):
     """Test dims property"""
     proposal.x_dtype = [

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -474,6 +474,40 @@ def test_set_parameter_order(proposal):
     ]
 
 
+@pytest.mark.parametrize(
+    "persistent, expected",
+    [
+        ([], ["x_scaled"]),
+        (["x_bounded"], ["x_bounded", "x_scaled"]),
+    ],
+)
+def test_set_parameter_order_removes_non_persistent_intermediate_prime_inputs(
+    proposal, persistent, expected
+):
+    proposal.model.names = ["x"]
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.parameters = ["x"]
+    proposal._reparameterisation.values.return_value = [
+        MagicMock(
+            input_parameters=["x"],
+            output_parameters=["x_bounded"],
+            x_prime_input_parameters=[],
+            x_prime_persistent_parameters=[],
+        ),
+        MagicMock(
+            input_parameters=["x_bounded"],
+            output_parameters=["x_scaled"],
+            x_prime_input_parameters=["x_bounded"],
+            x_prime_persistent_parameters=persistent,
+        ),
+    ]
+
+    BaseFlowProposal._set_parameter_order(proposal)
+
+    assert proposal._prime_parameters_internal == ["x_bounded", "x_scaled"]
+    assert proposal.prime_parameters == expected
+
+
 def test_set_rescaling_with_model(proposal, model):
     """
     Test setting the rescaling when the model contains reparmaeterisations.

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -46,6 +46,7 @@ def dummy_cmb_rc():
     m.values.return_value = []
     m.check_order = MagicMock()
     m.parameters = []
+    m.prime_parameters = []
     return m
 
 
@@ -148,7 +149,7 @@ def test_get_reparameterisation_from_spec_model_key(proposal, dummy_rc):
         spec_index=0,
         reparameterisation="default",
         source_is_parameter=True,
-        parameters=["x", "y"],
+        input_parameters=["x", "y"],
         kwargs={"scale": 2.0},
     )
 
@@ -159,7 +160,7 @@ def test_get_reparameterisation_from_spec_model_key(proposal, dummy_rc):
     assert rc is dummy_rc
     assert config == {
         "offset": 1.0,
-        "parameters": ["x", "y"],
+        "input_parameters": ["x", "y"],
         "scale": 2.0,
     }
     proposal.get_reparameterisation.assert_called_once_with("default")
@@ -216,7 +217,7 @@ def test_get_reparameterisation_from_spec_resolves_patterns(
         spec_index=0,
         reparameterisation="z-score",
         source_is_parameter=False,
-        parameters=parameters,
+        input_parameters=parameters,
         kwargs={},
     )
 
@@ -225,7 +226,7 @@ def test_get_reparameterisation_from_spec_resolves_patterns(
     )
 
     assert rc is dummy_rc
-    assert config == {"parameters": ["x_0", "x_1"]}
+    assert config == {"input_parameters": ["x_0", "x_1"]}
 
 
 @pytest.mark.parametrize(
@@ -236,7 +237,7 @@ def test_get_reparameterisation_from_spec_resolves_patterns(
             spec_index=0,
             reparameterisation="sine",
             source_is_parameter=True,
-            parameters=["x"],
+            input_parameters=["x"],
             kwargs={},
         ),
         ReparameterisationSpec(
@@ -244,7 +245,7 @@ def test_get_reparameterisation_from_spec_resolves_patterns(
             spec_index=0,
             reparameterisation="sine",
             source_is_parameter=False,
-            parameters=["x"],
+            input_parameters=["x"],
             kwargs={},
         ),
     ],
@@ -260,7 +261,7 @@ def test_get_reparameterisation_from_spec_unknown(proposal, spec):
 
 
 def test_get_reparameterisation_from_spec_no_parameters(proposal, dummy_rc):
-    """Assert an error is raised if the resolved config has no parameters."""
+    """Assert an error is raised if the resolved config has no inputs."""
     proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
     proposal.model.names = ["x"]
     proposal._reparameterisation = MagicMock()
@@ -270,14 +271,14 @@ def test_get_reparameterisation_from_spec_no_parameters(proposal, dummy_rc):
         spec_index=0,
         reparameterisation="default",
         source_is_parameter=False,
-        parameters=None,
+        input_parameters=None,
         kwargs={"update_bounds": True},
     )
 
     with pytest.raises(RuntimeError) as excinfo:
         BaseFlowProposal.get_reparameterisation_from_spec(proposal, spec)
 
-    assert "No parameters key" in str(excinfo.value)
+    assert "No input_parameters key" in str(excinfo.value)
 
 
 def test_get_reparameterisation_from_spec_empty_parameters(proposal, dummy_rc):
@@ -287,33 +288,33 @@ def test_get_reparameterisation_from_spec_empty_parameters(proposal, dummy_rc):
         spec_index=0,
         reparameterisation="default",
         source_is_parameter=True,
-        parameters=[],
+        input_parameters=[],
         kwargs={},
     )
 
     with pytest.raises(RuntimeError) as excinfo:
         BaseFlowProposal.get_reparameterisation_from_spec(proposal, spec)
 
-    assert "No parameters key" in str(excinfo.value)
+    assert "No input_parameters key" in str(excinfo.value)
 
 
-def test_get_reparameterisation_from_spec_allows_prime_requires(
+def test_get_reparameterisation_from_spec_allows_prime_inputs(
     proposal, dummy_rc
 ):
-    """Assert prime-only chained specs do not require x-space parameters."""
+    """Assert chained specs can use prime-space input parameters."""
     proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
     proposal.model.names = ["x"]
     proposal._reparameterisation = MagicMock()
     proposal._reparameterisation.parameters = ["x"]
+    proposal._reparameterisation.prime_parameters = ["x_bounded"]
     spec = ReparameterisationSpec(
         source_key="prime-scale",
         spec_index=1,
         reparameterisation="prime-scale",
         source_is_parameter=False,
-        parameters=[],
+        input_parameters=["x_bounded"],
         kwargs={
-            "prime_requires": ["x_bounded"],
-            "prime_parameters": ["x_scaled"],
+            "output_parameters": ["x_scaled"],
         },
     )
 
@@ -323,9 +324,8 @@ def test_get_reparameterisation_from_spec_allows_prime_requires(
 
     assert rc is dummy_rc
     assert config == {
-        "parameters": [],
-        "prime_parameters": ["x_scaled"],
-        "prime_requires": ["x_bounded"],
+        "input_parameters": ["x_bounded"],
+        "output_parameters": ["x_scaled"],
     }
 
 
@@ -334,7 +334,7 @@ def test_instantiate_reparameterisation_from_spec_with_rng(proposal, rng):
     spec = Mock()
     proposal.rng = rng
     proposal.get_reparameterisation_from_spec = MagicMock(
-        return_value=(Reparameterisation, {"parameters": ["x"]})
+        return_value=(Reparameterisation, {"input_parameters": ["x"]})
     )
     proposal._get_prior_bounds_for_parameters = MagicMock(
         return_value={"x": [-1, 1]}
@@ -411,7 +411,7 @@ def test_configure_reparameterisations_fallback(
         ["x", "y"],
     )
     dummy_rc.assert_called_once_with(
-        parameters=["x", "y"],
+        input_parameters=["x", "y"],
         prior_bounds={"x": [-1, 1], "y": [-1, 1]},
     )
     proposal._reparameterisation.add_reparameterisations.assert_called_once_with(
@@ -445,16 +445,22 @@ def test_set_parameter_order(proposal):
     proposal._reparameterisation.values.return_value = [
         MagicMock(
             parameters=["x", "z"],
-            prime_parameters=["x_prime", "z_prime"],
+            output_parameters=["x_prime", "z_prime"],
+            x_prime_input_parameters=[],
+            x_prime_persistent_parameters=[],
         ),
         MagicMock(
             parameters=["y"],
-            prime_parameters=["y_prime", "y_aux"],
+            output_parameters=["y_prime", "y_aux"],
+            x_prime_input_parameters=[],
+            x_prime_persistent_parameters=[],
         ),
         # Derived parameter (isn't present in model)
         MagicMock(
             parameters=["w"],
-            prime_parameters=["w_prime"],
+            output_parameters=["w_prime"],
+            x_prime_input_parameters=[],
+            x_prime_persistent_parameters=[],
         ),
     ]
     BaseFlowProposal._set_parameter_order(proposal)
@@ -479,6 +485,7 @@ def test_set_rescaling_with_model(proposal, model):
     def update(self):
         proposal.parameters = model.names
         proposal.prime_parameters = ["x_prime"]
+        proposal._prime_parameters_internal = proposal.prime_parameters
 
     proposal.configure_reparameterisations = MagicMock()
     proposal.configure_reparameterisations.side_effect = update
@@ -504,6 +511,7 @@ def test_set_rescaling_with_reparameterisations(proposal, model):
     def update(self):
         proposal.parameters = model.names
         proposal.prime_parameters = ["x_prime"]
+        proposal._prime_parameters_internal = proposal.prime_parameters
 
     proposal.configure_reparameterisations = MagicMock()
     proposal.configure_reparameterisations.side_effect = update
@@ -526,7 +534,7 @@ def test_rescale(proposal, n, map_to_unit_hypercube):
     x_prime = numpy_array_to_live_points(
         np.random.randn(n, 2), ["x_prime", "y_prime"]
     )
-    proposal.x_prime_dtype = get_dtype(["x_prime", "y_prime"])
+    proposal.x_prime_internal_dtype = get_dtype(["x_prime", "y_prime"])
     proposal.map_to_unit_hypercube = map_to_unit_hypercube
     proposal._reparameterisation = MagicMock()
     proposal._reparameterisation.reparameterise = MagicMock(

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -165,6 +165,50 @@ def test_get_reparameterisation_from_spec_model_key(proposal, dummy_rc):
     proposal.get_reparameterisation.assert_called_once_with("default")
 
 
+def test_get_prior_bounds_for_parameters_allows_missing_auxiliary(proposal):
+    """Assert auxiliary parameters are ignored in the default lookup mode."""
+    proposal.prior_bounds = {"x": [-1, 1]}
+    proposal.model.bounds = {"x": [-10, 10], "aux": [0, 1]}
+
+    out = BaseFlowProposal._get_prior_bounds_for_parameters(
+        proposal, ["x", "aux"]
+    )
+
+    assert out == {"x": [-1, 1]}
+
+
+def test_get_prior_bounds_for_parameters_require_all_uses_model_bounds(
+    proposal,
+):
+    """Assert full model bounds are used when all parameters are required."""
+    proposal.prior_bounds = {"x": [-1, 1]}
+    proposal.model.bounds = {"x": [-10, 10], "y": [0, 1]}
+
+    out = BaseFlowProposal._get_prior_bounds_for_parameters(
+        proposal, ["x", "y"], require_all=True
+    )
+
+    assert out == {"x": [-10, 10], "y": [0, 1]}
+
+
+def test_get_prior_bounds_for_parameters_single_parameter(proposal):
+    proposal.prior_bounds = {"x": [-1, 1]}
+    proposal.model.bounds = {"x": [-10, 10]}
+
+    out = BaseFlowProposal._get_prior_bounds_for_parameters(proposal, "x")
+
+    assert out == {"x": [-1, 1]}
+
+
+def test_get_prior_bounds_for_parameters_unknown_parameter(proposal):
+    proposal.prior_bounds = {"x": [-1, 1]}
+    proposal.model.bounds = {"x": [-10, 10]}
+
+    out = BaseFlowProposal._get_prior_bounds_for_parameters(proposal, "y")
+
+    assert out is None
+
+
 @pytest.mark.parametrize(
     "parameters",
     [
@@ -242,6 +286,23 @@ def test_get_reparameterisation_from_spec_no_parameters(proposal, dummy_rc):
         source_is_parameter=False,
         parameters=None,
         kwargs={"update_bounds": True},
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        BaseFlowProposal.get_reparameterisation_from_spec(proposal, spec)
+
+    assert "No parameters key" in str(excinfo.value)
+
+
+def test_get_reparameterisation_from_spec_empty_parameters(proposal, dummy_rc):
+    proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
+    spec = ReparameterisationSpec(
+        source_key="x",
+        spec_index=0,
+        reparameterisation="default",
+        source_is_parameter=True,
+        parameters=[],
+        kwargs={},
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -337,6 +398,9 @@ def test_configure_reparameterisations_fallback(
     proposal.add_default_reparameterisations = MagicMock()
     proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
     proposal.instantiate_reparameterisation_from_spec = MagicMock()
+    proposal._get_prior_bounds_for_parameters = MagicMock(
+        return_value={"x": [-1, 1], "y": [-1, 1]}
+    )
     proposal._set_parameter_order = MagicMock()
     proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
     proposal.model.names = ["x", "y"]
@@ -357,6 +421,9 @@ def test_configure_reparameterisations_fallback(
 
     proposal.add_default_reparameterisations.assert_not_called()
     proposal.get_reparameterisation.assert_called_once_with("default")
+    proposal._get_prior_bounds_for_parameters.assert_called_once_with(
+        ["x", "y"], require_all=True
+    )
     dummy_rc.assert_called_once_with(
         parameters=["x", "y"],
         prior_bounds={"x": [-1, 1], "y": [-1, 1]},

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -7,18 +7,15 @@ import pytest
 
 from nessai.livepoint import (
     get_dtype,
-    live_points_to_array,
     numpy_array_to_live_points,
 )
 from nessai.model import Model
 from nessai.proposal.flowproposal.base import BaseFlowProposal
 from nessai.reparameterisations import (
-    NullReparameterisation,
     Reparameterisation,
     ReparameterisationError,
-    RescaleToBounds,
-    get_reparameterisation,
 )
+from nessai.reparameterisations.utils import ReparameterisationSpec
 
 
 @pytest.fixture
@@ -27,21 +24,8 @@ def proposal(proposal):
     proposal.use_default_reparameterisations = False
     proposal.reverse_reparameterisations = False
     proposal.model = MagicMock(spec=Model)
-    proposal._set_parameter_order = (
-        BaseFlowProposal._set_parameter_order.__get__(
-            proposal, BaseFlowProposal
-        )
-    )
-    proposal._resolve_reparameterisation_parameters = (
-        BaseFlowProposal._resolve_reparameterisation_parameters.__get__(
-            proposal, BaseFlowProposal
-        )
-    )
-    proposal._get_prior_bounds_for_parameters = (
-        BaseFlowProposal._get_prior_bounds_for_parameters.__get__(
-            proposal, BaseFlowProposal
-        )
-    )
+    proposal.fallback_reparameterisation = None
+    proposal.prior_bounds = {}
     return proposal
 
 
@@ -58,117 +42,11 @@ def dummy_cmb_rc():
     """Dummy combined reparameteristation class"""
     m = MagicMock()
     m.add_reparameterisation = MagicMock()
+    m.add_reparameterisations = MagicMock()
+    m.values.return_value = []
+    m.check_order = MagicMock()
+    m.parameters = []
     return m
-
-
-class DummyFlowProposal(BaseFlowProposal):
-    def populate(self, worst_point, n_samples=10000):
-        raise NotImplementedError(
-            "This is a dummy proposal and does not implement populate."
-        )
-
-
-class AddAuxiliaryReparameterisation(Reparameterisation):
-    def __init__(
-        self,
-        parameters=None,
-        prior_bounds=None,
-        auxiliary_parameter="aux",
-        rng=None,
-    ):
-        super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
-        )
-        self.auxiliary_parameter = auxiliary_parameter
-        self.auxiliary_parameters = [auxiliary_parameter]
-
-    def reparameterise(self, x, x_prime, log_j, **kwargs):
-        if self.auxiliary_parameter not in x.dtype.names:
-            x_out = np.empty(
-                x.shape,
-                dtype=x.dtype.descr + [(self.auxiliary_parameter, "f8")],
-            )
-            for name in x.dtype.names:
-                x_out[name] = x[name]
-            x = x_out
-        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
-        x_prime[self.prime_parameters[0]] = x[self.parameters[0]]
-        return x, x_prime, log_j
-
-    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x[self.parameters[0]] = x_prime[self.prime_parameters[0]]
-        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
-        return x, x_prime, log_j
-
-
-class RescaleAuxiliaryReparameterisation(Reparameterisation):
-    def __init__(
-        self, parameters=None, prior_bounds=None, scale=10.0, rng=None
-    ):
-        super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
-        )
-        self.scale = scale
-
-    def reparameterise(self, x, x_prime, log_j, **kwargs):
-        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] / self.scale
-        log_j -= np.log(self.scale)
-        return x, x_prime, log_j
-
-    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] * self.scale
-        log_j += np.log(self.scale)
-        return x, x_prime, log_j
-
-
-def make_test_proposal(reparameterisations, rng):
-    """Construct a concrete proposal with a toy four-parameter model."""
-    model = MagicMock(spec=Model)
-    model.names = ["a", "b", "c", "d"]
-    model.bounds = {n: [-1.0, 1.0] for n in model.names}
-    model.reparameterisations = None
-
-    proposal = DummyFlowProposal(
-        model,
-        rng=rng,
-        poolsize=10,
-        reparameterisations=reparameterisations,
-        fallback_reparameterisation=None,
-    )
-    proposal.get_reparameterisation = MagicMock(
-        side_effect=get_reparameterisation
-    )
-    proposal.set_rescaling()
-    return proposal
-
-
-def make_auxiliary_test_proposal(reparameterisations, rng):
-    model = MagicMock(spec=Model)
-    model.names = ["a", "b"]
-    model.bounds = {n: [-1.0, 1.0] for n in model.names}
-    model.reparameterisations = None
-
-    proposal = DummyFlowProposal(
-        model,
-        rng=rng,
-        poolsize=10,
-        reparameterisations=reparameterisations,
-        fallback_reparameterisation=None,
-    )
-
-    def get_test_reparameterisation(name):
-        mapping = {
-            "null": (NullReparameterisation, {}),
-            "add-aux": (AddAuxiliaryReparameterisation, {}),
-            "aux-rescale": (RescaleAuxiliaryReparameterisation, {}),
-        }
-        return mapping[name]
-
-    proposal.get_reparameterisation = MagicMock(
-        side_effect=get_test_reparameterisation
-    )
-    proposal.set_rescaling()
-    return proposal
 
 
 def test_default_reparameterisation(proposal):
@@ -187,10 +65,9 @@ def test_get_reparamaterisation(mocked_fn, proposal):
 
 @pytest.mark.parametrize("reverse_order", [False, True])
 @pytest.mark.parametrize("use_default_reparameterisations", [False, True])
-def test_configure_reparameterisations_dict(
+def test_configure_reparameterisations(
     proposal,
     dummy_cmb_rc,
-    dummy_rc,
     reverse_order,
     use_default_reparameterisations,
 ):
@@ -199,289 +76,300 @@ def test_configure_reparameterisations_dict(
     Also tests to make sure boundary inversion is set and if the
     `reverse_reparameterisation` is correctly set.
     """
-    dummy_rc.return_value = "r"
-    # Need to add the parameters before hand to prevent a
-    # NullReparameterisation from being added
-    dummy_cmb_rc.parameters = ["x"]
     proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = MagicMock(
-        return_value=(dummy_rc, {"boundary_inversion": True})
-    )
     proposal.map_to_unit_hypercube = False
     proposal.model = MagicMock()
     proposal.model.bounds = {"x": [-1, 1]}
     proposal.model.names = ["x"]
-    proposal.fallback_reparameterisations = None
+    proposal.fallback_reparameterisation = None
     proposal.reverse_reparameterisations = reverse_order
     proposal.use_default_reparameterisations = use_default_reparameterisations
     proposal.prior_bounds = proposal.model.bounds
 
-    with patch(
-        "nessai.proposal.flowproposal.base.CombinedReparameterisation",
-        return_value=dummy_cmb_rc,
-    ) as mocked_class:
+    dummy_cmb_rc.parameters = ["x"]
+    reparams = [MagicMock()]
+    proposal.instantiate_reparameterisation_from_spec = MagicMock(
+        side_effect=reparams
+    )
+    specs = [MagicMock()]
+    proposal._set_parameter_order = MagicMock()
+
+    reparameterisations = {"x": {"reparameterisation": "default"}}
+
+    with (
+        patch(
+            "nessai.proposal.flowproposal.base.CombinedReparameterisation",
+            return_value=dummy_cmb_rc,
+        ) as mocked_class,
+        patch(
+            "nessai.proposal.flowproposal.base.parse_reparameterisations",
+            return_value=specs,
+        ) as mocked_parse,
+    ):
         BaseFlowProposal.configure_reparameterisations(
-            proposal, {"x": {"reparameterisation": "default"}}
+            proposal, reparameterisations
         )
 
-    proposal.get_reparameterisation.assert_called_once_with("default")
+    mocked_parse.assert_called_once_with(
+        reparameterisations,
+        model_names=proposal.model.names,
+        class_name=proposal.__class__.__name__,
+    )
+
+    proposal.instantiate_reparameterisation_from_spec.assert_has_calls(
+        [call(spec) for spec in specs]
+    )
+    proposal._reparameterisation.add_reparameterisations.assert_has_calls(
+        [call(r) for r in reparams]
+    )
 
     if use_default_reparameterisations:
         proposal.add_default_reparameterisations.assert_called_once()
     else:
         proposal.add_default_reparameterisations.assert_not_called()
 
-    dummy_rc.assert_called_once_with(
-        prior_bounds={"x": [-1, 1]}, parameters="x", boundary_inversion=True
-    )
+    # other_params should be empty
+    proposal.get_reparameterisation.assert_not_called()
+
     mocked_class.assert_called_once_with(
         reverse_order=reverse_order, initial_parameters=["x"]
     )
-    # fmt: off
-    proposal._reparameterisation.add_reparameterisations \
-        .assert_called_once_with("r")
-    # fmt: on
 
-    assert proposal.boundary_inversion is True
-    assert proposal.parameters == ["x"]
+    proposal._set_parameter_order.assert_called_once()
 
 
-@patch("nessai.proposal.flowproposal.base.CombinedReparameterisation")
-@pytest.mark.parametrize("parameters_value", ["y", ["y"], ("y",)])
-def test_configure_reparameterisations_dict_w_params(
-    mocked_class, proposal, dummy_rc, dummy_cmb_rc, parameters_value
-):
-    """Test configuration for reparameterisations dictionary with parameters.
-
-    For example:
-
-        {'x': {'reparmeterisation': 'default', 'parameters': 'y'}}
-
-    This should add both x and y to the reparameterisation.
-    """
-    dummy_rc.return_value = "r"
-    # Need to add the parameters before hand to prevent a
-    # NullReparameterisation from being added
-    dummy_cmb_rc.parameters = ["x", "y"]
-    proposal.add_default_reparameterisations = MagicMock()
+def test_get_reparameterisation_from_spec_model_key(proposal, dummy_rc):
+    """Assert parameter-key specs are converted into a config."""
     proposal.get_reparameterisation = MagicMock(
-        return_value=(
-            dummy_rc,
-            {},
-        )
+        return_value=(dummy_rc, {"offset": 1.0})
     )
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.map_to_unit_hypercube = False
-    proposal.prior_bounds = proposal.model.bounds
-
-    with patch(
-        "nessai.proposal.flowproposal.base.CombinedReparameterisation",
-        return_value=dummy_cmb_rc,
-    ) as mocked_class:
-        BaseFlowProposal.configure_reparameterisations(
-            proposal,
-            {
-                "x": {
-                    "reparameterisation": "default",
-                    "parameters": parameters_value,
-                }
-            },
-        )
-
-    proposal.get_reparameterisation.assert_called_once_with("default")
-    proposal.add_default_reparameterisations.assert_not_called()
-    dummy_rc.assert_called_once_with(
-        prior_bounds={"x": [-1, 1], "y": [-1, 1]},
+    spec = ReparameterisationSpec(
+        source_key="x",
+        spec_index=0,
+        reparameterisation="default",
+        source_is_parameter=True,
         parameters=["x", "y"],
-    )
-    mocked_class.assert_called_once_with(
-        reverse_order=False, initial_parameters=["x", "y"]
-    )
-    # fmt: off
-    proposal._reparameterisation.add_reparameterisations \
-        .assert_called_once_with("r")
-    # fmt: on
-
-    assert proposal.parameters == ["x", "y"]
-
-
-@patch("nessai.reparameterisations.CombinedReparameterisation")
-def test_configure_reparameterisations_dict_missing(mocked_class, proposal):
-    """
-    Test configuration for reparameterisations dictionary when missing
-    the reparameterisation for a parameter.
-
-    This should raise a runtime error.
-    """
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-
-    with pytest.raises(RuntimeError) as excinfo:
-        BaseFlowProposal.configure_reparameterisations(
-            proposal, {"x": {"scale": 1.0}}
-        )
-
-    assert "No reparameterisation found for x" in str(excinfo.value)
-
-
-def test_configure_reparameterisations_dict_str(proposal):
-    """Test configuration for reparameterisations dictionary from a str"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(proposal, {"x": "default"})
-
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_prime", "y"]
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == ["x_prime", "y"]
-
-
-def test_configure_reparameterisations_dict_reparam(proposal):
-    """Test configuration for reparameterisations dictionary"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(
-        proposal, {"default": {"parameters": ["x"]}}
+        kwargs={"scale": 2.0},
     )
 
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_prime", "y"]
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == ["x_prime", "y"]
-
-
-def test_configure_reparameterisations_dict_reparam_list(proposal):
-    """Test configuration for reparameterisations dictionary"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(
-        proposal, {"default": ["x", "y"]}
+    rc, config = BaseFlowProposal.get_reparameterisation_from_spec(
+        proposal, spec
     )
 
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_prime", "y_prime"]
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == [
-        "x_prime",
-        "y_prime",
-    ]
+    assert rc is dummy_rc
+    assert config == {
+        "offset": 1.0,
+        "parameters": ["x", "y"],
+        "scale": 2.0,
+    }
+    proposal.get_reparameterisation.assert_called_once_with("default")
 
 
 @pytest.mark.parametrize(
     "parameters",
     [
         "x.*",
-        [
-            "x.*",
-        ],
+        ["x.*"],
         ("x.*",),
     ],
 )
-def test_configure_reparameterisations_regex(proposal, parameters):
-    """Test configuration for reparameterisations dictionary"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
+def test_get_reparameterisation_from_spec_resolves_patterns(
+    proposal, dummy_rc, parameters
+):
+    """Assert non-parameter specs resolve regex patterns."""
+    proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
     proposal.model.names = ["x_0", "x_1", "y"]
-    proposal.model.bounds = {"x_0": [-1, 1], "x_1": [-1, 1], "y": [-1, 1]}
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(
-        proposal,
-        {"z-score": {"parameters": parameters}},
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.parameters = ["x_0", "x_1", "y"]
+    spec = ReparameterisationSpec(
+        source_key="z-score",
+        spec_index=0,
+        reparameterisation="z-score",
+        source_is_parameter=False,
+        parameters=parameters,
+        kwargs={},
     )
 
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_0_prime", "x_1_prime", "y"]
-    assert proposal._reparameterisation.parameters == ["x_0", "x_1", "y"]
-    assert proposal._reparameterisation.prime_parameters == [
-        "x_0_prime",
-        "x_1_prime",
-        "y",
-    ]
-
-
-def test_configure_reparameterisations_none(proposal):
-    """Test configuration when input is None"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(proposal, None)
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x", "y"]
-
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == ["x", "y"]
-    assert all(
-        [
-            isinstance(r, NullReparameterisation)
-            for r in proposal._reparameterisation.reparameterisations.values()
-        ]
+    rc, config = BaseFlowProposal.get_reparameterisation_from_spec(
+        proposal, spec
     )
 
+    assert rc is dummy_rc
+    assert config == {"parameters": ["x_0", "x_1"]}
 
-def test_configure_reparameterisations_string(proposal):
-    """Test configuration when input is a string"""
-    proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
-    proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
-    proposal.model.names = ["x", "y"]
-    proposal.fallback_reparameterisation = None
-    BaseFlowProposal.configure_reparameterisations(proposal, "rescaletobounds")
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_prime", "y_prime"]
 
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == [
-        "x_prime",
-        "y_prime",
-    ]
-    assert all(
-        [
-            isinstance(r, RescaleToBounds)
-            for r in proposal._reparameterisation.reparameterisations.values()
-        ]
+@pytest.mark.parametrize(
+    "spec",
+    [
+        ReparameterisationSpec(
+            source_key="x",
+            spec_index=0,
+            reparameterisation="sine",
+            source_is_parameter=True,
+            parameters=["x"],
+            kwargs={},
+        ),
+        ReparameterisationSpec(
+            source_key="sine",
+            spec_index=0,
+            reparameterisation="sine",
+            source_is_parameter=False,
+            parameters=["x"],
+            kwargs={},
+        ),
+    ],
+)
+def test_get_reparameterisation_from_spec_unknown(proposal, spec):
+    """Assert unknown reparameterisations raise a runtime error."""
+    proposal.get_reparameterisation = MagicMock(side_effect=ValueError)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        BaseFlowProposal.get_reparameterisation_from_spec(proposal, spec)
+
+    assert "is not a parameter in the model or a known" in str(excinfo.value)
+
+
+def test_get_reparameterisation_from_spec_no_parameters(proposal, dummy_rc):
+    """Assert an error is raised if the resolved config has no parameters."""
+    proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
+    proposal.model.names = ["x"]
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.parameters = ["x"]
+    spec = ReparameterisationSpec(
+        source_key="default",
+        spec_index=0,
+        reparameterisation="default",
+        source_is_parameter=False,
+        parameters=None,
+        kwargs={"update_bounds": True},
     )
 
+    with pytest.raises(RuntimeError) as excinfo:
+        BaseFlowProposal.get_reparameterisation_from_spec(proposal, spec)
 
-def test_configure_reparameterisations_fallback(proposal):
-    """Test configuration when input is None"""
+    assert "No parameters key" in str(excinfo.value)
+
+
+def test_get_reparameterisation_from_spec_allows_prime_requires(
+    proposal, dummy_rc
+):
+    """Assert prime-only chained specs do not require x-space parameters."""
+    proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
+    proposal.model.names = ["x"]
+    proposal._reparameterisation = MagicMock()
+    proposal._reparameterisation.parameters = ["x"]
+    spec = ReparameterisationSpec(
+        source_key="prime-scale",
+        spec_index=1,
+        reparameterisation="prime-scale",
+        source_is_parameter=False,
+        parameters=[],
+        kwargs={
+            "prime_requires": ["x_bounded"],
+            "prime_parameters": ["x_scaled"],
+        },
+    )
+
+    rc, config = BaseFlowProposal.get_reparameterisation_from_spec(
+        proposal, spec
+    )
+
+    assert rc is dummy_rc
+    assert config == {
+        "parameters": [],
+        "prime_parameters": ["x_scaled"],
+        "prime_requires": ["x_bounded"],
+    }
+
+
+def test_instantiate_reparameterisation_from_spec_with_rng(proposal, rng):
+    """Test that the rng is passed through when supported by the class."""
+    spec = Mock()
+    proposal.rng = rng
+    proposal.get_reparameterisation_from_spec = MagicMock(
+        return_value=(Reparameterisation, {"parameters": ["x"]})
+    )
+    proposal._get_prior_bounds_for_parameters = MagicMock(
+        return_value={"x": [-1, 1]}
+    )
+
+    with patch("numpy.random.default_rng") as mocked_rng:
+        reparameterisation = (
+            BaseFlowProposal.instantiate_reparameterisation_from_spec(
+                proposal, spec
+            )
+        )
+
+    mocked_rng.assert_not_called()
+    proposal.get_reparameterisation_from_spec.assert_called_once_with(spec)
+    proposal._get_prior_bounds_for_parameters.assert_called_once_with(["x"])
+    assert reparameterisation.rng is rng
+
+
+def test_configure_reparameterisations_dict_missing(proposal, dummy_cmb_rc):
+    """Assert parser errors propagate out of configure."""
+    proposal.model.names = ["x", "y"]
+    proposal._set_parameter_order = MagicMock()
+
+    with (
+        patch(
+            "nessai.proposal.flowproposal.base.CombinedReparameterisation",
+            return_value=dummy_cmb_rc,
+        ),
+        patch(
+            "nessai.proposal.flowproposal.base.parse_reparameterisations",
+            side_effect=RuntimeError("No reparameterisation found for x"),
+        ),
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            BaseFlowProposal.configure_reparameterisations(
+                proposal, {"x": {"scale": 1.0}}
+            )
+
+    assert "No reparameterisation found for x" in str(excinfo.value)
+
+
+def test_configure_reparameterisations_fallback(
+    proposal, dummy_rc, dummy_cmb_rc
+):
+    """Assert the fallback reparameterisation is added for unclaimed parameters."""
+    dummy_rc.return_value = "r"
     proposal.add_default_reparameterisations = MagicMock()
-    proposal.get_reparameterisation = get_reparameterisation
+    proposal.get_reparameterisation = MagicMock(return_value=(dummy_rc, {}))
+    proposal.instantiate_reparameterisation_from_spec = MagicMock()
+    proposal._set_parameter_order = MagicMock()
     proposal.model.bounds = {"x": [-1, 1], "y": [-1, 1]}
     proposal.model.names = ["x", "y"]
+    proposal.prior_bounds = proposal.model.bounds
     proposal.fallback_reparameterisation = "default"
-    BaseFlowProposal.configure_reparameterisations(proposal, None)
-    proposal.add_default_reparameterisations.assert_not_called()
-    assert proposal.prime_parameters == ["x_prime", "y_prime"]
 
-    assert proposal._reparameterisation.parameters == ["x", "y"]
-    assert proposal._reparameterisation.prime_parameters == [
-        "x_prime",
-        "y_prime",
-    ]
-    assert all(
-        [
-            isinstance(r, RescaleToBounds)
-            for r in proposal._reparameterisation.reparameterisations.values()
-        ]
+    with (
+        patch(
+            "nessai.proposal.flowproposal.base.CombinedReparameterisation",
+            return_value=dummy_cmb_rc,
+        ),
+        patch(
+            "nessai.proposal.flowproposal.base.parse_reparameterisations",
+            return_value=[],
+        ),
+    ):
+        BaseFlowProposal.configure_reparameterisations(proposal, None)
+
+    proposal.add_default_reparameterisations.assert_not_called()
+    proposal.get_reparameterisation.assert_called_once_with("default")
+    dummy_rc.assert_called_once_with(
+        parameters=["x", "y"],
+        prior_bounds={"x": [-1, 1], "y": [-1, 1]},
     )
+    proposal._reparameterisation.add_reparameterisations.assert_called_once_with(
+        "r"
+    )
+    proposal._set_parameter_order.assert_called_once()
 
 
 def test_configure_reparameterisations_incorrect_type(proposal):
     """Assert an error is raised when input is not a dictionary"""
+    proposal.model.names = []
     with pytest.raises(TypeError) as excinfo:
         BaseFlowProposal.configure_reparameterisations(proposal, ["default"])
     assert "must be a dictionary" in str(excinfo.value)
@@ -493,59 +381,8 @@ def test_configure_reparameterisations_incorrect_config_type(proposal):
     """
     proposal.model.names = ["x"]
     with pytest.raises(TypeError) as excinfo:
-        BaseFlowProposal.configure_reparameterisations(proposal, {"x": ["a"]})
+        BaseFlowProposal.configure_reparameterisations(proposal, {"x": [1]})
     assert "Unknown config type" in str(excinfo.value)
-
-
-@pytest.mark.parametrize(
-    "reparam",
-    [{"z": {"reparameterisation": "sine"}}, {"sine": {"parameters": ["x"]}}],
-)
-def test_configure_reparameterisation_unknown(proposal, reparam):
-    """
-    Assert an error is raised if an unknown reparameterisation or parameters
-    is passed.
-    """
-    proposal.model.names = ["x"]
-    with pytest.raises(RuntimeError) as excinfo:
-        BaseFlowProposal.configure_reparameterisations(proposal, reparam)
-    assert "is not a parameter in the model or a known" in str(excinfo.value)
-
-
-def test_configure_reparameterisation_no_parameters(proposal, dummy_rc):
-    """Assert an error is raised if no parameters are specified"""
-    proposal.model.names = ["x"]
-    proposal.get_reparameterisation = MagicMock(
-        return_value=(
-            dummy_rc,
-            {},
-        )
-    )
-    with pytest.raises(RuntimeError) as excinfo:
-        BaseFlowProposal.configure_reparameterisations(
-            proposal, {"default": {"update_bounds": True}}
-        )
-    assert "No parameters key" in str(excinfo.value)
-
-
-def test_configure_reparameterisation_with_rng(proposal, rng):
-    """Test that the rng is correctly passed to the reparameterisation if it is
-    in the signature."""
-    proposal.model.names = ["x"]
-    proposal.model.bounds = {"x": [-1, 1]}
-    proposal.get_reparameterisation = MagicMock(
-        return_value=(
-            Reparameterisation,
-            {},
-        )
-    )
-    proposal.rng = rng
-    with patch("numpy.random.default_rng") as mocked_rng:
-        BaseFlowProposal.configure_reparameterisations(
-            proposal, {"default": {"parameters": ["x"]}}
-        )
-    mocked_rng.assert_not_called()
-    assert proposal._reparameterisation["reparameterisation_x"].rng is rng
 
 
 def test_set_parameter_order(proposal):
@@ -567,12 +404,8 @@ def test_set_parameter_order(proposal):
             prime_parameters=["w_prime"],
         ),
     ]
-    proposal._set_parameter_order()
-    # Parameter order will be model + others in order returned by the
-    # reparameterisation
-    assert proposal.parameters == ["x", "y", "w", "z"]
-    # Model parameters, additional parameters from reparams with model
-    # parameters, then any remaining parameters from reparams in order
+    BaseFlowProposal._set_parameter_order(proposal)
+    assert proposal.parameters == ["x", "y", "z"]
     assert proposal.prime_parameters == [
         "x_prime",
         "z_prime",
@@ -629,48 +462,6 @@ def test_set_rescaling_with_reparameterisations(proposal, model):
     )
     assert proposal.reparameterisations == {"x": "default"}
     assert proposal.prime_parameters == ["x_prime"]
-
-
-def test_configure_reparameterisations_with_auxiliary_parameter(rng):
-    proposal = make_auxiliary_test_proposal(
-        {
-            "a": {
-                "reparameterisation": "add-aux",
-                "auxiliary_parameter": "aux",
-            },
-            "aux-rescale": {"parameters": ["aux"], "scale": 10.0},
-            "b": "null",
-        },
-        rng=rng,
-    )
-
-    assert proposal.parameters == ["a", "b", "aux"]
-    assert proposal.prime_parameters == ["a_prime", "b", "aux_prime"]
-
-    x = numpy_array_to_live_points(
-        np.array([[1.0, 2.0], [10.0, 20.0]]),
-        ["a", "b"],
-    )
-
-    x_prime, log_j = proposal.rescale(x)
-    x_out, log_j_inv = proposal.inverse_rescale(x_prime)
-
-    expected_prime = np.array([[1.0, 2.0, 0.2], [10.0, 20.0, 2.0]])
-    expected_x = np.array([[1.0, 2.0, 2.0], [10.0, 20.0, 20.0]])
-    expected_log_j = -np.log(10.0) * np.ones(x.shape[0])
-
-    np.testing.assert_array_equal(
-        live_points_to_array(
-            x_prime, names=proposal.prime_parameters, copy=True
-        ),
-        expected_prime,
-    )
-    np.testing.assert_array_equal(
-        live_points_to_array(x_out, names=proposal.parameters, copy=True),
-        expected_x,
-    )
-    np.testing.assert_allclose(log_j, expected_log_j)
-    np.testing.assert_allclose(log_j_inv, -expected_log_j)
 
 
 @pytest.mark.parametrize("n", [1, 10])
@@ -923,150 +714,3 @@ def test_check_state_update(proposal, map_to_unit_hypercube):
         proposal._reparameterisation.update.assert_called_once_with(x_hyper)
     else:
         proposal._reparameterisation.update.assert_called_once_with(x)
-
-
-def test_multi_parameter_reparameterisation_ordering(rng):
-    """Parameter-key grouping should preserve model-order parameters."""
-    grouped = make_test_proposal(
-        {
-            "a": {"reparameterisation": "null", "parameters": ["d"]},
-            "b": "null",
-            "c": "null",
-        },
-        rng=rng,
-    )
-
-    assert grouped.parameters == ["a", "b", "c", "d"]
-    assert grouped.prime_parameters == ["a", "b", "c", "d"]
-
-
-@pytest.mark.integration_test
-def test_multi_parameter_reparameterisation_flow_input_order(rng):
-    baseline = make_test_proposal(
-        {"a": "null", "b": "null", "c": "null", "d": "null"},
-        rng=rng,
-    )
-    grouped = make_test_proposal(
-        {
-            "a": {"reparameterisation": "null", "parameters": ["d"]},
-            "b": "null",
-            "c": "null",
-        },
-        rng=rng,
-    )
-    x = numpy_array_to_live_points(
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-        ["a", "b", "c", "d"],
-    )
-
-    x_prime_baseline, _ = baseline.rescale(x)
-    x_prime_grouped, _ = grouped.rescale(x)
-
-    np.testing.assert_array_equal(
-        live_points_to_array(
-            x_prime_baseline, names=baseline.prime_parameters, copy=True
-        ),
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-    )
-    np.testing.assert_array_equal(
-        live_points_to_array(
-            x_prime_grouped, names=grouped.prime_parameters, copy=True
-        ),
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-    )
-
-    baseline.flow = MagicMock()
-    baseline.flow.forward_and_log_prob = MagicMock(
-        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
-    )
-    grouped.flow = MagicMock()
-    grouped.flow.forward_and_log_prob = MagicMock(
-        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
-    )
-
-    baseline.forward_pass(x)
-    grouped.forward_pass(x)
-
-    np.testing.assert_array_equal(
-        baseline.flow.forward_and_log_prob.call_args[0][0],
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-    )
-    np.testing.assert_array_equal(
-        grouped.flow.forward_and_log_prob.call_args[0][0],
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-    )
-
-
-@pytest.mark.integration_test
-def test_multi_parameter_reparameterisation_ordering_integration(rng):
-    """Grouped scaling should affect only `a` and `d` in stable order."""
-    baseline = make_test_proposal(
-        {
-            "a": {"reparameterisation": "rescale", "scale": 2.0},
-            "b": "null",
-            "c": "null",
-            "d": {"reparameterisation": "rescale", "scale": 10.0},
-        },
-        rng=rng,
-    )
-    grouped = make_test_proposal(
-        {
-            "rescale": {
-                "parameters": ["a", "d"],
-                "scale": {"a": 2.0, "d": 10.0},
-            },
-            "b": "null",
-            "c": "null",
-        },
-        rng=rng,
-    )
-    x = numpy_array_to_live_points(
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
-        ["a", "b", "c", "d"],
-    )
-
-    x_prime_baseline, log_j_baseline = baseline.rescale(x)
-    x_prime_grouped, log_j_grouped = grouped.rescale(x)
-    x_out_grouped, log_j_inv_grouped = grouped.inverse_rescale(x_prime_grouped)
-
-    expected = np.array([[0.5, 2.0, 3.0, 0.4], [5.0, 20.0, 30.0, 4.0]])
-    expected_log_j = -np.log(20.0) * np.ones(x.shape[0])
-
-    np.testing.assert_array_equal(
-        live_points_to_array(
-            x_prime_baseline, names=baseline.prime_parameters, copy=True
-        ),
-        expected,
-    )
-    np.testing.assert_array_equal(
-        live_points_to_array(
-            x_prime_grouped, names=grouped.prime_parameters, copy=True
-        ),
-        expected,
-    )
-    np.testing.assert_allclose(log_j_baseline, expected_log_j)
-    np.testing.assert_allclose(log_j_grouped, expected_log_j)
-    np.testing.assert_array_equal(
-        live_points_to_array(x_out_grouped, names=grouped.model.names),
-        live_points_to_array(x, names=grouped.model.names),
-    )
-    np.testing.assert_allclose(log_j_inv_grouped, -expected_log_j)
-
-    baseline.flow = MagicMock()
-    baseline.flow.forward_and_log_prob = MagicMock(
-        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
-    )
-    grouped.flow = MagicMock()
-    grouped.flow.forward_and_log_prob = MagicMock(
-        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
-    )
-
-    baseline.forward_pass(x)
-    grouped.forward_pass(x)
-
-    np.testing.assert_array_equal(
-        baseline.flow.forward_and_log_prob.call_args[0][0], expected
-    )
-    np.testing.assert_array_equal(
-        grouped.flow.forward_and_log_prob.call_args[0][0], expected
-    )

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -32,6 +32,16 @@ def proposal(proposal):
             proposal, BaseFlowProposal
         )
     )
+    proposal._resolve_reparameterisation_parameters = (
+        BaseFlowProposal._resolve_reparameterisation_parameters.__get__(
+            proposal, BaseFlowProposal
+        )
+    )
+    proposal._get_prior_bounds_for_parameters = (
+        BaseFlowProposal._get_prior_bounds_for_parameters.__get__(
+            proposal, BaseFlowProposal
+        )
+    )
     return proposal
 
 
@@ -58,6 +68,59 @@ class DummyFlowProposal(BaseFlowProposal):
         )
 
 
+class AddAuxiliaryReparameterisation(Reparameterisation):
+    def __init__(
+        self,
+        parameters=None,
+        prior_bounds=None,
+        auxiliary_parameter="aux",
+        rng=None,
+    ):
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
+        self.auxiliary_parameter = auxiliary_parameter
+        self.auxiliary_parameters = [auxiliary_parameter]
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        if self.auxiliary_parameter not in x.dtype.names:
+            x_out = np.empty(
+                x.shape,
+                dtype=x.dtype.descr + [(self.auxiliary_parameter, "f8")],
+            )
+            for name in x.dtype.names:
+                x_out[name] = x[name]
+            x = x_out
+        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
+        x_prime[self.prime_parameters[0]] = x[self.parameters[0]]
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x[self.parameters[0]] = x_prime[self.prime_parameters[0]]
+        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
+        return x, x_prime, log_j
+
+
+class RescaleAuxiliaryReparameterisation(Reparameterisation):
+    def __init__(
+        self, parameters=None, prior_bounds=None, scale=10.0, rng=None
+    ):
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
+        self.scale = scale
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] / self.scale
+        log_j -= np.log(self.scale)
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] * self.scale
+        log_j += np.log(self.scale)
+        return x, x_prime, log_j
+
+
 def make_test_proposal(reparameterisations, rng):
     """Construct a concrete proposal with a toy four-parameter model."""
     model = MagicMock(spec=Model)
@@ -74,6 +137,35 @@ def make_test_proposal(reparameterisations, rng):
     )
     proposal.get_reparameterisation = MagicMock(
         side_effect=get_reparameterisation
+    )
+    proposal.set_rescaling()
+    return proposal
+
+
+def make_auxiliary_test_proposal(reparameterisations, rng):
+    model = MagicMock(spec=Model)
+    model.names = ["a", "b"]
+    model.bounds = {n: [-1.0, 1.0] for n in model.names}
+    model.reparameterisations = None
+
+    proposal = DummyFlowProposal(
+        model,
+        rng=rng,
+        poolsize=10,
+        reparameterisations=reparameterisations,
+        fallback_reparameterisation=None,
+    )
+
+    def get_test_reparameterisation(name):
+        mapping = {
+            "null": (NullReparameterisation, {}),
+            "add-aux": (AddAuxiliaryReparameterisation, {}),
+            "aux-rescale": (RescaleAuxiliaryReparameterisation, {}),
+        }
+        return mapping[name]
+
+    proposal.get_reparameterisation = MagicMock(
+        side_effect=get_test_reparameterisation
     )
     proposal.set_rescaling()
     return proposal
@@ -142,7 +234,9 @@ def test_configure_reparameterisations_dict(
     dummy_rc.assert_called_once_with(
         prior_bounds={"x": [-1, 1]}, parameters="x", boundary_inversion=True
     )
-    mocked_class.assert_called_once_with(reverse_order=reverse_order)
+    mocked_class.assert_called_once_with(
+        reverse_order=reverse_order, initial_parameters=["x"]
+    )
     # fmt: off
     proposal._reparameterisation.add_reparameterisations \
         .assert_called_once_with("r")
@@ -201,7 +295,9 @@ def test_configure_reparameterisations_dict_w_params(
         prior_bounds={"x": [-1, 1], "y": [-1, 1]},
         parameters=["x", "y"],
     )
-    mocked_class.assert_called_once()
+    mocked_class.assert_called_once_with(
+        reverse_order=False, initial_parameters=["x", "y"]
+    )
     # fmt: off
     proposal._reparameterisation.add_reparameterisations \
         .assert_called_once_with("r")
@@ -533,6 +629,48 @@ def test_set_rescaling_with_reparameterisations(proposal, model):
     )
     assert proposal.reparameterisations == {"x": "default"}
     assert proposal.prime_parameters == ["x_prime"]
+
+
+def test_configure_reparameterisations_with_auxiliary_parameter(rng):
+    proposal = make_auxiliary_test_proposal(
+        {
+            "a": {
+                "reparameterisation": "add-aux",
+                "auxiliary_parameter": "aux",
+            },
+            "aux-rescale": {"parameters": ["aux"], "scale": 10.0},
+            "b": "null",
+        },
+        rng=rng,
+    )
+
+    assert proposal.parameters == ["a", "b", "aux"]
+    assert proposal.prime_parameters == ["a_prime", "b", "aux_prime"]
+
+    x = numpy_array_to_live_points(
+        np.array([[1.0, 2.0], [10.0, 20.0]]),
+        ["a", "b"],
+    )
+
+    x_prime, log_j = proposal.rescale(x)
+    x_out, log_j_inv = proposal.inverse_rescale(x_prime)
+
+    expected_prime = np.array([[1.0, 2.0, 0.2], [10.0, 20.0, 2.0]])
+    expected_x = np.array([[1.0, 2.0, 2.0], [10.0, 20.0, 20.0]])
+    expected_log_j = -np.log(10.0) * np.ones(x.shape[0])
+
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime, names=proposal.prime_parameters, copy=True
+        ),
+        expected_prime,
+    )
+    np.testing.assert_array_equal(
+        live_points_to_array(x_out, names=proposal.parameters, copy=True),
+        expected_x,
+    )
+    np.testing.assert_allclose(log_j, expected_log_j)
+    np.testing.assert_allclose(log_j_inv, -expected_log_j)
 
 
 @pytest.mark.parametrize("n", [1, 10])

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -405,7 +405,7 @@ def test_set_parameter_order(proposal):
         ),
     ]
     BaseFlowProposal._set_parameter_order(proposal)
-    assert proposal.parameters == ["x", "y", "z"]
+    assert proposal.parameters == ["x", "y", "w", "z"]
     assert proposal.prime_parameters == [
         "x_prime",
         "z_prime",

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -559,6 +559,29 @@ def test_set_rescaling_with_reparameterisations(proposal, model):
     assert proposal.prime_parameters == ["x_prime"]
 
 
+def test_set_rescaling_logs_intermediate_prime_parameters(
+    proposal, model, caplog
+):
+    proposal.model = model
+    proposal.model.reparameterisations = None
+    proposal.reparameterisations = {"x": "default"}
+    proposal.expansion_fraction = None
+
+    def update(self):
+        proposal.parameters = model.names
+        proposal.prime_parameters = ["x_prime"]
+        proposal._prime_parameters_internal = ["x_prime", "x_aux"]
+
+    proposal.configure_reparameterisations = MagicMock()
+    proposal.configure_reparameterisations.side_effect = update
+
+    with caplog.at_level("INFO"):
+        BaseFlowProposal.set_rescaling(proposal)
+
+    assert proposal.rescaling_set is True
+    assert "Intermediate parameters: ['x_aux']" in caplog.text
+
+
 @pytest.mark.parametrize("n", [1, 10])
 def test_rescale(proposal, n, map_to_unit_hypercube):
     """Test rescaling when using reparameterisation dict"""

--- a/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_reparameterisations.py
@@ -177,20 +177,6 @@ def test_get_prior_bounds_for_parameters_allows_missing_auxiliary(proposal):
     assert out == {"x": [-1, 1]}
 
 
-def test_get_prior_bounds_for_parameters_require_all_uses_model_bounds(
-    proposal,
-):
-    """Assert full model bounds are used when all parameters are required."""
-    proposal.prior_bounds = {"x": [-1, 1]}
-    proposal.model.bounds = {"x": [-10, 10], "y": [0, 1]}
-
-    out = BaseFlowProposal._get_prior_bounds_for_parameters(
-        proposal, ["x", "y"], require_all=True
-    )
-
-    assert out == {"x": [-10, 10], "y": [0, 1]}
-
-
 def test_get_prior_bounds_for_parameters_single_parameter(proposal):
     proposal.prior_bounds = {"x": [-1, 1]}
     proposal.model.bounds = {"x": [-10, 10]}
@@ -422,7 +408,7 @@ def test_configure_reparameterisations_fallback(
     proposal.add_default_reparameterisations.assert_not_called()
     proposal.get_reparameterisation.assert_called_once_with("default")
     proposal._get_prior_bounds_for_parameters.assert_called_once_with(
-        ["x", "y"], require_all=True
+        ["x", "y"],
     )
     dummy_rc.assert_called_once_with(
         parameters=["x", "y"],

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
@@ -130,3 +130,42 @@ def test_backward_pass_with_internal_prime_parameters(
 
     assert len(out[0]) == len(log_p)
     proposal.inverse_rescale.assert_called_once()
+
+
+def test_backward_pass_with_1d_flow_output(
+    proposal, model, map_to_unit_hypercube
+):
+    """Assert 1D flow outputs are promoted to a single-sample batch."""
+    x = np.array([1.0, 2.0])
+    log_p = np.array([0.0])
+    z = np.random.randn(1, model.dims)
+
+    def inverse_rescale(a, return_unit_hypercube):
+        assert a.size == 1
+        np.testing.assert_allclose(a["x"], [1.0])
+        np.testing.assert_allclose(a["y"], [2.0])
+        return a, np.zeros(a.size)
+
+    proposal.inverse_rescale = MagicMock(side_effect=inverse_rescale)
+    proposal.prime_parameters = model.names
+    proposal._prime_parameters_internal = proposal.prime_parameters
+    proposal.x_prime_internal_dtype = get_dtype(
+        proposal._prime_parameters_internal
+    )
+    proposal.alt_dist = None
+    proposal.check_prior_bounds = MagicMock(
+        side_effect=lambda a, b, c: (a, b, c)
+    )
+    proposal.flow = MagicMock()
+    proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
+
+    out = FlowProposal.backward_pass(
+        proposal,
+        z,
+        discard_nans=False,
+        return_unit_hypercube=map_to_unit_hypercube,
+    )
+
+    assert len(out[0]) == 1
+    assert len(out[1]) == 1
+    proposal.inverse_rescale.assert_called_once()

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from nessai.livepoint import get_dtype
 from nessai.proposal import FlowProposal
 
 
@@ -35,6 +36,10 @@ def test_backward_pass(
 
     proposal.inverse_rescale = MagicMock(side_effect=inverse_rescale)
     proposal.prime_parameters = model.names
+    proposal._prime_parameters_internal = proposal.prime_parameters
+    proposal.x_prime_internal_dtype = get_dtype(
+        proposal._prime_parameters_internal
+    )
     proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
@@ -88,3 +93,40 @@ def test_backwards_pass_assertion_error(proposal, caplog, return_z):
     else:
         assert len(out) == 2
     assert "Domain" in caplog.text
+
+
+def test_backward_pass_with_internal_prime_parameters(
+    proposal, model, map_to_unit_hypercube
+):
+    """Assert hidden prime parameters are retained for inverse rescaling."""
+    x = np.array([[1.0, 2.0], [3.0, 4.0]])
+    log_p = np.ones(2)
+    z = np.random.randn(2, model.dims)
+
+    def inverse_rescale(a, return_unit_hypercube):
+        assert a.dtype.names[:3] == ("x_prime", "y_01", "y_prime")
+        np.testing.assert_allclose(a["x_prime"], x[:, 0])
+        np.testing.assert_allclose(a["y_prime"], x[:, 1])
+        return a, np.zeros(a.size)
+
+    proposal.inverse_rescale = MagicMock(side_effect=inverse_rescale)
+    proposal.prime_parameters = ["x_prime", "y_prime"]
+    proposal._prime_parameters_internal = ["x_prime", "y_01", "y_prime"]
+    proposal.x_prime_internal_dtype = get_dtype(
+        proposal._prime_parameters_internal
+    )
+    proposal.alt_dist = None
+    proposal.check_prior_bounds = MagicMock(
+        side_effect=lambda a, b, c: (a, b, c)
+    )
+    proposal.flow = MagicMock()
+    proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
+
+    out = FlowProposal.backward_pass(
+        proposal,
+        z,
+        return_unit_hypercube=map_to_unit_hypercube,
+    )
+
+    assert len(out[0]) == len(log_p)
+    proposal.inverse_rescale.assert_called_once()

--- a/tests/test_proposal/test_flowproposal/test_reparam_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_reparam_integration.py
@@ -8,9 +8,16 @@ from unittest.mock import MagicMock, create_autospec
 import numpy as np
 import pytest
 
+from nessai.livepoint import live_points_to_array, numpy_array_to_live_points
 from nessai.model import Model
 from nessai.proposal.flowproposal import FlowProposal
-from nessai.reparameterisations import default_reparameterisations
+from nessai.proposal.flowproposal.base import BaseFlowProposal
+from nessai.reparameterisations import (
+    NullReparameterisation,
+    Reparameterisation,
+    default_reparameterisations,
+    get_reparameterisation,
+)
 
 # General reparameterisations that do not need extra parameters
 general_reparameterisations = {
@@ -18,6 +25,167 @@ general_reparameterisations = {
     for k, v in default_reparameterisations.items()
     if k not in ["scale", "rescale", "angle-pair", "scaleandshift"]
 }
+
+
+class DummyFlowProposal(BaseFlowProposal):
+    def populate(self, worst_point, n_samples=10000):
+        raise NotImplementedError
+
+
+class AddAuxiliaryReparameterisation(Reparameterisation):
+    def __init__(
+        self,
+        parameters=None,
+        prior_bounds=None,
+        auxiliary_parameter="aux",
+        rng=None,
+    ):
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
+        self.auxiliary_parameter = auxiliary_parameter
+        self.auxiliary_parameters = [auxiliary_parameter]
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        if self.auxiliary_parameter not in x.dtype.names:
+            x_out = np.empty(
+                x.shape,
+                dtype=x.dtype.descr + [(self.auxiliary_parameter, "f8")],
+            )
+            for name in x.dtype.names:
+                x_out[name] = x[name]
+            x = x_out
+        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
+        x_prime[self.prime_parameters[0]] = x[self.parameters[0]]
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x[self.parameters[0]] = x_prime[self.prime_parameters[0]]
+        x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
+        return x, x_prime, log_j
+
+
+class RescaleAuxiliaryReparameterisation(Reparameterisation):
+    def __init__(
+        self, parameters=None, prior_bounds=None, scale=10.0, rng=None
+    ):
+        super().__init__(
+            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+        )
+        self.scale = scale
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] / self.scale
+        log_j -= np.log(self.scale)
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] * self.scale
+        log_j += np.log(self.scale)
+        return x, x_prime, log_j
+
+
+class PrimeProducerReparameterisation(Reparameterisation):
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] + 1.0
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] - 1.0
+        return x, x_prime, log_j
+
+
+class PrimeScaleReparameterisation(Reparameterisation):
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime[self.prime_parameters[0]] = (
+            2.0 * x_prime[self.prime_requires[0]]
+        )
+        log_j -= np.log(2.0)
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime[self.prime_requires[0]] = (
+            x_prime[self.prime_parameters[0]] / 2.0
+        )
+        log_j += np.log(2.0)
+        return x, x_prime, log_j
+
+
+def make_auxiliary_test_proposal(reparameterisations, rng):
+    model = create_autospec(Model)
+    model.names = ["a", "b"]
+    model.bounds = {n: [-1.0, 1.0] for n in model.names}
+    model.reparameterisations = None
+
+    proposal = DummyFlowProposal(
+        model,
+        rng=rng,
+        poolsize=10,
+        reparameterisations=reparameterisations,
+        fallback_reparameterisation=None,
+    )
+
+    def get_test_reparameterisation(name):
+        mapping = {
+            "null": (NullReparameterisation, {}),
+            "add-aux": (AddAuxiliaryReparameterisation, {}),
+            "aux-rescale": (RescaleAuxiliaryReparameterisation, {}),
+        }
+        return mapping[name]
+
+    proposal.get_reparameterisation = MagicMock(
+        side_effect=get_test_reparameterisation
+    )
+    proposal.set_rescaling()
+    return proposal
+
+
+def make_prime_chain_test_proposal(reparameterisations, rng):
+    model = create_autospec(Model)
+    model.names = ["x"]
+    model.bounds = {"x": [-1.0, 1.0]}
+    model.reparameterisations = None
+
+    proposal = DummyFlowProposal(
+        model,
+        rng=rng,
+        poolsize=10,
+        reparameterisations=reparameterisations,
+        fallback_reparameterisation=None,
+    )
+
+    def get_test_reparameterisation(name):
+        mapping = {
+            "prime-producer": (PrimeProducerReparameterisation, {}),
+            "prime-scale": (PrimeScaleReparameterisation, {}),
+        }
+        return mapping[name]
+
+    proposal.get_reparameterisation = MagicMock(
+        side_effect=get_test_reparameterisation
+    )
+    proposal.set_rescaling()
+    return proposal
+
+
+def make_test_proposal(reparameterisations, rng):
+    model = create_autospec(Model)
+    model.names = ["a", "b", "c", "d"]
+    model.bounds = {n: [-1.0, 1.0] for n in model.names}
+    model.reparameterisations = None
+
+    proposal = DummyFlowProposal(
+        model,
+        rng=rng,
+        poolsize=10,
+        reparameterisations=reparameterisations,
+        fallback_reparameterisation=None,
+    )
+    proposal.get_reparameterisation = MagicMock(
+        side_effect=get_reparameterisation
+    )
+    proposal.set_rescaling()
+    return proposal
 
 
 @pytest.fixture(params=general_reparameterisations.keys())
@@ -106,3 +274,239 @@ def test_default_reparameterisations(caplog, tmpdir):
     assert isinstance(reparams[0], ScaleAndShift)
     assert reparams[0].estimate_scale is True
     assert reparams[0].estimate_shift is True
+
+
+@pytest.mark.integration_test
+def test_configure_reparameterisations_with_auxiliary_parameter(rng):
+    proposal = make_auxiliary_test_proposal(
+        {
+            "a": {
+                "reparameterisation": "add-aux",
+                "auxiliary_parameter": "aux",
+            },
+            "aux-rescale": {"parameters": ["aux"], "scale": 10.0},
+            "b": "null",
+        },
+        rng=rng,
+    )
+
+    assert proposal.parameters == ["a", "b", "aux"]
+    assert proposal.prime_parameters == ["a_prime", "b", "aux_prime"]
+
+    x = numpy_array_to_live_points(
+        np.array([[1.0, 2.0], [10.0, 20.0]]),
+        ["a", "b"],
+    )
+
+    x_prime, log_j = proposal.rescale(x)
+    x_out, log_j_inv = proposal.inverse_rescale(x_prime)
+
+    expected_prime = np.array([[1.0, 2.0, 0.2], [10.0, 20.0, 2.0]])
+    expected_x = np.array([[1.0, 2.0, 2.0], [10.0, 20.0, 20.0]])
+    expected_log_j = -np.log(10.0) * np.ones(x.shape[0])
+
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime, names=proposal.prime_parameters, copy=True
+        ),
+        expected_prime,
+    )
+    np.testing.assert_array_equal(
+        live_points_to_array(x_out, names=proposal.parameters, copy=True),
+        expected_x,
+    )
+    np.testing.assert_allclose(log_j, expected_log_j)
+    np.testing.assert_allclose(log_j_inv, -expected_log_j)
+
+
+@pytest.mark.integration_test
+def test_configure_reparameterisations_with_prime_spec_chain(rng):
+    proposal = make_prime_chain_test_proposal(
+        {
+            "x": [
+                {
+                    "reparameterisation": "prime-producer",
+                    "prime_parameters": ["x_bounded"],
+                },
+                {
+                    "reparameterisation": "prime-scale",
+                    "parameters": [],
+                    "prime_requires": ["x_bounded"],
+                    "prime_parameters": ["x_scaled"],
+                },
+            ]
+        },
+        rng=rng,
+    )
+
+    assert proposal.parameters == ["x"]
+    assert proposal.prime_parameters == ["x_bounded", "x_scaled"]
+
+    x = numpy_array_to_live_points(np.array([[1.0], [2.0]]), ["x"])
+
+    x_prime, log_j = proposal.rescale(x)
+    x_out, log_j_inv = proposal.inverse_rescale(x_prime)
+
+    expected_prime = np.array([[2.0, 4.0], [3.0, 6.0]])
+    expected_x = np.array([[1.0], [2.0]])
+
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime, names=proposal.prime_parameters, copy=True
+        ),
+        expected_prime,
+    )
+    np.testing.assert_array_equal(
+        live_points_to_array(x_out, names=proposal.parameters, copy=True),
+        expected_x,
+    )
+    np.testing.assert_allclose(log_j, -np.log(2.0) * np.ones(x.shape[0]))
+    np.testing.assert_allclose(log_j_inv, -log_j)
+
+
+@pytest.mark.integration_test
+def test_multi_parameter_reparameterisation_ordering(rng):
+    """Parameter-key grouping should preserve model-order parameters."""
+    grouped = make_test_proposal(
+        {
+            "a": {"reparameterisation": "null", "parameters": ["d"]},
+            "b": "null",
+            "c": "null",
+        },
+        rng=rng,
+    )
+
+    assert grouped.parameters == ["a", "b", "c", "d"]
+    assert grouped.prime_parameters == ["a", "b", "c", "d"]
+
+
+@pytest.mark.integration_test
+def test_multi_parameter_reparameterisation_flow_input_order(rng):
+    baseline = make_test_proposal(
+        {"a": "null", "b": "null", "c": "null", "d": "null"},
+        rng=rng,
+    )
+    grouped = make_test_proposal(
+        {
+            "a": {"reparameterisation": "null", "parameters": ["d"]},
+            "b": "null",
+            "c": "null",
+        },
+        rng=rng,
+    )
+    x = numpy_array_to_live_points(
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+        ["a", "b", "c", "d"],
+    )
+
+    x_prime_baseline, _ = baseline.rescale(x)
+    x_prime_grouped, _ = grouped.rescale(x)
+
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime_baseline, names=baseline.prime_parameters, copy=True
+        ),
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+    )
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime_grouped, names=grouped.prime_parameters, copy=True
+        ),
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+    )
+
+    baseline.flow = MagicMock()
+    baseline.flow.forward_and_log_prob = MagicMock(
+        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
+    )
+    grouped.flow = MagicMock()
+    grouped.flow.forward_and_log_prob = MagicMock(
+        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
+    )
+
+    baseline.forward_pass(x)
+    grouped.forward_pass(x)
+
+    np.testing.assert_array_equal(
+        baseline.flow.forward_and_log_prob.call_args[0][0],
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+    )
+    np.testing.assert_array_equal(
+        grouped.flow.forward_and_log_prob.call_args[0][0],
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+    )
+
+
+@pytest.mark.integration_test
+def test_multi_parameter_reparameterisation_ordering_integration(rng):
+    """Grouped scaling should affect only `a` and `d` in stable order."""
+    baseline = make_test_proposal(
+        {
+            "a": {"reparameterisation": "rescale", "scale": 2.0},
+            "b": "null",
+            "c": "null",
+            "d": {"reparameterisation": "rescale", "scale": 10.0},
+        },
+        rng=rng,
+    )
+    grouped = make_test_proposal(
+        {
+            "rescale": {
+                "parameters": ["a", "d"],
+                "scale": {"a": 2.0, "d": 10.0},
+            },
+            "b": "null",
+            "c": "null",
+        },
+        rng=rng,
+    )
+    x = numpy_array_to_live_points(
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+        ["a", "b", "c", "d"],
+    )
+
+    x_prime_baseline, log_j_baseline = baseline.rescale(x)
+    x_prime_grouped, log_j_grouped = grouped.rescale(x)
+    x_out_grouped, log_j_inv_grouped = grouped.inverse_rescale(x_prime_grouped)
+
+    expected = np.array([[0.5, 2.0, 3.0, 0.4], [5.0, 20.0, 30.0, 4.0]])
+    expected_log_j = -np.log(20.0) * np.ones(x.shape[0])
+
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime_baseline, names=baseline.prime_parameters, copy=True
+        ),
+        expected,
+    )
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime_grouped, names=grouped.prime_parameters, copy=True
+        ),
+        expected,
+    )
+    np.testing.assert_allclose(log_j_baseline, expected_log_j)
+    np.testing.assert_allclose(log_j_grouped, expected_log_j)
+    np.testing.assert_array_equal(
+        live_points_to_array(x_out_grouped, names=grouped.model.names),
+        live_points_to_array(x, names=grouped.model.names),
+    )
+    np.testing.assert_allclose(log_j_inv_grouped, -expected_log_j)
+
+    baseline.flow = MagicMock()
+    baseline.flow.forward_and_log_prob = MagicMock(
+        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
+    )
+    grouped.flow = MagicMock()
+    grouped.flow.forward_and_log_prob = MagicMock(
+        return_value=(np.zeros((x.size, 4)), np.zeros(x.size))
+    )
+
+    baseline.forward_pass(x)
+    grouped.forward_pass(x)
+
+    np.testing.assert_array_equal(
+        baseline.flow.forward_and_log_prob.call_args[0][0], expected
+    )
+    np.testing.assert_array_equal(
+        grouped.flow.forward_and_log_prob.call_args[0][0], expected
+    )

--- a/tests/test_proposal/test_flowproposal/test_reparam_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_reparam_integration.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, create_autospec
 
 import numpy as np
 import pytest
+from scipy.stats import norm
 
 from nessai.livepoint import live_points_to_array, numpy_array_to_live_points
 from nessai.model import Model
@@ -35,13 +36,17 @@ class DummyFlowProposal(BaseFlowProposal):
 class AddAuxiliaryReparameterisation(Reparameterisation):
     def __init__(
         self,
-        parameters=None,
+        input_parameters=None,
         prior_bounds=None,
         auxiliary_parameter="aux",
         rng=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            input_parameters=input_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            parameters=parameters,
         )
         self.auxiliary_parameter = auxiliary_parameter
         self.auxiliary_parameters = [auxiliary_parameter]
@@ -56,56 +61,64 @@ class AddAuxiliaryReparameterisation(Reparameterisation):
                 x_out[name] = x[name]
             x = x_out
         x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
-        x_prime[self.prime_parameters[0]] = x[self.parameters[0]]
+        x_prime[self.output_parameters[0]] = x[self.parameters[0]]
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x[self.parameters[0]] = x_prime[self.prime_parameters[0]]
+        x[self.parameters[0]] = x_prime[self.output_parameters[0]]
         x[self.auxiliary_parameter] = 2.0 * x[self.parameters[0]]
         return x, x_prime, log_j
 
 
 class RescaleAuxiliaryReparameterisation(Reparameterisation):
     def __init__(
-        self, parameters=None, prior_bounds=None, scale=10.0, rng=None
+        self,
+        input_parameters=None,
+        prior_bounds=None,
+        scale=10.0,
+        rng=None,
+        parameters=None,
     ):
         super().__init__(
-            parameters=parameters, prior_bounds=prior_bounds, rng=rng
+            input_parameters=input_parameters,
+            prior_bounds=prior_bounds,
+            rng=rng,
+            parameters=parameters,
         )
         self.scale = scale
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
-        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] / self.scale
+        x_prime[self.output_parameters[0]] = x[self.parameters[0]] / self.scale
         log_j -= np.log(self.scale)
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] * self.scale
+        x[self.parameters[0]] = x_prime[self.output_parameters[0]] * self.scale
         log_j += np.log(self.scale)
         return x, x_prime, log_j
 
 
 class PrimeProducerReparameterisation(Reparameterisation):
     def reparameterise(self, x, x_prime, log_j, **kwargs):
-        x_prime[self.prime_parameters[0]] = x[self.parameters[0]] + 1.0
+        x_prime[self.output_parameters[0]] = x[self.parameters[0]] + 1.0
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x[self.parameters[0]] = x_prime[self.prime_parameters[0]] - 1.0
+        x[self.parameters[0]] = x_prime[self.output_parameters[0]] - 1.0
         return x, x_prime, log_j
 
 
 class PrimeScaleReparameterisation(Reparameterisation):
     def reparameterise(self, x, x_prime, log_j, **kwargs):
-        x_prime[self.prime_parameters[0]] = (
-            2.0 * x_prime[self.prime_requires[0]]
+        x_prime[self.output_parameters[0]] = (
+            2.0 * x_prime[self.x_prime_input_parameters[0]]
         )
         log_j -= np.log(2.0)
         return x, x_prime, log_j
 
     def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
-        x_prime[self.prime_requires[0]] = (
-            x_prime[self.prime_parameters[0]] / 2.0
+        x_prime[self.x_prime_input_parameters[0]] = (
+            x_prime[self.output_parameters[0]] / 2.0
         )
         log_j += np.log(2.0)
         return x, x_prime, log_j
@@ -244,7 +257,10 @@ def test_configure_reparameterisation_angle_pair(tmpdir, model):
         output=str(tmpdir.mkdir("test")),
         poolsize=10,
         reparameterisations={
-            "x": {"reparameterisation": "angle-pair", "parameters": ["y"]}
+            "x": {
+                "reparameterisation": "angle-pair",
+                "input_parameters": ["x", "y"],
+            }
         },
     )
     proposal.set_rescaling()
@@ -291,7 +307,7 @@ def test_configure_reparameterisations_with_auxiliary_parameter(rng):
     )
 
     assert proposal.parameters == ["a", "b", "aux"]
-    assert proposal.prime_parameters == ["a_prime", "b", "aux_prime"]
+    assert proposal.prime_parameters == ["a_prime", "aux_prime", "b"]
 
     x = numpy_array_to_live_points(
         np.array([[1.0, 2.0], [10.0, 20.0]]),
@@ -301,7 +317,7 @@ def test_configure_reparameterisations_with_auxiliary_parameter(rng):
     x_prime, log_j = proposal.rescale(x)
     x_out, log_j_inv = proposal.inverse_rescale(x_prime)
 
-    expected_prime = np.array([[1.0, 2.0, 0.2], [10.0, 20.0, 2.0]])
+    expected_prime = np.array([[1.0, 0.2, 2.0], [10.0, 2.0, 20.0]])
     expected_x = np.array([[1.0, 2.0, 2.0], [10.0, 20.0, 20.0]])
     expected_log_j = -np.log(10.0) * np.ones(x.shape[0])
 
@@ -326,13 +342,12 @@ def test_configure_reparameterisations_with_prime_spec_chain(rng):
             "x": [
                 {
                     "reparameterisation": "prime-producer",
-                    "prime_parameters": ["x_bounded"],
+                    "output_parameters": ["x_bounded"],
                 },
                 {
                     "reparameterisation": "prime-scale",
-                    "parameters": [],
-                    "prime_requires": ["x_bounded"],
-                    "prime_parameters": ["x_scaled"],
+                    "input_parameters": ["x_bounded"],
+                    "output_parameters": ["x_scaled"],
                 },
             ]
         },
@@ -340,16 +355,24 @@ def test_configure_reparameterisations_with_prime_spec_chain(rng):
     )
 
     assert proposal.parameters == ["x"]
-    assert proposal.prime_parameters == ["x_bounded", "x_scaled"]
+    assert proposal.prime_parameters == ["x_scaled"]
+    assert proposal._prime_parameters_internal == ["x_bounded", "x_scaled"]
 
     x = numpy_array_to_live_points(np.array([[1.0], [2.0]]), ["x"])
 
     x_prime, log_j = proposal.rescale(x)
     x_out, log_j_inv = proposal.inverse_rescale(x_prime)
 
-    expected_prime = np.array([[2.0, 4.0], [3.0, 6.0]])
+    expected_prime_internal = np.array([[2.0, 4.0], [3.0, 6.0]])
+    expected_prime = np.array([[4.0], [6.0]])
     expected_x = np.array([[1.0], [2.0]])
 
+    np.testing.assert_array_equal(
+        live_points_to_array(
+            x_prime, names=proposal._prime_parameters_internal, copy=True
+        ),
+        expected_prime_internal,
+    )
     np.testing.assert_array_equal(
         live_points_to_array(
             x_prime, names=proposal.prime_parameters, copy=True
@@ -365,8 +388,61 @@ def test_configure_reparameterisations_with_prime_spec_chain(rng):
 
 
 @pytest.mark.integration_test
+def test_verify_rescaling_with_prime_input_update_chain(tmpdir):
+    class HalfGaussian(Model):
+        def __init__(self):
+            self.names = ["x", "y"]
+            self.bounds = {"x": [-10.0, 10.0], "y": [0.0, 10.0]}
+            self.reparameterisations = None
+            self.rng = np.random.default_rng(1234)
+
+        def log_prior(self, x):
+            log_p = np.log(self.in_bounds(x), dtype="float")
+            for bounds in self.bounds.values():
+                log_p -= np.log(bounds[1] - bounds[0])
+            return log_p
+
+        def log_likelihood(self, x):
+            log_l = np.zeros(x.size)
+            for name in self.names:
+                log_l += norm.logpdf(x[name])
+            return log_l
+
+    proposal = FlowProposal(
+        HalfGaussian(),
+        output=str(tmpdir.mkdir("test")),
+        poolsize=10,
+        plot=False,
+        reparameterisations={
+            "x": "default",
+            "y": [
+                {
+                    "reparameterisation": "rescaletobounds",
+                    "output_parameters": ["y_01"],
+                },
+                {
+                    "reparameterisation": "z-score",
+                    "input_parameters": ["y_01"],
+                    "output_parameters": ["y_prime"],
+                },
+            ],
+        },
+    )
+
+    proposal.set_rescaling()
+    proposal.verify_rescaling()
+
+    assert proposal.prime_parameters == ["x_prime", "y_prime"]
+    assert proposal._prime_parameters_internal == [
+        "x_prime",
+        "y_01",
+        "y_prime",
+    ]
+
+
+@pytest.mark.integration_test
 def test_multi_parameter_reparameterisation_ordering(rng):
-    """Parameter-key grouping should preserve model-order parameters."""
+    """Prime parameters should follow reparameterisation output order."""
     grouped = make_test_proposal(
         {
             "a": {"reparameterisation": "null", "parameters": ["d"]},
@@ -377,7 +453,10 @@ def test_multi_parameter_reparameterisation_ordering(rng):
     )
 
     assert grouped.parameters == ["a", "b", "c", "d"]
-    assert grouped.prime_parameters == ["a", "b", "c", "d"]
+    expected = []
+    for reparameterisation in grouped._reparameterisation.values():
+        expected.extend(reparameterisation.output_parameters)
+    assert grouped.prime_parameters == expected
 
 
 @pytest.mark.integration_test
@@ -408,11 +487,14 @@ def test_multi_parameter_reparameterisation_flow_input_order(rng):
         ),
         np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
     )
+    expected_grouped = live_points_to_array(
+        x, names=grouped.prime_parameters, copy=True
+    )
     np.testing.assert_array_equal(
         live_points_to_array(
             x_prime_grouped, names=grouped.prime_parameters, copy=True
         ),
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+        expected_grouped,
     )
 
     baseline.flow = MagicMock()
@@ -433,7 +515,7 @@ def test_multi_parameter_reparameterisation_flow_input_order(rng):
     )
     np.testing.assert_array_equal(
         grouped.flow.forward_and_log_prob.call_args[0][0],
-        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+        expected_grouped,
     )
 
 
@@ -469,20 +551,23 @@ def test_multi_parameter_reparameterisation_ordering_integration(rng):
     x_prime_grouped, log_j_grouped = grouped.rescale(x)
     x_out_grouped, log_j_inv_grouped = grouped.inverse_rescale(x_prime_grouped)
 
-    expected = np.array([[0.5, 2.0, 3.0, 0.4], [5.0, 20.0, 30.0, 4.0]])
+    expected_baseline = np.array(
+        [[0.5, 2.0, 3.0, 0.4], [5.0, 20.0, 30.0, 4.0]]
+    )
+    expected_grouped = np.array([[0.5, 0.4, 2.0, 3.0], [5.0, 4.0, 20.0, 30.0]])
     expected_log_j = -np.log(20.0) * np.ones(x.shape[0])
 
     np.testing.assert_array_equal(
         live_points_to_array(
             x_prime_baseline, names=baseline.prime_parameters, copy=True
         ),
-        expected,
+        expected_baseline,
     )
     np.testing.assert_array_equal(
         live_points_to_array(
             x_prime_grouped, names=grouped.prime_parameters, copy=True
         ),
-        expected,
+        expected_grouped,
     )
     np.testing.assert_allclose(log_j_baseline, expected_log_j)
     np.testing.assert_allclose(log_j_grouped, expected_log_j)
@@ -505,8 +590,8 @@ def test_multi_parameter_reparameterisation_ordering_integration(rng):
     grouped.forward_pass(x)
 
     np.testing.assert_array_equal(
-        baseline.flow.forward_and_log_prob.call_args[0][0], expected
+        baseline.flow.forward_and_log_prob.call_args[0][0], expected_baseline
     )
     np.testing.assert_array_equal(
-        grouped.flow.forward_and_log_prob.call_args[0][0], expected
+        grouped.flow.forward_and_log_prob.call_args[0][0], expected_grouped
     )

--- a/tests/test_reparameterisations/conftest.py
+++ b/tests/test_reparameterisations/conftest.py
@@ -1,6 +1,6 @@
 """Configuration for the reparameterisation tests"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 import numpy as np
@@ -17,6 +17,22 @@ class _LightReparam:
     name: str
     parameters: List[str]
     requires: List[str]
+    auxiliary_parameters: List[str] = field(default_factory=list)
+    prime_parameters: List[str] = field(default_factory=list)
+    prime_requires: List[str] = field(default_factory=list)
+    inverse_requires: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.prime_parameters:
+            self.prime_parameters = [p + "_prime" for p in self.parameters]
+
+    @property
+    def output_parameters(self) -> List[str]:
+        return self.parameters + self.auxiliary_parameters
+
+    @property
+    def input_parameters(self) -> List[str]:
+        return list(dict.fromkeys(self.parameters + self.requires))
 
 
 @pytest.fixture

--- a/tests/test_reparameterisations/conftest.py
+++ b/tests/test_reparameterisations/conftest.py
@@ -10,29 +10,115 @@ from nessai.livepoint import empty_structured_array
 from nessai.utils.testing import assert_structured_arrays_equal
 
 
-@dataclass
+@dataclass(init=False)
 class _LightReparam:
     """Reparameterisation-like object"""
 
     name: str
-    parameters: List[str]
-    requires: List[str]
+    input_parameters: List[str]
+    output_parameters: List[str] = field(default_factory=list)
+    persistent_parameters: List[str] = field(default_factory=list)
     auxiliary_parameters: List[str] = field(default_factory=list)
-    prime_parameters: List[str] = field(default_factory=list)
-    prime_requires: List[str] = field(default_factory=list)
-    inverse_requires: List[str] = field(default_factory=list)
+    inverse_input_parameters: List[str] = field(default_factory=list)
+
+    def __init__(
+        self,
+        name,
+        input_parameters=None,
+        output_parameters=None,
+        persistent_parameters=None,
+        auxiliary_parameters=None,
+        inverse_input_parameters=None,
+        parameters=None,
+    ) -> None:
+        if input_parameters is None:
+            input_parameters = parameters
+        if input_parameters is None:
+            input_parameters = []
+
+        self.name = name
+        self.input_parameters = list(input_parameters)
+        self.output_parameters = list(output_parameters or [])
+        self.persistent_parameters = list(persistent_parameters or [])
+        self.auxiliary_parameters = list(auxiliary_parameters or [])
+        self.inverse_input_parameters = list(inverse_input_parameters or [])
+        self.__post_init__()
 
     def __post_init__(self) -> None:
-        if not self.prime_parameters:
-            self.prime_parameters = [p + "_prime" for p in self.parameters]
+        if not self.output_parameters:
+            self.output_parameters = [
+                p + "_prime" for p in self.input_parameters
+            ]
+        self._x_input_parameters = []
+        self._x_prime_input_parameters = []
+        self._x_persistent_parameters = []
+        self._x_prime_persistent_parameters = []
+        self._x_inverse_input_parameters = []
+        self._x_prime_inverse_input_parameters = []
 
     @property
-    def output_parameters(self) -> List[str]:
-        return self.parameters + self.auxiliary_parameters
+    def parameters(self) -> List[str]:
+        return self.input_parameters
+
+    @parameters.setter
+    def parameters(self, value) -> None:
+        self.input_parameters = value
 
     @property
-    def input_parameters(self) -> List[str]:
-        return list(dict.fromkeys(self.parameters + self.requires))
+    def x_input_parameters(self) -> List[str]:
+        return self._x_input_parameters or self.input_parameters
+
+    @property
+    def x_prime_input_parameters(self) -> List[str]:
+        return self._x_prime_input_parameters
+
+    @property
+    def x_persistent_parameters(self) -> List[str]:
+        return self._x_persistent_parameters
+
+    @property
+    def x_prime_persistent_parameters(self) -> List[str]:
+        return self._x_prime_persistent_parameters
+
+    @property
+    def x_output_parameters(self) -> List[str]:
+        return self.input_parameters + self.auxiliary_parameters
+
+    def resolve_forward_input_spaces(self, parameters, prime_parameters):
+        self._x_input_parameters = []
+        self._x_prime_input_parameters = []
+        missing = []
+        for p in self.input_parameters:
+            if p in parameters:
+                self._x_input_parameters.append(p)
+            elif p in prime_parameters:
+                self._x_prime_input_parameters.append(p)
+            else:
+                missing.append(p)
+        self._x_persistent_parameters = [
+            p
+            for p in self.persistent_parameters
+            if p in self._x_input_parameters
+        ]
+        self._x_prime_persistent_parameters = [
+            p
+            for p in self.persistent_parameters
+            if p in self._x_prime_input_parameters
+        ]
+        return missing
+
+    def resolve_inverse_input_spaces(self, parameters, prime_parameters):
+        self._x_inverse_input_parameters = []
+        self._x_prime_inverse_input_parameters = []
+        missing = []
+        for p in self.inverse_input_parameters:
+            if p in parameters:
+                self._x_inverse_input_parameters.append(p)
+            elif p in prime_parameters:
+                self._x_prime_inverse_input_parameters.append(p)
+            else:
+                missing.append(p)
+        return missing
 
 
 @pytest.fixture
@@ -51,13 +137,13 @@ def is_invertible(model, n=100):
             x = model.sample_unit_hypercube(n)
         else:
             x = model.new_point(N=n)
-        x_prime = empty_structured_array(n, names=reparam.prime_parameters)
+        x_prime = empty_structured_array(n, names=reparam.output_parameters)
         log_j = np.zeros(n)
         assert x.size == x_prime.size
 
         x_re, x_prime_re, log_j_re = reparam.reparameterise(x, x_prime, log_j)
 
-        x_in = empty_structured_array(x_re.size, reparam.parameters)
+        x_in = empty_structured_array(x_re.size, reparam.x_output_parameters)
         log_j = np.zeros(x_re.size)
 
         x_inv, x_prime_inv, log_j_inv = reparam.inverse_reparameterise(

--- a/tests/test_reparameterisations/test_angle.py
+++ b/tests/test_reparameterisations/test_angle.py
@@ -32,7 +32,7 @@ def reparam():
 @pytest.fixture(scope="function")
 def assert_invertibility(model, n=100):
     def test_invertibility(reparam, angle, radial=None):
-        x = empty_structured_array(n, names=reparam.parameters)
+        x = empty_structured_array(n, names=reparam.output_parameters)
         x_prime = empty_structured_array(n, names=reparam.prime_parameters)
         log_j = 0
 
@@ -50,7 +50,7 @@ def assert_invertibility(model, n=100):
                 x[reparam.radial], x_re[reparam.radial]
             )
 
-        x_in = empty_structured_array(n, names=reparam.parameters)
+        x_in = empty_structured_array(n, names=reparam.output_parameters)
 
         x_inv, x_prime_inv, log_j_inv = reparam.inverse_reparameterise(
             x_in, x_prime_re, log_j
@@ -96,10 +96,14 @@ def test_angle_parameter(bounds, scale, expected_scale):
         assert reparam._zero_bound is False
 
     assert reparam.angle == parameter
+    assert reparam.parameters == [parameter]
+    assert reparam.auxiliary_parameters == [parameter + "_radial"]
+    assert reparam.output_parameters == [parameter, parameter + "_radial"]
     assert reparam.radial == (parameter + "_radial")
     assert reparam.radius == (parameter + "_radial")
     assert reparam.x == (parameter + "_x")
     assert reparam.y == (parameter + "_y")
+    assert reparam.input_parameters == [parameter]
     assert reparam.scale == expected_scale
 
 
@@ -119,7 +123,9 @@ def test_log_prior(reparam):
     """Assert the log-prior calls the correct function"""
     reparam.chi = MagicMock()
     reparam.chi.logpdf = MagicMock()
-    reparam.parameters = ["theta", "theta_radial"]
+    reparam.parameters = ["theta"]
+    reparam.auxiliary_parameters = ["theta_radial"]
+    reparam.radial = "theta_radial"
     x = {"theta": [1.0], "theta_radial": [0.5]}
     Angle.log_prior(reparam, x)
     reparam.chi.logpdf.assert_called_once_with([0.5])
@@ -139,7 +145,10 @@ def test_both_parameters():
     assert reparam._zero_bound is True
 
     assert reparam.angle == parameters[0]
+    assert reparam.parameters == parameters
+    assert reparam.auxiliary_parameters == []
     assert reparam.radial == parameters[1]
+    assert reparam.input_parameters == parameters
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reparameterisations/test_angle.py
+++ b/tests/test_reparameterisations/test_angle.py
@@ -26,7 +26,9 @@ def scale(request):
 
 @pytest.fixture
 def reparam():
-    return create_autospec(Angle)
+    r = create_autospec(Angle)
+    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    return r
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_reparameterisations/test_angle.py
+++ b/tests/test_reparameterisations/test_angle.py
@@ -13,7 +13,7 @@ from nessai.livepoint import (
     numpy_array_to_live_points,
     parameters_to_live_point,
 )
-from nessai.reparameterisations import Angle
+from nessai.reparameterisations import Angle, Reparameterisation
 from nessai.utils.testing import assert_structured_arrays_equal
 
 scales = [1.0, 2.0]
@@ -27,15 +27,23 @@ def scale(request):
 @pytest.fixture
 def reparam():
     r = create_autospec(Angle)
-    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    r._format_parameters = lambda x: (
+        x.copy() if isinstance(x, list) else ([] if x is None else [x])
+    )
+    r.get_parameter_value = Reparameterisation.get_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.set_parameter_value = Reparameterisation.set_parameter_value.__get__(
+        r, Reparameterisation
+    )
     return r
 
 
 @pytest.fixture(scope="function")
 def assert_invertibility(model, n=100):
     def test_invertibility(reparam, angle, radial=None):
-        x = empty_structured_array(n, names=reparam.output_parameters)
-        x_prime = empty_structured_array(n, names=reparam.prime_parameters)
+        x = empty_structured_array(n, names=reparam.x_output_parameters)
+        x_prime = empty_structured_array(n, names=reparam.output_parameters)
         log_j = 0
 
         x[reparam.angle] = angle
@@ -52,7 +60,7 @@ def assert_invertibility(model, n=100):
                 x[reparam.radial], x_re[reparam.radial]
             )
 
-        x_in = empty_structured_array(n, names=reparam.output_parameters)
+        x_in = empty_structured_array(n, names=reparam.x_output_parameters)
 
         x_inv, x_prime_inv, log_j_inv = reparam.inverse_reparameterise(
             x_in, x_prime_re, log_j
@@ -100,7 +108,8 @@ def test_angle_parameter(bounds, scale, expected_scale):
     assert reparam.angle == parameter
     assert reparam.parameters == [parameter]
     assert reparam.auxiliary_parameters == [parameter + "_radial"]
-    assert reparam.output_parameters == [parameter, parameter + "_radial"]
+    assert reparam.x_output_parameters == [parameter, parameter + "_radial"]
+    assert reparam.output_parameters == [parameter + "_x", parameter + "_y"]
     assert reparam.radial == (parameter + "_radial")
     assert reparam.radius == (parameter + "_radial")
     assert reparam.x == (parameter + "_x")
@@ -117,7 +126,7 @@ def test_angle_too_many_parameters(reparam):
         Angle.__init__(
             reparam, parameters=parameters, prior_bounds=prior_bounds
         )
-    assert reparam.parameters == parameters
+    assert reparam.input_parameters == parameters
     assert "Too many parameters for Angle" in str(excinfo.value)
 
 
@@ -151,6 +160,7 @@ def test_both_parameters():
     assert reparam.auxiliary_parameters == []
     assert reparam.radial == parameters[1]
     assert reparam.input_parameters == parameters
+    assert reparam.x_output_parameters == parameters
 
 
 @pytest.mark.parametrize(
@@ -210,7 +220,7 @@ def test_periodic_parameter(value, output_x, output_y):
     )
     x = parameters_to_live_point((value,), parameters)
     x_prime = parameters_to_live_point(
-        (np.nan, np.nan), reparam.prime_parameters
+        (np.nan, np.nan), reparam.output_parameters
     )
     log_j = np.zeros(x.size)
     x_out, x_prime_out, log_j_out = reparam.reparameterise(x, x_prime, log_j)

--- a/tests/test_reparameterisations/test_angle_pair.py
+++ b/tests/test_reparameterisations/test_angle_pair.py
@@ -13,7 +13,7 @@ from nessai.livepoint import (
     numpy_array_to_live_points,
     parameters_to_live_point,
 )
-from nessai.reparameterisations import AnglePair
+from nessai.reparameterisations import AnglePair, Reparameterisation
 
 angle_pairs = [
     (["ra", "dec"], [[0, 2 * np.pi], [-np.pi / 2, np.pi / 2]]),
@@ -32,7 +32,15 @@ def angles(request):
 @pytest.fixture
 def reparam():
     r = create_autospec(AnglePair)
-    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    r._format_parameters = lambda x: (
+        x.copy() if isinstance(x, list) else ([] if x is None else [x])
+    )
+    r.get_parameter_value = Reparameterisation.get_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.set_parameter_value = Reparameterisation.set_parameter_value.__get__(
+        r, Reparameterisation
+    )
     return r
 
 
@@ -40,8 +48,8 @@ def reparam():
 def assert_invertibility():
     def test_invertibility(reparam, angles, radial=None):
         n = list(angles.values())[0].size
-        x = np.zeros([n], dtype=get_dtype(reparam.output_parameters))
-        x_prime = np.zeros([n], dtype=get_dtype(reparam.prime_parameters))
+        x = np.zeros([n], dtype=get_dtype(reparam.x_output_parameters))
+        x_prime = np.zeros([n], dtype=get_dtype(reparam.output_parameters))
         log_j = 0
 
         for a in reparam.angles:
@@ -60,7 +68,7 @@ def assert_invertibility():
                 x[reparam.radial], x_re[reparam.radial]
             )
 
-        x_in = np.zeros([n], dtype=get_dtype(reparam.output_parameters))
+        x_in = np.zeros([n], dtype=get_dtype(reparam.x_output_parameters))
 
         x_inv, x_prime_inv, log_j_inv = reparam.inverse_reparameterise(
             x_in, x_prime_re, log_j
@@ -110,16 +118,19 @@ def test_two_angles(angles):
     assert reparam.chi is not False
     assert hasattr(reparam.chi, "rvs")
 
-    m = "_".join(parameters[:2])
-    assert reparam.parameters == parameters[:2]
+    m = "_".join(reparam.parameters[:2])
+    assert set(reparam.parameters) == set(parameters[:2])
     assert reparam.auxiliary_parameters == [m + "_radial"]
-    assert reparam.output_parameters == parameters[:2] + [m + "_radial"]
-    assert reparam.angles == parameters[:2]
+    assert reparam.x_output_parameters == reparam.parameters[:2] + [
+        m + "_radial"
+    ]
+    assert reparam.angles == reparam.parameters[:2]
     assert reparam.radial == (m + "_radial")
     assert reparam.x == (m + "_x")
     assert reparam.y == (m + "_y")
     assert reparam.z == (m + "_z")
-    assert reparam.input_parameters == parameters[:2]
+    assert reparam.input_parameters == reparam.parameters[:2]
+    assert reparam.output_parameters == [m + "_x", m + "_y", m + "_z"]
 
 
 def test_ra_dec(assert_invertibility):
@@ -236,8 +247,8 @@ def test_specific_points_x_prime_to_x_0_2pi(convention, input, expected):
         convention=convention,
     )
 
-    x_prime = parameters_to_live_point(input, reparam.prime_parameters)
-    x = parameters_to_live_point([0, 0, 0], reparam.output_parameters)
+    x_prime = parameters_to_live_point(input, reparam.output_parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.x_output_parameters)
     log_j = 0
 
     out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)
@@ -291,8 +302,8 @@ def test_specific_points_x_prime_to_x_pi_pi(convention, input, expected):
         convention=convention,
     )
 
-    x_prime = parameters_to_live_point(input, reparam.prime_parameters)
-    x = parameters_to_live_point([0, 0, 0], reparam.output_parameters)
+    x_prime = parameters_to_live_point(input, reparam.output_parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.x_output_parameters)
     log_j = 0
 
     out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)

--- a/tests/test_reparameterisations/test_angle_pair.py
+++ b/tests/test_reparameterisations/test_angle_pair.py
@@ -38,7 +38,7 @@ def reparam():
 def assert_invertibility():
     def test_invertibility(reparam, angles, radial=None):
         n = list(angles.values())[0].size
-        x = np.zeros([n], dtype=get_dtype(reparam.parameters))
+        x = np.zeros([n], dtype=get_dtype(reparam.output_parameters))
         x_prime = np.zeros([n], dtype=get_dtype(reparam.prime_parameters))
         log_j = 0
 
@@ -58,7 +58,7 @@ def assert_invertibility():
                 x[reparam.radial], x_re[reparam.radial]
             )
 
-        x_in = np.zeros([n], dtype=get_dtype(reparam.parameters))
+        x_in = np.zeros([n], dtype=get_dtype(reparam.output_parameters))
 
         x_inv, x_prime_inv, log_j_inv = reparam.inverse_reparameterise(
             x_in, x_prime_re, log_j
@@ -109,11 +109,15 @@ def test_two_angles(angles):
     assert hasattr(reparam.chi, "rvs")
 
     m = "_".join(parameters[:2])
+    assert reparam.parameters == parameters[:2]
+    assert reparam.auxiliary_parameters == [m + "_radial"]
+    assert reparam.output_parameters == parameters[:2] + [m + "_radial"]
     assert reparam.angles == parameters[:2]
     assert reparam.radial == (m + "_radial")
     assert reparam.x == (m + "_x")
     assert reparam.y == (m + "_y")
     assert reparam.z == (m + "_z")
+    assert reparam.input_parameters == parameters[:2]
 
 
 def test_ra_dec(assert_invertibility):
@@ -174,6 +178,8 @@ def test_w_radial(assert_invertibility):
     assert reparam.parameters == ["ra", "dec", "r"]
     assert reparam.angles == ["ra", "dec"]
     assert reparam.chi is False
+    assert reparam.auxiliary_parameters == []
+    assert reparam.input_parameters == ["ra", "dec", "r"]
 
     n = 100
     angles = {
@@ -231,14 +237,14 @@ def test_specific_points_x_prime_to_x_0_2pi(convention, input, expected):
     )
 
     x_prime = parameters_to_live_point(input, reparam.prime_parameters)
-    x = parameters_to_live_point([0, 0, 0], reparam.parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.output_parameters)
     log_j = 0
 
     out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)
 
     np.testing.assert_equal(out[reparam.parameters[0]], expected[0])
     np.testing.assert_equal(out[reparam.parameters[1]], expected[1])
-    np.testing.assert_equal(out[reparam.parameters[2]], expected[2])
+    np.testing.assert_equal(out[reparam.radial], expected[2])
 
 
 @pytest.mark.parametrize(
@@ -286,14 +292,14 @@ def test_specific_points_x_prime_to_x_pi_pi(convention, input, expected):
     )
 
     x_prime = parameters_to_live_point(input, reparam.prime_parameters)
-    x = parameters_to_live_point([0, 0, 0], reparam.parameters)
+    x = parameters_to_live_point([0, 0, 0], reparam.output_parameters)
     log_j = 0
 
     out, _, _ = reparam.inverse_reparameterise(x, x_prime, log_j)
 
     np.testing.assert_equal(out[reparam.parameters[0]], expected[0])
     np.testing.assert_equal(out[reparam.parameters[1]], expected[1])
-    np.testing.assert_equal(out[reparam.parameters[2]], expected[2])
+    np.testing.assert_equal(out[reparam.radial], expected[2])
 
 
 @pytest.mark.parametrize(
@@ -360,9 +366,12 @@ def test_no_convention():
 def test_log_prior():
     """Assert log_prior calls the log pdf of a chi distribution."""
     reparam = create_autospec(AnglePair)
-    reparam.parameters = ["a", "b", "r"]
+    reparam.parameters = ["a", "b"]
+    reparam.auxiliary_parameters = ["r"]
+    reparam.output_parameters = ["a", "b", "r"]
+    reparam.radial = "r"
     reparam.has_prior = True
-    x = parameters_to_live_point([0, 0, 2.0], reparam.parameters)
+    x = parameters_to_live_point([0, 0, 2.0], reparam.output_parameters)
     reparam.chi = MagicMock()
     reparam.chi.logpdf = MagicMock(return_value=1.0)
     out = AnglePair.log_prior(reparam, x)

--- a/tests/test_reparameterisations/test_angle_pair.py
+++ b/tests/test_reparameterisations/test_angle_pair.py
@@ -31,7 +31,9 @@ def angles(request):
 
 @pytest.fixture
 def reparam():
-    return create_autospec(AnglePair)
+    r = create_autospec(AnglePair)
+    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    return r
 
 
 @pytest.fixture(scope="function")
@@ -132,7 +134,6 @@ def test_ra_dec(assert_invertibility):
         parameters=parameters,
         prior_bounds=prior_bounds,
         convention="ra-dec",
-        prior="isotropic",
     )
 
     n = 100
@@ -152,7 +153,6 @@ def test_azimuth_zenith(assert_invertibility):
         parameters=parameters,
         prior_bounds=prior_bounds,
         convention="az-zen",
-        prior="isotropic",
     )
 
     n = 100

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -102,6 +102,29 @@ def test_missing_bounds_allowed_for_auxiliary_parameters():
     assert_equal(reparam.prior_bounds, {"x": np.array([0, 1])})
 
 
+def test_conflicting_parameters_and_input_parameters():
+    with pytest.raises(
+        RuntimeError, match="Received conflicting values for `parameters`"
+    ):
+        Reparameterisation(
+            parameters=["x"],
+            input_parameters=["y"],
+            prior_bounds={"y": [0, 1]},
+        )
+
+
+def test_persistent_parameters_must_be_subset():
+    with pytest.raises(
+        RuntimeError,
+        match="Persistent parameters must be a subset of the input",
+    ):
+        Reparameterisation(
+            parameters=["x"],
+            persistent_parameters=["y"],
+            prior_bounds={"x": [0, 1]},
+        )
+
+
 def test_incorrect_bounds_type():
     with pytest.raises(TypeError) as excinfo:
         Reparameterisation(parameters=["x", "y"], prior_bounds=1)
@@ -149,6 +172,42 @@ def test_reset(reparam):
     expected = copy.deepcopy(reparam)
     Reparameterisation.reset(reparam)
     assert expected == reparam
+
+
+def test_resolve_forward_input_spaces():
+    reparam = Reparameterisation(
+        input_parameters=["x", "x_prime", "missing"],
+        persistent_parameters=["x", "x_prime"],
+        prior_bounds={"x": [0, 1]},
+    )
+
+    missing = reparam.resolve_forward_input_spaces(
+        available_parameters=["x", "y"],
+        available_prime_parameters=["x_prime", "y_prime"],
+    )
+
+    assert missing == ["missing"]
+    assert reparam.x_input_parameters == ["x"]
+    assert reparam.x_prime_input_parameters == ["x_prime"]
+    assert reparam.x_persistent_parameters == ["x"]
+    assert reparam.x_prime_persistent_parameters == ["x_prime"]
+
+
+def test_resolve_inverse_input_spaces():
+    reparam = Reparameterisation(
+        parameters=["x"],
+        inverse_input_parameters=["y", "y_prime", "missing"],
+        prior_bounds={"x": [0, 1]},
+    )
+
+    missing = reparam.resolve_inverse_input_spaces(
+        available_parameters=["x", "y"],
+        available_prime_parameters=["x_prime", "y_prime"],
+    )
+
+    assert missing == ["missing"]
+    assert reparam.x_inverse_input_parameters == ["y"]
+    assert reparam.x_prime_inverse_input_parameters == ["y_prime"]
 
 
 def test_get_parameter_value_from_x():

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
+from nessai.livepoint import empty_structured_array
 from nessai.reparameterisations import Reparameterisation
 
 
@@ -23,8 +24,8 @@ def reparam():
 def test_init(name, prior_bounds):
     """Test the init method with the allowed types of inputs"""
     reparam = Reparameterisation(parameters=name, prior_bounds=prior_bounds)
-    assert reparam.parameters == ["x1"]
-    assert reparam.prime_parameters == ["x1_prime"]
+    assert reparam.input_parameters == ["x1"]
+    assert reparam.output_parameters == ["x1_prime"]
     assert_equal(reparam.prior_bounds, {"x1": np.array([0, 1])})
 
 
@@ -33,8 +34,8 @@ def test_init_infinite_bounds():
     reparam = Reparameterisation(
         parameters=["x", "y"], prior_bounds={"x": [0, 1], "y": [0, np.inf]}
     )
-    assert reparam.parameters == ["x", "y"]
-    assert reparam.prime_parameters == ["x_prime", "y_prime"]
+    assert reparam.input_parameters == ["x", "y"]
+    assert reparam.output_parameters == ["x_prime", "y_prime"]
     assert_equal(reparam.prior_bounds["x"], [0, 1])
     assert_equal(reparam.prior_bounds["y"], [0, np.inf])
 
@@ -127,7 +128,8 @@ def test_methods_not_implemented():
 def test_output_parameters():
     reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
     reparam.auxiliary_parameters = ["x_aux"]
-    assert reparam.output_parameters == ["x", "x_aux"]
+    assert reparam.output_parameters == ["x_prime"]
+    assert reparam.x_output_parameters == ["x", "x_aux"]
 
 
 def test_format_parameters_invalid_type():
@@ -147,3 +149,70 @@ def test_reset(reparam):
     expected = copy.deepcopy(reparam)
     Reparameterisation.reset(reparam)
     assert expected == reparam
+
+
+def test_get_parameter_value_from_x():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    x = empty_structured_array(2, names=["x"])
+    x["x"] = np.array([1.0, 2.0])
+
+    out = reparam.get_parameter_value("x", x)
+
+    np.testing.assert_array_equal(out, x["x"])
+
+
+def test_get_parameter_value_from_x_prime():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    reparam._x_prime_input_parameters = ["x"]
+    x = empty_structured_array(2, names=["x"])
+    x["x"] = np.array([1.0, 2.0])
+    x_prime = empty_structured_array(2, names=["x"])
+    x_prime["x"] = np.array([3.0, 4.0])
+
+    out = reparam.get_parameter_value("x", x, x_prime=x_prime)
+
+    np.testing.assert_array_equal(out, x_prime["x"])
+
+
+def test_get_parameter_value_from_x_prime_missing_array():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    reparam._x_prime_input_parameters = ["x"]
+    x = empty_structured_array(2, names=["x"])
+
+    with pytest.raises(RuntimeError, match="no x_prime array was provided"):
+        reparam.get_parameter_value("x", x)
+
+
+def test_set_parameter_value_in_x():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    x = empty_structured_array(2, names=["x"])
+
+    x_out, x_prime_out = reparam.set_parameter_value(
+        "x", np.array([1.0, 2.0]), x
+    )
+
+    np.testing.assert_array_equal(x_out["x"], np.array([1.0, 2.0]))
+    assert x_prime_out is None
+
+
+def test_set_parameter_value_in_x_prime():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    reparam._x_prime_input_parameters = ["x"]
+    x = empty_structured_array(2, names=["x"])
+    x_prime = empty_structured_array(2, names=["x"])
+
+    x_out, x_prime_out = reparam.set_parameter_value(
+        "x", np.array([3.0, 4.0]), x, x_prime=x_prime
+    )
+
+    np.testing.assert_array_equal(x_prime_out["x"], np.array([3.0, 4.0]))
+    assert x_out is x
+
+
+def test_set_parameter_value_in_x_prime_missing_array():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    reparam._x_prime_input_parameters = ["x"]
+    x = empty_structured_array(2, names=["x"])
+
+    with pytest.raises(RuntimeError, match="no x_prime array was provided"):
+        reparam.set_parameter_value("x", np.array([1.0, 2.0]), x)

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -130,6 +130,11 @@ def test_output_parameters():
     assert reparam.output_parameters == ["x", "x_aux"]
 
 
+def test_format_parameters_invalid_type():
+    with pytest.raises(TypeError, match="Parameters must be a string"):
+        Reparameterisation._format_parameters(1)
+
+
 def test_update(reparam):
     """Assert the default update method can be called and does not raised an
     error.

--- a/tests/test_reparameterisations/test_base_reparameterisation.py
+++ b/tests/test_reparameterisations/test_base_reparameterisation.py
@@ -86,9 +86,19 @@ def test_parameters_error():
 
 
 def test_missing_bounds():
+    class TestReparam(Reparameterisation):
+        requires_bounded_prior = True
+
     with pytest.raises(RuntimeError) as excinfo:
-        Reparameterisation(parameters=["x", "y"], prior_bounds={"x": [0, 1]})
+        TestReparam(parameters=["x", "y"], prior_bounds={"x": [0, 1]})
     assert "Mismatch" in str(excinfo.value)
+
+
+def test_missing_bounds_allowed_for_auxiliary_parameters():
+    reparam = Reparameterisation(
+        parameters=["x", "aux"], prior_bounds={"x": [0, 1]}
+    )
+    assert_equal(reparam.prior_bounds, {"x": np.array([0, 1])})
 
 
 def test_incorrect_bounds_type():
@@ -112,6 +122,12 @@ def test_methods_not_implemented():
 
     with pytest.raises(NotImplementedError):
         reparam.inverse_reparameterise(None, None, None)
+
+
+def test_output_parameters():
+    reparam = Reparameterisation(parameters=["x"], prior_bounds={"x": [0, 1]})
+    reparam.auxiliary_parameters = ["x_aux"]
+    assert reparam.output_parameters == ["x", "x_aux"]
 
 
 def test_update(reparam):

--- a/tests/test_reparameterisations/test_combined.py
+++ b/tests/test_reparameterisations/test_combined.py
@@ -64,7 +64,8 @@ def test_init_none():
 
 def test_init_w_reparam():
     c = CombinedReparameterisation(
-        RescaleToBounds("x", [0, 1]), initial_parameters=["x"]
+        RescaleToBounds(parameters="x", prior_bounds=[0, 1]),
+        initial_parameters=["x"],
     )
     assert c.parameters == ["x"]
     assert c.prime_parameters == ["x_prime"]
@@ -122,12 +123,8 @@ def test_add_multiple_reparameterisations(model):
     Test adding multiple reparameterisations and using the reparameterisation.
     """
     r = [
-        RescaleToBounds(
-            parameters="x", prior_bounds=model.bounds["x"], prior="uniform"
-        ),
-        RescaleToBounds(
-            parameters="y", prior_bounds=model.bounds["y"], prior="uniform"
-        ),
+        RescaleToBounds(parameters="x", prior_bounds=model.bounds["x"]),
+        RescaleToBounds(parameters="y", prior_bounds=model.bounds["y"]),
     ]
     reparam = CombinedReparameterisation(initial_parameters=["x", "y"])
     reparam.add_reparameterisations(r)

--- a/tests/test_reparameterisations/test_combined.py
+++ b/tests/test_reparameterisations/test_combined.py
@@ -18,6 +18,35 @@ from nessai.reparameterisations import (
 from nessai.utils.testing import assert_structured_arrays_equal
 
 
+class PrimeProducer(Reparameterisation):
+    def __init__(self):
+        super().__init__(parameters="x", prior_bounds=None)
+        self.prime_parameters = ["u"]
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime["u"] = 2.0 * x["x"]
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x["x"] = x_prime["u"] / 2.0
+        return x, x_prime, log_j
+
+
+class PrimeConsumer(Reparameterisation):
+    def __init__(self):
+        super().__init__(parameters="y", prior_bounds=None)
+        self.prime_parameters = ["v"]
+        self.prime_requires = ["u"]
+
+    def reparameterise(self, x, x_prime, log_j, **kwargs):
+        x_prime["v"] = x["y"] + x_prime["u"]
+        return x, x_prime, log_j
+
+    def inverse_reparameterise(self, x, x_prime, log_j, **kwargs):
+        x["y"] = x_prime["v"] - x_prime["u"]
+        return x, x_prime, log_j
+
+
 @pytest.fixture
 def reparam():
     # Use spec_set to raised an error if an unknown attribute is set
@@ -30,10 +59,13 @@ def reparam():
 def test_init_none():
     c = CombinedReparameterisation()
     assert c.parameters == []
+    assert c.initial_parameters == []
 
 
 def test_init_w_reparam():
-    c = CombinedReparameterisation(RescaleToBounds("x", [0, 1]))
+    c = CombinedReparameterisation(
+        RescaleToBounds("x", [0, 1]), initial_parameters=["x"]
+    )
     assert c.parameters == ["x"]
     assert c.prime_parameters == ["x_prime"]
 
@@ -71,9 +103,18 @@ def test_from_prime_order(reverse_order, reparam):
 def test_add_single_reparameterisations():
     """Test the core functionality of adding reparameterisations"""
     r = RescaleToBounds(parameters="x", prior_bounds=[0, 1])
-    c = CombinedReparameterisation()
+    c = CombinedReparameterisation(initial_parameters=["x"])
     c.add_reparameterisations(r)
     assert c.parameters == ["x"]
+
+
+def test_add_single_reparameterisations_with_auxiliary_parameter(LightReparam):
+    r = LightReparam(
+        "a", parameters=["x"], requires=[], auxiliary_parameters=["aux"]
+    )
+    c = CombinedReparameterisation(initial_parameters=["x"])
+    c.add_reparameterisations(r)
+    assert c.parameters == ["x", "aux"]
 
 
 def test_add_multiple_reparameterisations(model):
@@ -88,7 +129,7 @@ def test_add_multiple_reparameterisations(model):
             parameters="y", prior_bounds=model.bounds["y"], prior="uniform"
         ),
     ]
-    reparam = CombinedReparameterisation()
+    reparam = CombinedReparameterisation(initial_parameters=["x", "y"])
     reparam.add_reparameterisations(r)
 
     assert reparam.parameters == ["x", "y"]
@@ -118,10 +159,15 @@ def test_add_multiple_reparameterisations(model):
 def test_base_add_reparameterisation_missing_requirements(reparam):
     """Assert an error is raised if a required parameter is missing"""
     r = MagicMock(spec=Reparameterisation)
+    r.parameters = ["y"]
     r.requires = ["x"]
+    r.input_parameters = ["y", "x"]
+    r.output_parameters = ["y"]
+    r.prime_requires = []
 
     reparam.parameters = ["y"]
     reparam.prime_parameters = ["y_prime"]
+    reparam.initial_parameters = []
 
     with pytest.raises(RuntimeError) as excinfo:
         CombinedReparameterisation._add_reparameterisation(reparam, r)
@@ -144,6 +190,8 @@ def test_add_reparameterisations_single(reparam):
     Should convert to a list and then pass to `_add_reparameterisation`
     """
     reparam.parameters = []
+    reparam.initial_parameters = []
+    reparam.prime_parameters = []
     new_reparam = MagicMock(spec=Reparameterisation)
     with patch(
         "nessai.reparameterisations.combined.sort_reparameterisations",
@@ -153,7 +201,9 @@ def test_add_reparameterisations_single(reparam):
             reparam, new_reparam
         )
     reparam._add_reparameterisation.assert_called_once_with(new_reparam)
-    mock.assert_called_once_with([new_reparam], existing_parameters=[])
+    mock.assert_called_once_with(
+        [new_reparam], existing_parameters=[], existing_prime_parameters=[]
+    )
 
 
 def test_add_reparameterisations_multiple(reparam):
@@ -163,6 +213,8 @@ def test_add_reparameterisations_multiple(reparam):
     """
     parameters = ["x"]
     reparam.parameters = parameters
+    reparam.initial_parameters = []
+    reparam.prime_parameters = []
     r1 = MagicMock(spec=Reparameterisation)
     r2 = MagicMock(spec=Reparameterisation)
     reparams = [r1, r2]
@@ -172,15 +224,89 @@ def test_add_reparameterisations_multiple(reparam):
     ) as mock:
         CombinedReparameterisation.add_reparameterisations(reparam, reparams)
     reparam._add_reparameterisation.assert_has_calls([call(r1), call(r2)])
-    mock.assert_called_once_with(reparams, existing_parameters=parameters)
+    mock.assert_called_once_with(
+        reparams,
+        existing_parameters=parameters,
+        existing_prime_parameters=[],
+    )
+
+
+def test_add_reparameterisations_with_prime_requirement(LightReparam):
+    r0 = LightReparam(
+        "a", parameters=["x"], requires=[], prime_parameters=["u"]
+    )
+    r1 = LightReparam(
+        "b",
+        parameters=["y"],
+        requires=[],
+        prime_parameters=["v"],
+        prime_requires=["u"],
+    )
+
+    c = CombinedReparameterisation(initial_parameters=["x", "y"])
+    c.add_reparameterisations([r1, r0])
+
+    assert c.order == ["a", "b"]
+
+
+def test_prime_requires_chain():
+    c = CombinedReparameterisation(initial_parameters=["x", "y"])
+    c.add_reparameterisations([PrimeConsumer(), PrimeProducer()])
+
+    assert c.order == ["primeproducer_x", "primeconsumer_y"]
+    assert c.prime_parameters == ["u", "v"]
+
+    x = empty_structured_array(4, names=["x", "y"])
+    x["x"] = np.array([0.5, 1.0, 1.5, 2.0])
+    x["y"] = np.array([1.0, 2.0, 3.0, 4.0])
+    x_prime = empty_structured_array(4, names=c.prime_parameters)
+    log_j = np.zeros(x.size)
+
+    x_re, x_prime_re, log_j_re = c.reparameterise(x, x_prime, log_j)
+    assert_structured_arrays_equal(x_re, x)
+    np.testing.assert_allclose(x_prime_re["u"], 2.0 * x["x"])
+    np.testing.assert_allclose(x_prime_re["v"], x["y"] + x_prime_re["u"])
+
+    x_in = empty_structured_array(4, names=c.parameters)
+    x_inv, x_prime_inv, log_j_inv = c.inverse_reparameterise(
+        x_in, x_prime_re, log_j
+    )
+
+    assert_structured_arrays_equal(x_inv, x)
+    assert_structured_arrays_equal(x_prime_inv, x_prime_re)
+    np.testing.assert_array_equal(log_j_re, log_j_inv)
+
+
+def test_base_add_reparameterisation_missing_prime_requirements(reparam):
+    """Assert an error is raised if a prime requirement is missing"""
+    r = MagicMock(spec=Reparameterisation)
+    r.parameters = ["y"]
+    r.requires = []
+    r.input_parameters = ["y"]
+    r.output_parameters = ["y"]
+    r.prime_requires = ["x_prime"]
+
+    reparam.parameters = ["y"]
+    reparam.prime_parameters = ["y_prime"]
+    reparam.initial_parameters = ["y"]
+
+    with pytest.raises(RuntimeError) as excinfo:
+        CombinedReparameterisation._add_reparameterisation(reparam, r)
+    assert "Missing prime requirement(s)" in str(excinfo.value)
 
 
 def test_check_order_valid(reparam, LightReparam):
     """Assert no error is raised if the order is valid"""
     d = dict(
-        a=LightReparam("a", parameters=["x"], requires=[]),
-        b=LightReparam("b", parameters=["y"], requires=["x"]),
-        c=LightReparam("c", parameters=["z"], requires=["y"]),
+        a=LightReparam(
+            "a", parameters=["x"], requires=[], inverse_requires=[]
+        ),
+        b=LightReparam(
+            "b", parameters=["y"], requires=["x"], inverse_requires=["x"]
+        ),
+        c=LightReparam(
+            "c", parameters=["z"], requires=["y"], inverse_requires=["y"]
+        ),
     )
     reparam.__getitem__.side_effect = d.__getitem__
     reparam.from_prime_order = ["a", "b", "c"]
@@ -191,9 +317,15 @@ def test_check_order_valid(reparam, LightReparam):
 def test_check_order_invalid(reparam, LightReparam):
     """Assert an error is raised if the order is invalid"""
     d = dict(
-        a=LightReparam("a", parameters=["x"], requires=["z"]),
-        b=LightReparam("b", parameters=["y"], requires=[]),
-        c=LightReparam("c", parameters=["z"], requires=["y"]),
+        a=LightReparam(
+            "a", parameters=["x"], requires=["z"], inverse_requires=["w"]
+        ),
+        b=LightReparam(
+            "b", parameters=["y"], requires=[], inverse_requires=[]
+        ),
+        c=LightReparam(
+            "c", parameters=["z"], requires=["y"], inverse_requires=[]
+        ),
     )
     reparam.__getitem__.side_effect = d.__getitem__
     reparam.from_prime_order = ["a", "b", "c"]

--- a/tests/test_reparameterisations/test_combined.py
+++ b/tests/test_reparameterisations/test_combined.py
@@ -21,7 +21,7 @@ from nessai.utils.testing import assert_structured_arrays_equal
 class PrimeProducer(Reparameterisation):
     def __init__(self):
         super().__init__(parameters="x", prior_bounds=None)
-        self.prime_parameters = ["u"]
+        self.output_parameters = ["u"]
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
         x_prime["u"] = 2.0 * x["x"]
@@ -34,9 +34,11 @@ class PrimeProducer(Reparameterisation):
 
 class PrimeConsumer(Reparameterisation):
     def __init__(self):
-        super().__init__(parameters="y", prior_bounds=None)
-        self.prime_parameters = ["v"]
-        self.prime_requires = ["u"]
+        super().__init__(
+            input_parameters=["y", "u"],
+            output_parameters=["v"],
+            prior_bounds=None,
+        )
 
     def reparameterise(self, x, x_prime, log_j, **kwargs):
         x_prime["v"] = x["y"] + x_prime["u"]
@@ -110,9 +112,7 @@ def test_add_single_reparameterisations():
 
 
 def test_add_single_reparameterisations_with_auxiliary_parameter(LightReparam):
-    r = LightReparam(
-        "a", parameters=["x"], requires=[], auxiliary_parameters=["aux"]
-    )
+    r = LightReparam("a", parameters=["x"], auxiliary_parameters=["aux"])
     c = CombinedReparameterisation(initial_parameters=["x"])
     c.add_reparameterisations(r)
     assert c.parameters == ["x", "aux"]
@@ -157,10 +157,10 @@ def test_base_add_reparameterisation_missing_requirements(reparam):
     """Assert an error is raised if a required parameter is missing"""
     r = MagicMock(spec=Reparameterisation)
     r.parameters = ["y"]
-    r.requires = ["x"]
     r.input_parameters = ["y", "x"]
-    r.output_parameters = ["y"]
-    r.prime_requires = []
+    r.output_parameters = ["y_prime"]
+    r.x_output_parameters = ["y"]
+    r.resolve_forward_input_spaces.return_value = ["x"]
 
     reparam.parameters = ["y"]
     reparam.prime_parameters = ["y_prime"]
@@ -229,15 +229,11 @@ def test_add_reparameterisations_multiple(reparam):
 
 
 def test_add_reparameterisations_with_prime_requirement(LightReparam):
-    r0 = LightReparam(
-        "a", parameters=["x"], requires=[], prime_parameters=["u"]
-    )
+    r0 = LightReparam("a", parameters=["x"], output_parameters=["u"])
     r1 = LightReparam(
         "b",
-        parameters=["y"],
-        requires=[],
-        prime_parameters=["v"],
-        prime_requires=["u"],
+        input_parameters=["y", "u"],
+        output_parameters=["v"],
     )
 
     c = CombinedReparameterisation(initial_parameters=["x", "y"])
@@ -246,11 +242,11 @@ def test_add_reparameterisations_with_prime_requirement(LightReparam):
     assert c.order == ["a", "b"]
 
 
-def test_prime_requires_chain():
+def test_prime_input_chain():
     c = CombinedReparameterisation(initial_parameters=["x", "y"])
-    c.add_reparameterisations([PrimeConsumer(), PrimeProducer()])
+    c.add_reparameterisations([PrimeProducer(), PrimeConsumer()])
 
-    assert c.order == ["primeproducer_x", "primeconsumer_y"]
+    assert c.order == ["primeproducer_x", "primeconsumer_y_u"]
     assert c.prime_parameters == ["u", "v"]
 
     x = empty_structured_array(4, names=["x", "y"])
@@ -278,10 +274,10 @@ def test_base_add_reparameterisation_missing_prime_requirements(reparam):
     """Assert an error is raised if a prime requirement is missing"""
     r = MagicMock(spec=Reparameterisation)
     r.parameters = ["y"]
-    r.requires = []
-    r.input_parameters = ["y"]
-    r.output_parameters = ["y"]
-    r.prime_requires = ["x_prime"]
+    r.input_parameters = ["y", "x_prime"]
+    r.output_parameters = ["y_prime"]
+    r.x_output_parameters = ["y"]
+    r.resolve_forward_input_spaces.return_value = ["x_prime"]
 
     reparam.parameters = ["y"]
     reparam.prime_parameters = ["y_prime"]
@@ -289,20 +285,26 @@ def test_base_add_reparameterisation_missing_prime_requirements(reparam):
 
     with pytest.raises(RuntimeError) as excinfo:
         CombinedReparameterisation._add_reparameterisation(reparam, r)
-    assert "Missing prime requirement(s)" in str(excinfo.value)
+    assert "missing requirement(s)" in str(excinfo.value)
 
 
 def test_check_order_valid(reparam, LightReparam):
     """Assert no error is raised if the order is valid"""
     d = dict(
         a=LightReparam(
-            "a", parameters=["x"], requires=[], inverse_requires=[]
+            "a",
+            parameters=["x"],
+            inverse_input_parameters=[],
         ),
         b=LightReparam(
-            "b", parameters=["y"], requires=["x"], inverse_requires=["x"]
+            "b",
+            input_parameters=["y", "x"],
+            inverse_input_parameters=["x"],
         ),
         c=LightReparam(
-            "c", parameters=["z"], requires=["y"], inverse_requires=["y"]
+            "c",
+            input_parameters=["z", "y"],
+            inverse_input_parameters=["y"],
         ),
     )
     reparam.__getitem__.side_effect = d.__getitem__
@@ -315,13 +317,19 @@ def test_check_order_invalid(reparam, LightReparam):
     """Assert an error is raised if the order is invalid"""
     d = dict(
         a=LightReparam(
-            "a", parameters=["x"], requires=["z"], inverse_requires=["w"]
+            "a",
+            input_parameters=["x", "z"],
+            inverse_input_parameters=["w"],
         ),
         b=LightReparam(
-            "b", parameters=["y"], requires=[], inverse_requires=[]
+            "b",
+            parameters=["y"],
+            inverse_input_parameters=[],
         ),
         c=LightReparam(
-            "c", parameters=["z"], requires=["y"], inverse_requires=[]
+            "c",
+            input_parameters=["z", "y"],
+            inverse_input_parameters=[],
         ),
     )
     reparam.__getitem__.side_effect = d.__getitem__
@@ -336,18 +344,34 @@ def test_check_order_invalid(reparam, LightReparam):
 
 def test_update_bounds(reparam):
     """Assert update bounds calls the method for each reparam"""
-    x = [1, 2]
+    x = np.array([(1.0, 2.0)], dtype=[("x", "f8"), ("y", "f8")])
     # Angle doesn't have update bounds
     r1 = MagicMock(spec=Angle)
     # RescaleToBounds does have update bounds
     r2 = MagicMock(spec=RescaleToBounds)
-    reparam.values = MagicMock(return_value=[r1, r2])
+    r1.reparameterise.side_effect = lambda x, x_prime, log_j: (
+        x,
+        x_prime,
+        log_j,
+    )
+    r2.reparameterise.side_effect = lambda x, x_prime, log_j: (
+        x,
+        x_prime,
+        log_j,
+    )
+    reparam.to_prime_order = ["r1", "r2"]
+    reparam.__getitem__.side_effect = {"r1": r1, "r2": r2}.__getitem__
+    reparam.prime_parameters = ["x_prime"]
 
     assert not hasattr(r1, "update_bounds")
 
     CombinedReparameterisation.update_bounds(reparam, x)
 
-    r2.update_bounds.assert_called_once_with(x)
+    r2.update_bounds.assert_called_once()
+    assert_structured_arrays_equal(r2.update_bounds.call_args.args[0], x)
+    assert (
+        "x_prime" in r2.update_bounds.call_args.kwargs["x_prime"].dtype.names
+    )
 
 
 def test_reset_inversion(reparam):
@@ -369,14 +393,30 @@ def test_update(reparam):
     """Assert update calls the update method for all reparameterisations."""
     r1 = MagicMock(spec=Angle)
     r2 = MagicMock(spec=RescaleToBounds)
-    reparam.values = MagicMock(return_value=[r1, r2])
+    r1.reparameterise.side_effect = lambda x, x_prime, log_j: (
+        x,
+        x_prime,
+        log_j,
+    )
+    r2.reparameterise.side_effect = lambda x, x_prime, log_j: (
+        x,
+        x_prime,
+        log_j,
+    )
+    reparam.to_prime_order = ["r1", "r2"]
+    reparam.__getitem__.side_effect = {"r1": r1, "r2": r2}.__getitem__
+    reparam.prime_parameters = ["x_prime"]
 
     x = np.array((1, 2), dtype=[("x", "f8"), ("y", "f8")])
 
     CombinedReparameterisation.update(reparam, x)
 
-    r1.update.assert_called_once_with(x)
-    r2.update.assert_called_once_with(x)
+    r1.update.assert_called_once()
+    r2.update.assert_called_once()
+    assert_structured_arrays_equal(r1.update.call_args.args[0], x)
+    assert_structured_arrays_equal(r2.update.call_args.args[0], x)
+    assert "x_prime" in r1.update.call_args.kwargs["x_prime"].dtype.names
+    assert "x_prime" in r2.update.call_args.kwargs["x_prime"].dtype.names
 
 
 def test_log_prior(reparam):

--- a/tests/test_reparameterisations/test_discrete.py
+++ b/tests/test_reparameterisations/test_discrete.py
@@ -10,7 +10,12 @@ from nessai.utils.testing import assert_structured_arrays_equal
 
 @pytest.fixture
 def reparam(rng):
-    return create_autospec(Dequantise, rng=rng)
+    r = create_autospec(
+        Dequantise(parameters="a", prior_bounds={"a": [0, 1]}, rng=rng),
+        instance=True,
+    )
+    r.rng = rng
+    return r
 
 
 def test_dequantise_init():
@@ -47,7 +52,7 @@ def test_dequantise_integration():
         rescale_bounds=[0, 1],
     )
 
-    x_prime = empty_structured_array(len(x), names=reparam.prime_parameters)
+    x_prime = empty_structured_array(len(x), names=reparam.output_parameters)
     x_out, x_prime, log_j_out = reparam.reparameterise(
         x, x_prime, np.zeros(len(x))
     )

--- a/tests/test_reparameterisations/test_null.py
+++ b/tests/test_reparameterisations/test_null.py
@@ -17,7 +17,7 @@ def test_invertiblity():
     reparam = NullReparameterisation(parameters=["x", "y"])
     n = 100
     x = numpy_array_to_live_points(np.random.rand(n, 2), reparam.parameters)
-    x_prime = empty_structured_array(n, names=reparam.prime_parameters)
+    x_prime = empty_structured_array(n, names=reparam.output_parameters)
     log_j = 0
 
     x_re, x_prime_re, log_j_re = reparam.reparameterise(x, x_prime, log_j)

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -13,7 +13,7 @@ from nessai.livepoint import (
     get_dtype,
     numpy_array_to_live_points,
 )
-from nessai.reparameterisations import RescaleToBounds
+from nessai.reparameterisations import Reparameterisation, RescaleToBounds
 from nessai.utils.testing import assert_structured_arrays_equal
 
 # Tolerances for assert_allclose
@@ -23,8 +23,20 @@ rtol = 1e-15
 
 @pytest.fixture
 def reparam(rng):
-    r = create_autospec(RescaleToBounds, rng=rng)
-    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    r = create_autospec(
+        RescaleToBounds(parameters="x", prior_bounds={"x": [0, 1]}, rng=rng),
+        instance=True,
+    )
+    r._format_parameters = lambda x: (
+        x.copy() if isinstance(x, list) else ([] if x is None else [x])
+    )
+    r.get_parameter_value = Reparameterisation.get_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.set_parameter_value = Reparameterisation.set_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.rng = rng
     return r
 
 
@@ -42,7 +54,7 @@ def reparameterisation(model):
 def is_invertible(model, n=100):
     def test_invertibility(reparam, model=model, atol=1e-15, rtol=1e-15):
         x = model.new_point(N=n)
-        x_prime = empty_structured_array(n, names=reparam.prime_parameters)
+        x_prime = empty_structured_array(n, names=reparam.output_parameters)
         log_j = np.zeros(n)
         assert x.size == x_prime.size
 
@@ -80,10 +92,9 @@ def is_invertible(model, n=100):
         ({"x": [0, 1], "y": [-1, 1]}, {"x": [0, 1], "y": [-1, 1]}),
     ],
 )
-def test_rescale_bounds_config(reparam, input, expected_value):
+def test_rescale_bounds_config(input, expected_value):
     """Assert the rescale bounds are set correctly."""
-    RescaleToBounds.__init__(
-        reparam,
+    reparam = RescaleToBounds(
         parameters=["x", "y"],
         prior_bounds={"x": [-1, 1], "y": [0, 1]},
         rescale_bounds=input,
@@ -127,10 +138,9 @@ def test_rescale_bounds_incorrect_type(reparam):
         (None, False),
     ],
 )
-def test_boundary_inversion_config(reparam, input, expected_value):
+def test_boundary_inversion_config(input, expected_value):
     """Assert the boundary inversion dict is set correctly"""
-    RescaleToBounds.__init__(
-        reparam,
+    reparam = RescaleToBounds(
         parameters=["x", "y"],
         prior_bounds={"x": [0, 1], "y": [0, 1]},
         boundary_inversion=input,
@@ -214,7 +224,7 @@ def test_update(reparam):
     x = np.array((1, 2), dtype=[("x", "f8"), ("y", "f8")])
     RescaleToBounds.update(reparam, x)
     reparam.reset_inversion.assert_called_once()
-    reparam.update_bounds.assert_called_once_with(x)
+    reparam.update_bounds.assert_called_once_with(x, x_prime=None)
 
 
 def test_reset(reparam):
@@ -280,7 +290,7 @@ def test_reparameterise(reparam):
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam.boundary_inversion = False
     x = numpy_array_to_live_points(
@@ -290,7 +300,7 @@ def test_reparameterise(reparam):
         [
             2,
         ],
-        dtype=get_dtype(reparam.prime_parameters),
+        dtype=get_dtype(reparam.output_parameters),
     )
     x_prime_val = np.array([0.0, 0.5])
     log_j = np.zeros(x.size)
@@ -320,11 +330,11 @@ def test_inverse_reparameterise(reparam):
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam.boundary_inversion = False
     x_prime = numpy_array_to_live_points(
-        np.array([(1.0,), (2.0,)]), reparam.prime_parameters
+        np.array([(1.0,), (2.0,)]), reparam.output_parameters
     )
     x_in = np.zeros(
         [
@@ -357,20 +367,20 @@ def test_reparameterise_boundary_inversion(reparam):
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam.boundary_inversion = {"x": "split"}
     x = numpy_array_to_live_points(
         np.array([(1.0,), (2.0,)]), reparam.parameters
     )
     inversion_out = numpy_array_to_live_points(
-        np.array([(-1.0,), (-2.0,), (1.0,), (2.0,)]), reparam.prime_parameters
+        np.array([(-1.0,), (-2.0,), (1.0,), (2.0,)]), reparam.output_parameters
     )
     x_prime_in = np.zeros(
         [
             2,
         ],
-        dtype=get_dtype(reparam.prime_parameters),
+        dtype=get_dtype(reparam.output_parameters),
     )
     log_j = np.zeros(x.size)
 
@@ -418,11 +428,11 @@ def test_inverse_reparameterise_boundary_inversion(reparam):
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x"]
+    reparam.output_parameters = ["x"]
     reparam.offsets = {"x": 1.0}
     reparam.boundary_inversion = {"x": "split"}
     x_prime = numpy_array_to_live_points(
-        np.array([(-1.0,), (2.0,)]), reparam.prime_parameters
+        np.array([(-1.0,), (2.0,)]), reparam.output_parameters
     )
     inversion_out = numpy_array_to_live_points(
         np.array([(1.0,), (2.0,)]), reparam.parameters
@@ -470,7 +480,7 @@ def test_reparameterise_pre_post_rescaling(reparam):
     reparam.has_pre_rescaling = True
     reparam.has_post_rescaling = True
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 0.0}
     reparam.boundary_inversion = {}
     x = numpy_array_to_live_points(
@@ -480,7 +490,7 @@ def test_reparameterise_pre_post_rescaling(reparam):
         [
             2,
         ],
-        dtype=get_dtype(reparam.prime_parameters),
+        dtype=get_dtype(reparam.output_parameters),
     )
     x_prime_val = np.array([4.0, 8.0])
     log_j = np.zeros(x.size)
@@ -523,11 +533,11 @@ def test_inverse_reparameterise_pre_post_rescaling(reparam):
     reparam.has_pre_rescaling = True
     reparam.has_post_rescaling = True
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 0.0}
     reparam.boundary_inversion = {}
     x_prime = numpy_array_to_live_points(
-        np.array([(1.0,), (2.0,)]), reparam.prime_parameters
+        np.array([(1.0,), (2.0,)]), reparam.output_parameters
     )
     x_in = np.zeros(
         [
@@ -575,7 +585,7 @@ def test_inverse_reparameterise_pre_post_rescaling(reparam):
 def test_apply_inversion_detect_edge(reparam):
     """Assert detect edge is called with the correct arguments"""
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": None}
     reparam.detect_edges_kwargs = {"allowed_bounds": ["lower"]}
@@ -605,7 +615,7 @@ def test_apply_inversion_detect_edge(reparam):
 def test_apply_inversion_not_applied(reparam):
     """Assert the apply inversion works correctly"""
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": False}
     reparam.bounds = {"x": [0, 5]}
@@ -645,7 +655,7 @@ def test_apply_inversion_split(reparam):
     Also tests "upper" setting.
     """
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": "upper"}
     reparam.bounds = {"x": [0, 5]}
@@ -702,7 +712,7 @@ def test_apply_inversion_duplicate(reparam, inv_type, compute_radius):
     This test also covers compute_radius=True
     """
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y"]
+    reparam.output_parameters = ["x_prime", "y"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": "lower"}
     reparam.bounds = {"x": [0, 5]}
@@ -755,7 +765,7 @@ def test_apply_inversion_duplicate(reparam, inv_type, compute_radius):
 def test_reverse_inversion(reparam):
     """Assert the reverse inversion works correctly"""
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": "upper"}
     reparam.bounds = {"x": [0, 5]}
@@ -793,7 +803,7 @@ def test_reverse_inversion(reparam):
 def test_reverse_inversion_not_applied(reparam):
     """Assert the reverse inversion works correctly"""
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.offsets = {"x": 1.0}
     reparam._edges = {"x": False}
     reparam.bounds = {"x": [0, 5]}

--- a/tests/test_reparameterisations/test_rescale_to_bounds.py
+++ b/tests/test_reparameterisations/test_rescale_to_bounds.py
@@ -23,7 +23,9 @@ rtol = 1e-15
 
 @pytest.fixture
 def reparam(rng):
-    return create_autospec(RescaleToBounds, rng=rng)
+    r = create_autospec(RescaleToBounds, rng=rng)
+    r._format_parameters = lambda x: x if isinstance(x, list) else [x]
+    return r
 
 
 @pytest.fixture()

--- a/tests/test_reparameterisations/test_scale_and_shift.py
+++ b/tests/test_reparameterisations/test_scale_and_shift.py
@@ -10,14 +10,24 @@ import pytest
 from scipy import stats
 
 from nessai.livepoint import empty_structured_array, numpy_array_to_live_points
-from nessai.reparameterisations import ScaleAndShift
+from nessai.reparameterisations import Reparameterisation, ScaleAndShift
 from nessai.utils.rescaling import gaussian_cdf, inverse_gaussian_cdf
 from nessai.utils.testing import assert_structured_arrays_equal
 
 
 @pytest.fixture()
 def reparam():
-    return create_autospec(ScaleAndShift)
+    r = create_autospec(
+        ScaleAndShift(parameters="x", scale=1.0, prior_bounds={"x": [0, 1]}),
+        instance=True,
+    )
+    r.get_parameter_value = Reparameterisation.get_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.set_parameter_value = Reparameterisation.set_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    return r
 
 
 @pytest.fixture()
@@ -70,8 +80,7 @@ def test_init_scale_and_shift(reparam, parameters, prior_bounds):
 
 def test_init_estimate(reparam, parameters, prior_bounds):
     """Assert estimate shift and scale are enabled"""
-    ScaleAndShift.__init__(
-        reparam,
+    reparam = ScaleAndShift(
         parameters=parameters,
         prior_bounds=prior_bounds,
         estimate_scale=True,
@@ -90,14 +99,14 @@ def test_init_estimate(reparam, parameters, prior_bounds):
 def test_reparameterise_scale(reparam, n):
     """Test the reparameterise method"""
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = None
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     x = numpy_array_to_live_points(np.ones((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        np.zeros((n, 2)), reparam.prime_parameters
+        np.zeros((n, 2)), reparam.output_parameters
     )
     log_j = np.zeros(n)
 
@@ -115,14 +124,14 @@ def test_reparameterise_scale(reparam, n):
 def test_reparameterise_scale_and_shift(reparam, n):
     """Test the reparameterise method"""
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 2.0, "y": -2.0}
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     x = numpy_array_to_live_points(np.ones((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        np.zeros((n, 2)), reparam.prime_parameters
+        np.zeros((n, 2)), reparam.output_parameters
     )
     log_j = np.zeros(n)
 
@@ -139,7 +148,7 @@ def test_reparameterise_scale_and_shift(reparam, n):
 @pytest.mark.parametrize("n", [1, 2])
 def test_reparameterise_scale_and_shift_pre_rescaling(reparam, n):
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 1.0, "y": -2.0}
     reparam.has_pre_rescaling = True
@@ -147,7 +156,7 @@ def test_reparameterise_scale_and_shift_pre_rescaling(reparam, n):
     reparam.pre_rescaling = inverse_gaussian_cdf
     reparam.pre_rescaling_inv = gaussian_cdf
     x = numpy_array_to_live_points(0.2 * np.ones((n, 2)), reparam.parameters)
-    x_prime = empty_structured_array(n, names=reparam.prime_parameters)
+    x_prime = empty_structured_array(n, names=reparam.output_parameters)
     log_j = np.zeros(n)
 
     x_out, x_prime_out, log_j_out = ScaleAndShift.reparameterise(
@@ -168,7 +177,7 @@ def test_reparameterise_scale_post_rescaling(reparam, n):
     """Test the reparameterise method"""
 
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 2.0, "y": -2.0}
     reparam.has_pre_rescaling = False
@@ -177,7 +186,7 @@ def test_reparameterise_scale_post_rescaling(reparam, n):
     reparam.post_rescaling_inv = inverse_gaussian_cdf
     x = numpy_array_to_live_points(np.ones((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        np.zeros((n, 2)), reparam.prime_parameters
+        np.zeros((n, 2)), reparam.output_parameters
     )
     log_j = np.zeros(n)
 
@@ -201,7 +210,7 @@ def test_reparameterise_scale_overflow(reparam, scale):
     Checks precision to 14 decimal places.
     """
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.scale = {"x": scale}
     reparam.shift = None
     reparam.has_pre_rescaling = False
@@ -211,7 +220,7 @@ def test_reparameterise_scale_overflow(reparam, scale):
         scale * x_array[:, np.newaxis], reparam.parameters
     )
     x_prime = numpy_array_to_live_points(
-        np.ones((x_array.size, 1)), reparam.prime_parameters
+        np.ones((x_array.size, 1)), reparam.output_parameters
     )
     log_j = np.zeros(x.size)
 
@@ -229,14 +238,14 @@ def test_reparameterise_scale_overflow(reparam, scale):
 def test_inverse_reparameterise_scale(reparam, n):
     """Test the inverse reparameterise method"""
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = None
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     x = numpy_array_to_live_points(np.zeros((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        np.ones((n, 2)), reparam.prime_parameters
+        np.ones((n, 2)), reparam.output_parameters
     )
     x_prime["x_prime"] *= -1
     log_j = np.zeros(n)
@@ -257,7 +266,7 @@ def test_inverse_reparameterise_scale_overflow(reparam, scale):
     Test the inverse_reparameterise method with very small and large scales.
     """
     reparam.parameters = ["x"]
-    reparam.prime_parameters = ["x_prime"]
+    reparam.output_parameters = ["x_prime"]
     reparam.scale = {"x": scale}
     reparam.shift = None
     reparam.has_pre_rescaling = False
@@ -267,7 +276,7 @@ def test_inverse_reparameterise_scale_overflow(reparam, scale):
         np.ones((x_array.size, 1)), reparam.parameters
     )
     x_prime = numpy_array_to_live_points(
-        x_array[:, np.newaxis], reparam.prime_parameters
+        x_array[:, np.newaxis], reparam.output_parameters
     )
     log_j = np.zeros(x.size)
 
@@ -283,14 +292,14 @@ def test_inverse_reparameterise_scale_overflow(reparam, scale):
 def test_inverse_reparameterise_scale_and_shift(reparam, n):
     """Test the inverse reparameterise method"""
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 1.0, "y": -2.0}
     reparam.has_pre_rescaling = False
     reparam.has_post_rescaling = False
     x = numpy_array_to_live_points(np.zeros((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        np.ones((n, 2)), reparam.prime_parameters
+        np.ones((n, 2)), reparam.output_parameters
     )
     x_prime["x_prime"] *= -1
     log_j = np.zeros(n)
@@ -308,7 +317,7 @@ def test_inverse_reparameterise_scale_and_shift(reparam, n):
 @pytest.mark.parametrize("n", [1, 2])
 def test_inverse_reparameterise_scale_and_shift_pre_rescaling(reparam, n):
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 1.0, "y": -2.0}
     reparam.has_pre_rescaling = True
@@ -317,7 +326,7 @@ def test_inverse_reparameterise_scale_and_shift_pre_rescaling(reparam, n):
     reparam.pre_rescaling_inv = gaussian_cdf
     x = empty_structured_array(n, names=reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        2 * np.ones((n, 2)), reparam.prime_parameters
+        2 * np.ones((n, 2)), reparam.output_parameters
     )
     log_j = np.zeros(n)
 
@@ -334,7 +343,7 @@ def test_inverse_reparameterise_scale_and_shift_pre_rescaling(reparam, n):
 def test_inverse_reparameterise_scale_and_shift_post_rescaling(reparam, n):
     """Test the inverse reparameterise method"""
     reparam.parameters = ["x", "y"]
-    reparam.prime_parameters = ["x_prime", "y_prime"]
+    reparam.output_parameters = ["x_prime", "y_prime"]
     reparam.scale = {"x": -2.0, "y": 4.0}
     reparam.shift = {"x": 1.0, "y": -2.0}
     reparam.has_pre_rescaling = False
@@ -343,7 +352,7 @@ def test_inverse_reparameterise_scale_and_shift_post_rescaling(reparam, n):
     reparam.post_rescaling_inv = inverse_gaussian_cdf
     x = numpy_array_to_live_points(np.zeros((n, 2)), reparam.parameters)
     x_prime = numpy_array_to_live_points(
-        stats.norm.cdf(1) * np.ones((n, 2)), reparam.prime_parameters
+        stats.norm.cdf(1) * np.ones((n, 2)), reparam.output_parameters
     )
     log_j = np.zeros(n)
 

--- a/tests/test_reparameterisations/test_to_cartesian.py
+++ b/tests/test_reparameterisations/test_to_cartesian.py
@@ -9,13 +9,20 @@ import numpy as np
 import pytest
 
 from nessai.livepoint import numpy_array_to_live_points
-from nessai.reparameterisations import ToCartesian
+from nessai.reparameterisations import Reparameterisation, ToCartesian
 from nessai.utils.testing import assert_structured_arrays_equal
 
 
 @pytest.fixture
 def reparam(rng):
-    return create_autospec(ToCartesian, rng=rng)
+    r = create_autospec(ToCartesian, rng=rng)
+    r.get_parameter_value = Reparameterisation.get_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    r.set_parameter_value = Reparameterisation.set_parameter_value.__get__(
+        r, Reparameterisation
+    )
+    return r
 
 
 @pytest.fixture

--- a/tests/test_reparameterisations/test_utils.py
+++ b/tests/test_reparameterisations/test_utils.py
@@ -1,0 +1,221 @@
+import pytest
+
+from nessai.reparameterisations.utils import (
+    build_reparameterisation_spec,
+    normalise_reparameterisation_spec,
+    parse_reparameterisations,
+    resolve_reparameterisation_parameters,
+)
+
+
+@pytest.mark.parametrize(
+    "spec_cfg",
+    [
+        {"reparameterisation": "scale", "parameters": ["y"], "foo": 1},
+        {"reparameterisation": "scale", "foo": 1},
+    ],
+)
+def test_build_reparameterisation_spec_model_key(spec_cfg):
+    key = "y"
+    spec_index = 0
+    model_names = ["x", "y", "z"]
+    spec = build_reparameterisation_spec(
+        key, spec_cfg, spec_index, model_names
+    )
+    assert spec.source_key == key
+    assert spec.reparameterisation == "scale"
+    assert spec.parameters == ["y"]
+    assert spec.kwargs == {"foo": 1}
+
+
+def test_build_reparameterisation_spec_reparam_key():
+    key = "scale"
+    spec_cfg = {"parameters": ["y"], "foo": 1}
+    spec_index = 0
+    model_names = ["x", "y", "z"]
+    spec = build_reparameterisation_spec(
+        key, spec_cfg, spec_index, model_names
+    )
+    assert spec.source_key == key
+    assert spec.reparameterisation == "scale"
+    assert spec.parameters == ["y"]
+    assert spec.kwargs == {"foo": 1}
+
+
+def test_normalise_reparameterisation_spec_str():
+    key = "x"
+    spec_cfg = "scale"
+    spec_list = normalise_reparameterisation_spec(key, spec_cfg, [key])
+    assert spec_list == [spec_cfg]
+
+
+def test_normalise_reparameterisation_spec_dict():
+    key = "x"
+    spec_cfg = {"reparameterisation": "scale", "parameters": ["y"], "foo": 1}
+    spec = normalise_reparameterisation_spec(key, spec_cfg, [key])
+    assert spec == [spec_cfg]
+
+
+def test_normalise_reparameterisation_spec_list():
+    key = "x"
+    spec_cfg = ["y", "z"]
+    spec_list = normalise_reparameterisation_spec(key, spec_cfg, [key])
+    assert spec_list == spec_cfg
+
+
+def test_normalise_reparameterisation_spec_invalid():
+    key = "x"
+    spec_cfg = 1
+    with pytest.raises(
+        TypeError,
+        match="Unknown config type for: x. Expected str, dict or list, received instance of <class 'int'>.",
+    ):
+        normalise_reparameterisation_spec(key, spec_cfg, [key])
+
+
+def test_parse_reparameterisations_dict():
+    reparameterisations = {
+        "scale": {"parameters": ["w"]},
+        "x": "scale",
+        "y": {
+            "reparameterisation": "log",
+            "parameters": ["y_prime"],
+            "foo": 1,
+        },
+        "log": "z",
+    }
+    model_names = ["w", "x", "y", "z"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+
+    assert len(specs) == 4
+
+    spec_w = specs[0]
+    assert spec_w.source_key == "scale"
+    assert spec_w.reparameterisation == "scale"
+    assert spec_w.parameters == ["w"]
+    assert spec_w.kwargs == {}
+
+    spec_x = specs[1]
+    assert spec_x.source_key == "x"
+    assert spec_x.reparameterisation == "scale"
+    assert spec_x.parameters == ["x"]
+    assert spec_x.kwargs == {}
+
+    spec_y = specs[2]
+    assert spec_y.source_key == "y"
+    assert spec_y.reparameterisation == "log"
+    assert spec_y.parameters == ["y", "y_prime"]
+    assert spec_y.kwargs == {"foo": 1}
+
+    spec_z = specs[3]
+    assert spec_z.source_key == "log"
+    assert spec_z.reparameterisation == "log"
+    assert spec_z.parameters == ["z"]
+    assert spec_z.kwargs == {}
+
+
+def test_parse_reparameterisations_dict_reparam_list():
+    reparameterisations = {"scale": ["x", "y", "z"]}
+    model_names = ["x", "y", "z"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+
+    assert len(specs) == 1
+
+    spec_x = specs[0]
+    assert spec_x.source_key == "scale"
+    assert spec_x.reparameterisation == "scale"
+    assert spec_x.parameters == ["x", "y", "z"]
+    assert spec_x.kwargs == {}
+
+
+def test_parse_reparameterisations_str():
+    reparameterisations = "scale"
+    model_names = ["x", "y", "z"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+
+    assert len(specs) == 1
+
+    spec_x = specs[0]
+    assert spec_x.source_key == "scale"
+    assert spec_x.reparameterisation == "scale"
+    assert spec_x.parameters == ["x", "y", "z"]
+    assert spec_x.kwargs == {}
+
+
+def test_parse_reparameterisations_none():
+    reparameterisations = None
+    model_names = ["x", "y", "z"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+    assert len(specs) == 0
+
+
+def test_parse_reparameterisations_regex():
+    reparameterisations = {"scale": {"parameters": ["x.*"]}}
+    model_names = ["x_0", "x_1", "y"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+
+    assert len(specs) == 1
+
+    spec_x = specs[0]
+    assert spec_x.source_key == "scale"
+    assert spec_x.reparameterisation == "scale"
+    # Match happens later in resolve_reparameterisation_parameters
+    assert spec_x.parameters == ["x.*"]
+    assert spec_x.kwargs == {}
+
+
+def test_parse_reparameterisations_chained():
+    reparameterisations = {
+        "x": [
+            {
+                "reparameterisation": "rescaletobounds",
+                "prime_parameters": ["x_01"],
+            },
+            {"reparameterisation": "log", "prime_requires": ["x_01"]},
+        ]
+    }
+    model_names = ["x"]
+    specs = parse_reparameterisations(reparameterisations, model_names)
+    assert len(specs) == 2
+    assert specs[0].reparameterisation == "rescaletobounds"
+    assert specs[1].reparameterisation == "log"
+    assert specs[0].parameters == ["x"]
+    assert specs[1].parameters == ["x"]
+    assert specs[0].spec_index == 0
+    assert specs[1].spec_index == 1
+
+
+def test_resolve_reparameterisation_parameters():
+    parameters = ["x.*"]
+    available_parameters = ["x_0", "x_1", "y"]
+    resolved = resolve_reparameterisation_parameters(
+        parameters, available_parameters
+    )
+    assert resolved == ["x_0", "x_1"]
+
+
+def test_resolve_reparameterisation_parameters_no_match():
+    parameters = ["z.*"]
+    available_parameters = ["x_0", "x_1", "y"]
+    resolved = resolve_reparameterisation_parameters(
+        parameters, available_parameters
+    )
+    assert resolved == []
+
+
+def test_resolve_reparameterisation_parameters_list():
+    parameters = ["x_0", "x_1"]
+    available_parameters = ["x_0", "x_1", "y"]
+    resolved = resolve_reparameterisation_parameters(
+        parameters, available_parameters
+    )
+    assert resolved == ["x_0", "x_1"]
+
+
+def test_resolve_reparameterisation_parameters_str():
+    parameters = "x_0"
+    available_parameters = ["x_0", "x_1", "y"]
+    resolved = resolve_reparameterisation_parameters(
+        parameters, available_parameters
+    )
+    assert resolved == ["x_0"]

--- a/tests/test_reparameterisations/test_utils.py
+++ b/tests/test_reparameterisations/test_utils.py
@@ -42,6 +42,39 @@ def test_build_reparameterisation_spec_reparam_key():
     assert spec.kwargs == {"foo": 1}
 
 
+def test_build_reparameterisation_spec_model_key_missing_reparameterisation():
+    with pytest.raises(
+        RuntimeError, match="No reparameterisation found for x"
+    ):
+        build_reparameterisation_spec("x", {"scale": 2.0}, 0, ["x"])
+
+
+@pytest.mark.parametrize(
+    "parameters, expected",
+    [("y", ["x", "y"]), (None, [])],
+)
+def test_build_reparameterisation_spec_model_key_parameter_variants(
+    parameters, expected
+):
+    spec = build_reparameterisation_spec(
+        "x",
+        {"reparameterisation": "scale", "parameters": parameters},
+        0,
+        ["x"],
+    )
+    assert spec.parameters == expected
+
+
+def test_build_reparameterisation_spec_reparam_key_list():
+    spec = build_reparameterisation_spec("scale", ["x", "y"], 0, ["x", "y"])
+    assert spec.parameters == ["x", "y"]
+
+
+def test_build_reparameterisation_spec_reparam_key_invalid():
+    with pytest.raises(TypeError, match="Unknown config type for: scale"):
+        build_reparameterisation_spec("scale", 1, 0, ["x"])
+
+
 def test_normalise_reparameterisation_spec_str():
     key = "x"
     spec_cfg = "scale"

--- a/tests/test_reparameterisations/test_utils.py
+++ b/tests/test_reparameterisations/test_utils.py
@@ -24,7 +24,7 @@ def test_build_reparameterisation_spec_model_key(spec_cfg):
     )
     assert spec.source_key == key
     assert spec.reparameterisation == "scale"
-    assert spec.parameters == ["y"]
+    assert spec.input_parameters == ["y"]
     assert spec.kwargs == {"foo": 1}
 
 
@@ -38,7 +38,7 @@ def test_build_reparameterisation_spec_reparam_key():
     )
     assert spec.source_key == key
     assert spec.reparameterisation == "scale"
-    assert spec.parameters == ["y"]
+    assert spec.input_parameters == ["y"]
     assert spec.kwargs == {"foo": 1}
 
 
@@ -50,8 +50,35 @@ def test_build_reparameterisation_spec_model_key_missing_reparameterisation():
 
 
 @pytest.mark.parametrize(
+    "key, cfg, expected_kwargs",
+    [
+        (
+            "x",
+            {"reparameterisation": "scale", "prime_parameters": ["x_prime"]},
+            {"prime_parameters": ["x_prime"]},
+        ),
+        (
+            "scale",
+            {"inverse_input_parameters": ["x"]},
+            {"inverse_input_parameters": ["x"]},
+        ),
+        (
+            "scale",
+            {"persistent_parameters": ["x_prime"]},
+            {"persistent_parameters": ["x_prime"]},
+        ),
+    ],
+)
+def test_build_reparameterisation_spec_preserves_extra_keys(
+    key, cfg, expected_kwargs
+):
+    spec = build_reparameterisation_spec(key, cfg, 0, ["x"])
+    assert spec.kwargs == expected_kwargs
+
+
+@pytest.mark.parametrize(
     "parameters, expected",
-    [("y", ["x", "y"]), (None, [])],
+    [("y", ["y"]), (None, [])],
 )
 def test_build_reparameterisation_spec_model_key_parameter_variants(
     parameters, expected
@@ -62,12 +89,12 @@ def test_build_reparameterisation_spec_model_key_parameter_variants(
         0,
         ["x"],
     )
-    assert spec.parameters == expected
+    assert spec.input_parameters == expected
 
 
 def test_build_reparameterisation_spec_reparam_key_list():
     spec = build_reparameterisation_spec("scale", ["x", "y"], 0, ["x", "y"])
-    assert spec.parameters == ["x", "y"]
+    assert spec.input_parameters == ["x", "y"]
 
 
 def test_build_reparameterisation_spec_reparam_key_invalid():
@@ -125,25 +152,25 @@ def test_parse_reparameterisations_dict():
     spec_w = specs[0]
     assert spec_w.source_key == "scale"
     assert spec_w.reparameterisation == "scale"
-    assert spec_w.parameters == ["w"]
+    assert spec_w.input_parameters == ["w"]
     assert spec_w.kwargs == {}
 
     spec_x = specs[1]
     assert spec_x.source_key == "x"
     assert spec_x.reparameterisation == "scale"
-    assert spec_x.parameters == ["x"]
+    assert spec_x.input_parameters == ["x"]
     assert spec_x.kwargs == {}
 
     spec_y = specs[2]
     assert spec_y.source_key == "y"
     assert spec_y.reparameterisation == "log"
-    assert spec_y.parameters == ["y", "y_prime"]
+    assert spec_y.input_parameters == ["y_prime"]
     assert spec_y.kwargs == {"foo": 1}
 
     spec_z = specs[3]
     assert spec_z.source_key == "log"
     assert spec_z.reparameterisation == "log"
-    assert spec_z.parameters == ["z"]
+    assert spec_z.input_parameters == ["z"]
     assert spec_z.kwargs == {}
 
 
@@ -157,7 +184,7 @@ def test_parse_reparameterisations_dict_reparam_list():
     spec_x = specs[0]
     assert spec_x.source_key == "scale"
     assert spec_x.reparameterisation == "scale"
-    assert spec_x.parameters == ["x", "y", "z"]
+    assert spec_x.input_parameters == ["x", "y", "z"]
     assert spec_x.kwargs == {}
 
 
@@ -171,7 +198,7 @@ def test_parse_reparameterisations_str():
     spec_x = specs[0]
     assert spec_x.source_key == "scale"
     assert spec_x.reparameterisation == "scale"
-    assert spec_x.parameters == ["x", "y", "z"]
+    assert spec_x.input_parameters == ["x", "y", "z"]
     assert spec_x.kwargs == {}
 
 
@@ -193,7 +220,7 @@ def test_parse_reparameterisations_regex():
     assert spec_x.source_key == "scale"
     assert spec_x.reparameterisation == "scale"
     # Match happens later in resolve_reparameterisation_parameters
-    assert spec_x.parameters == ["x.*"]
+    assert spec_x.input_parameters == ["x.*"]
     assert spec_x.kwargs == {}
 
 
@@ -202,9 +229,9 @@ def test_parse_reparameterisations_chained():
         "x": [
             {
                 "reparameterisation": "rescaletobounds",
-                "prime_parameters": ["x_01"],
+                "output_parameters": ["x_01"],
             },
-            {"reparameterisation": "log", "prime_requires": ["x_01"]},
+            {"reparameterisation": "log", "input_parameters": ["x_01"]},
         ]
     }
     model_names = ["x"]
@@ -212,8 +239,8 @@ def test_parse_reparameterisations_chained():
     assert len(specs) == 2
     assert specs[0].reparameterisation == "rescaletobounds"
     assert specs[1].reparameterisation == "log"
-    assert specs[0].parameters == ["x"]
-    assert specs[1].parameters == ["x"]
+    assert specs[0].input_parameters == ["x"]
+    assert specs[1].input_parameters == ["x_01"]
     assert specs[0].spec_index == 0
     assert specs[1].spec_index == 1
 

--- a/tests/test_utils/test_sorting_utils.py
+++ b/tests/test_utils/test_sorting_utils.py
@@ -1,6 +1,6 @@
 """Tests for the sorting utilities"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 import pytest
@@ -15,6 +15,22 @@ class Reparameterisation:
     name: str
     parameters: List[str]
     requires: List[str]
+    auxiliary_parameters: List[str] = field(default_factory=list)
+    prime_parameters: List[str] = field(default_factory=list)
+    prime_requires: List[str] = field(default_factory=list)
+    inverse_requires: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.prime_parameters:
+            self.prime_parameters = [p + "_prime" for p in self.parameters]
+
+    @property
+    def output_parameters(self):
+        return self.parameters + self.auxiliary_parameters
+
+    @property
+    def input_parameters(self):
+        return list(dict.fromkeys(self.parameters + self.requires))
 
 
 def test_sorting():
@@ -23,7 +39,9 @@ def test_sorting():
     r1 = Reparameterisation("2", ["b"], requires=["c"])
     r2 = Reparameterisation("3", ["c"], requires=[])
 
-    out = sort_reparameterisations([r0, r1, r2])
+    out = sort_reparameterisations(
+        [r0, r1, r2], existing_parameters=["a", "b", "c"]
+    )
     print([o.name for o in out])
     assert out == [r2, r1, r0]
 
@@ -34,9 +52,11 @@ def test_sorting_existing():
     r1 = Reparameterisation("2", ["b"], requires=[])
     r2 = Reparameterisation("3", ["c"], requires=["d"])
 
-    out = sort_reparameterisations([r0, r1, r2], existing_parameters=["d"])
+    out = sort_reparameterisations(
+        [r0, r1, r2], existing_parameters=["a", "b", "c", "d"]
+    )
     print([o.name for o in out])
-    assert out == [r1, r2, r0]
+    assert out == [r1, r0, r2]
 
 
 def test_sorting_error():
@@ -44,4 +64,46 @@ def test_sorting_error():
     r0 = Reparameterisation("1", ["a"], requires=[])
     r1 = Reparameterisation("2", ["b"], requires=["c"])
     with pytest.raises(ValueError, match=r".* are not known \(\['a', 'b'\]\)"):
-        sort_reparameterisations([r0, r1])
+        sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])
+
+
+def test_sorting_with_auxiliary_parameters():
+    r0 = Reparameterisation(
+        "1", ["a"], requires=[], auxiliary_parameters=["aux"]
+    )
+    r1 = Reparameterisation("2", ["b"], requires=["aux"])
+
+    out = sort_reparameterisations([r1, r0], existing_parameters=["a", "b"])
+
+    assert out == [r0, r1]
+
+
+def test_sorting_with_prime_requirements():
+    r0 = Reparameterisation("1", ["a"], requires=[], prime_parameters=["a_p"])
+    r1 = Reparameterisation(
+        "2",
+        ["b"],
+        requires=[],
+        prime_parameters=["b_p"],
+        prime_requires=["a_p"],
+    )
+
+    out = sort_reparameterisations([r1, r0], existing_parameters=["a", "b"])
+
+    assert out == [r0, r1]
+
+
+def test_sorting_with_unknown_prime_requirement():
+    r0 = Reparameterisation("1", ["a"], requires=[], prime_parameters=["a_p"])
+    r1 = Reparameterisation(
+        "2",
+        ["b"],
+        requires=[],
+        prime_parameters=["b_p"],
+        prime_requires=["c_p"],
+    )
+
+    with pytest.raises(
+        ValueError, match=r"requires prime parameters \['c_p'\]"
+    ):
+        sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])

--- a/tests/test_utils/test_sorting_utils.py
+++ b/tests/test_utils/test_sorting_utils.py
@@ -107,3 +107,33 @@ def test_sorting_with_unknown_prime_requirement():
         ValueError, match=r"requires prime parameters \['c_p'\]"
     ):
         sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])
+
+
+def test_sorting_retries_skipped_reparameterisations():
+    """Assert skipped reparameterisations are retried after one pass.
+
+    The two reparameterisations have the same initial sort weight, so the
+    first pass keeps the input order. `r0` is skipped because it depends on
+    an auxiliary parameter that is only added once `r1` has been applied.
+    """
+    r0 = Reparameterisation("1", ["a"], requires=["aux"])
+    r1 = Reparameterisation(
+        "2",
+        ["b"],
+        requires=["seed"],
+        auxiliary_parameters=["aux"],
+    )
+
+    out = sort_reparameterisations(
+        [r0, r1], existing_parameters=["a", "b", "seed"]
+    )
+
+    assert out == [r1, r0]
+
+
+def test_sorting_error_if_skipped_and_no_progress():
+    r0 = Reparameterisation("1", ["a"], requires=["b"])
+    r1 = Reparameterisation("2", ["b"], requires=["a"])
+
+    with pytest.raises(ValueError, match="Could not sort reparameterisations"):
+        sort_reparameterisations([r0, r1])

--- a/tests/test_utils/test_sorting_utils.py
+++ b/tests/test_utils/test_sorting_utils.py
@@ -13,31 +13,63 @@ class Reparameterisation:
     """A dataclass that mocks the Reparameterisation class"""
 
     name: str
-    parameters: List[str]
-    requires: List[str]
+    input_parameters: List[str]
+    output_parameters: List[str] = field(default_factory=list)
+    persistent_parameters: List[str] = field(default_factory=list)
     auxiliary_parameters: List[str] = field(default_factory=list)
-    prime_parameters: List[str] = field(default_factory=list)
-    prime_requires: List[str] = field(default_factory=list)
-    inverse_requires: List[str] = field(default_factory=list)
+    inverse_input_parameters: List[str] = field(default_factory=list)
 
     def __post_init__(self):
-        if not self.prime_parameters:
-            self.prime_parameters = [p + "_prime" for p in self.parameters]
+        if not self.output_parameters:
+            self.output_parameters = [
+                p + "_prime" for p in self.input_parameters
+            ]
+        self._x_input_parameters = []
+        self._x_prime_input_parameters = []
+        self._x_persistent_parameters = []
+        self._x_prime_persistent_parameters = []
 
     @property
-    def output_parameters(self):
-        return self.parameters + self.auxiliary_parameters
+    def parameters(self):
+        return self.input_parameters
 
     @property
-    def input_parameters(self):
-        return list(dict.fromkeys(self.parameters + self.requires))
+    def prime_parameters(self):
+        return self.output_parameters
+
+    @property
+    def x_input_parameters(self):
+        return self._x_input_parameters or self.input_parameters
+
+    @property
+    def x_prime_input_parameters(self):
+        return self._x_prime_input_parameters
+
+    @property
+    def x_output_parameters(self):
+        return self.x_input_parameters + self.auxiliary_parameters
+
+    def resolve_forward_input_spaces(self, parameters, prime_parameters):
+        self._x_input_parameters = []
+        self._x_prime_input_parameters = []
+        self._x_persistent_parameters = []
+        self._x_prime_persistent_parameters = []
+        missing = []
+        for p in self.input_parameters:
+            if p in parameters:
+                self._x_input_parameters.append(p)
+            elif p in prime_parameters:
+                self._x_prime_input_parameters.append(p)
+            else:
+                missing.append(p)
+        return missing
 
 
 def test_sorting():
     """Test a basic sorting example"""
-    r0 = Reparameterisation("1", ["a"], requires=["b", "c"])
-    r1 = Reparameterisation("2", ["b"], requires=["c"])
-    r2 = Reparameterisation("3", ["c"], requires=[])
+    r0 = Reparameterisation("1", ["a", "b", "c"], ["a_p"])
+    r1 = Reparameterisation("2", ["b", "c"], ["b_p"])
+    r2 = Reparameterisation("3", ["c"], ["c_p"])
 
     out = sort_reparameterisations(
         [r0, r1, r2], existing_parameters=["a", "b", "c"]
@@ -48,9 +80,9 @@ def test_sorting():
 
 def test_sorting_existing():
     """Test sorting when there are existing parameters"""
-    r0 = Reparameterisation("1", ["a"], requires=["c"])
-    r1 = Reparameterisation("2", ["b"], requires=[])
-    r2 = Reparameterisation("3", ["c"], requires=["d"])
+    r0 = Reparameterisation("1", ["a", "c"], ["a_p"])
+    r1 = Reparameterisation("2", ["b"], ["b_p"])
+    r2 = Reparameterisation("3", ["c", "d"], ["c_p"])
 
     out = sort_reparameterisations(
         [r0, r1, r2], existing_parameters=["a", "b", "c", "d"]
@@ -61,17 +93,15 @@ def test_sorting_existing():
 
 def test_sorting_error():
     """Assert an errors is raised if there is an invalid requirement"""
-    r0 = Reparameterisation("1", ["a"], requires=[])
-    r1 = Reparameterisation("2", ["b"], requires=["c"])
-    with pytest.raises(ValueError, match=r".* are not known \(\['a', 'b'\]\)"):
+    r0 = Reparameterisation("1", ["a"], ["a_p"])
+    r1 = Reparameterisation("2", ["b", "c"], ["b_p"])
+    with pytest.raises(ValueError, match=r"requires inputs \['c'\]"):
         sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])
 
 
 def test_sorting_with_auxiliary_parameters():
-    r0 = Reparameterisation(
-        "1", ["a"], requires=[], auxiliary_parameters=["aux"]
-    )
-    r1 = Reparameterisation("2", ["b"], requires=["aux"])
+    r0 = Reparameterisation("1", ["a"], ["a_p"], auxiliary_parameters=["aux"])
+    r1 = Reparameterisation("2", ["b", "aux"], ["b_p"])
 
     out = sort_reparameterisations([r1, r0], existing_parameters=["a", "b"])
 
@@ -79,14 +109,8 @@ def test_sorting_with_auxiliary_parameters():
 
 
 def test_sorting_with_prime_requirements():
-    r0 = Reparameterisation("1", ["a"], requires=[], prime_parameters=["a_p"])
-    r1 = Reparameterisation(
-        "2",
-        ["b"],
-        requires=[],
-        prime_parameters=["b_p"],
-        prime_requires=["a_p"],
-    )
+    r0 = Reparameterisation("1", ["a"], ["a_p"])
+    r1 = Reparameterisation("2", ["b", "a_p"], ["b_p"])
 
     out = sort_reparameterisations([r1, r0], existing_parameters=["a", "b"])
 
@@ -94,18 +118,10 @@ def test_sorting_with_prime_requirements():
 
 
 def test_sorting_with_unknown_prime_requirement():
-    r0 = Reparameterisation("1", ["a"], requires=[], prime_parameters=["a_p"])
-    r1 = Reparameterisation(
-        "2",
-        ["b"],
-        requires=[],
-        prime_parameters=["b_p"],
-        prime_requires=["c_p"],
-    )
+    r0 = Reparameterisation("1", ["a"], ["a_p"])
+    r1 = Reparameterisation("2", ["b", "c_p"], ["b_p"])
 
-    with pytest.raises(
-        ValueError, match=r"requires prime parameters \['c_p'\]"
-    ):
+    with pytest.raises(ValueError, match=r"requires inputs \['c_p'\]"):
         sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])
 
 
@@ -116,11 +132,11 @@ def test_sorting_retries_skipped_reparameterisations():
     first pass keeps the input order. `r0` is skipped because it depends on
     an auxiliary parameter that is only added once `r1` has been applied.
     """
-    r0 = Reparameterisation("1", ["a"], requires=["aux"])
+    r0 = Reparameterisation("1", ["a", "aux"], ["a_p"])
     r1 = Reparameterisation(
         "2",
-        ["b"],
-        requires=["seed"],
+        ["b", "seed"],
+        ["b_p"],
         auxiliary_parameters=["aux"],
     )
 
@@ -132,8 +148,12 @@ def test_sorting_retries_skipped_reparameterisations():
 
 
 def test_sorting_error_if_skipped_and_no_progress():
-    r0 = Reparameterisation("1", ["a"], requires=["b"])
-    r1 = Reparameterisation("2", ["b"], requires=["a"])
+    r0 = Reparameterisation(
+        "1", ["a", "aux_b"], ["a_p"], auxiliary_parameters=["aux_a"]
+    )
+    r1 = Reparameterisation(
+        "2", ["b", "aux_a"], ["b_p"], auxiliary_parameters=["aux_b"]
+    )
 
     with pytest.raises(ValueError, match="Could not sort reparameterisations"):
-        sort_reparameterisations([r0, r1])
+        sort_reparameterisations([r0, r1], existing_parameters=["a", "b"])


### PR DESCRIPTION
This PR reworks reparameterisations to add support for chaining multiple reparameterisations for a single parameter.

**Example**

```
```

**Changes**

- Refactored reparameterisations to use a specification class
- Move reparameterisation logic from the proposal class to standalone utils
- Added new keyword arguments (`requires`, `prime_requires`, `inverse_requires`, `prime_parameters`, `available_parameters`)