### PR TITLE
MAINT: refactor flowproposal truncation

### DIFF
--- a/src/nessai/experimental/flowmodel/clustering.py
+++ b/src/nessai/experimental/flowmodel/clustering.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Any, Tuple
+from typing import Tuple
 
 import numpy as np
 from scipy.special import logsumexp
@@ -138,10 +138,8 @@ class ClusteringFlowModel(FlowModel):
             return samples
 
     def sample_and_log_prob(
-        self, N: int = 1, z: np.ndarray = None, alt_dist: Any = None
+        self, N: int = 1, z: np.ndarray = None
     ) -> Tuple[np.ndarray, np.ndarray]:
-        if alt_dist is not None:
-            raise RuntimeError
         if z is not None:
             N = len(z)
         # This could be optimised to not repeat calculations

--- a/src/nessai/flowmodel/base.py
+++ b/src/nessai/flowmodel/base.py
@@ -903,9 +903,7 @@ class FlowModel:
             z = self.model.sample_latent_distribution(n)
         return z.cpu().numpy().astype(np.float64)
 
-    def sample_and_log_prob(
-        self, N=1, z=None, alt_dist=None, conditional=None
-    ):
+    def sample_and_log_prob(self, N=1, z=None, conditional=None):
         """
         Generate samples from samples drawn from the base distribution or
         and alternative distribution from provided latent samples
@@ -915,13 +913,8 @@ class FlowModel:
         N : int, optional
             Number of samples to draw if z is not specified
         z : ndarray, optional
-            Array of latent samples to map the the data space, if ``alt_dist``
-            is not specified they are assumed to be drawn from the base
-            distribution of the flow.
-        alt_dist : :obj:`glasflow.nflows.distribution.Distribution`
-            Distribution object from which the latent samples z were
-            drawn from. Must have a ``log_prob`` method that accepts an
-            instance of ``torch.Tensor``
+            Array of latent samples to map to the data space. They are assumed
+            to be drawn from the base distribution of the flow.
 
         Returns
         -------
@@ -943,15 +936,10 @@ class FlowModel:
                     int(N), context=conditional
                 )
         else:
-            if alt_dist is not None:
-                log_prob_fn = alt_dist.log_prob
-            else:
-                log_prob_fn = self.model.base_distribution_log_prob
-
             with torch.inference_mode():
                 if isinstance(z, np.ndarray):
                     z = self.numpy_array_to_tensor(z)
-                log_prob = log_prob_fn(z)
+                log_prob = self.model.base_distribution_log_prob(z)
                 x, log_J = self.model.inverse(z, context=conditional)
                 log_prob -= log_J
 

--- a/src/nessai/proposal/augmented.py
+++ b/src/nessai/proposal/augmented.py
@@ -232,9 +232,7 @@ class AugmentedFlowProposal(FlowProposal):
             Jacobian)
         """
         try:
-            x, log_prob = self.flow.sample_and_log_prob(
-                z=z, alt_dist=self.alt_dist
-            )
+            x, log_prob = self.flow.sample_and_log_prob(z=z)
         except AssertionError as e:
             logger.warning(
                 "Assertion error raised when sampling from the flow."

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -398,7 +398,7 @@ class BaseFlowProposal(RejectionProposal):
             return z
         return np.sqrt(temperature) * z
 
-    def compute_latent_log_prob(self, z, temperature=None):
+    def latent_log_prob(self, z, temperature=None):
         """Compute the latent log-probability under the effective density."""
         z = np.asarray(z)
         if temperature in (None, 1.0):
@@ -1211,7 +1211,7 @@ class BaseFlowProposal(RejectionProposal):
             )
 
             z, log_q = self.forward_pass(x, compute_radius=False)
-            log_p = self.compute_latent_log_prob(z, self.latent_temperature)
+            log_p = self.latent_log_prob(z, self.latent_temperature)
 
             fig, axs = plt.subplots(3, 1, figsize=(3, 9))
             axs = axs.ravel()

--- a/src/nessai/proposal/flowproposal/base.py
+++ b/src/nessai/proposal/flowproposal/base.py
@@ -99,7 +99,6 @@ class BaseFlowProposal(RejectionProposal):
     behaviour to change without changing the keyword arguments.
     """
     _FlowModelClass = FlowModel
-    alt_dist = None
 
     def __init__(
         self,
@@ -390,6 +389,29 @@ class BaseFlowProposal(RejectionProposal):
         self.flow.initialise()
         self.populated = False
         self.initialised = True
+
+    def sample_latent_distribution(self, n):
+        """Sample from the flow latent distribution with optional temperature."""
+        z = self.flow.sample_latent_distribution(n)
+        temperature = getattr(self, "latent_temperature", None)
+        if temperature in (None, 1.0):
+            return z
+        return np.sqrt(temperature) * z
+
+    def compute_latent_log_prob(self, z, temperature=None):
+        """Compute the latent log-probability under the effective density."""
+        z = np.asarray(z)
+        if temperature in (None, 1.0):
+            z_in = z
+            log_j = 0.0
+        else:
+            scale = np.sqrt(float(temperature))
+            z_in = z / scale
+            log_j = z.shape[-1] * np.log(scale)
+        with torch.inference_mode():
+            z_tensor = self.flow.numpy_array_to_tensor(z_in)
+            log_p = self.flow.model.base_distribution_log_prob(z_tensor)
+        return log_p.cpu().numpy().astype(np.float64) - log_j
 
     def update_poolsize_scale(self, acceptance):
         """
@@ -781,7 +803,7 @@ class BaseFlowProposal(RejectionProposal):
         z_training_data, _ = self.forward_pass(
             self.training_data, rescale=True
         )
-        z_gen = self.flow.sample_latent_distribution(self.training_data.size)
+        z_gen = self.sample_latent_distribution(self.training_data.size)
 
         fig = plt.figure()
         plt.hist(np.sqrt(np.sum(z_training_data**2, axis=1)), "auto")
@@ -1189,20 +1211,7 @@ class BaseFlowProposal(RejectionProposal):
             )
 
             z, log_q = self.forward_pass(x, compute_radius=False)
-            z_tensor = (
-                torch.from_numpy(z)
-                .type(torch.get_default_dtype())
-                .to(self.flow.device)
-            )
-            with torch.inference_mode():
-                if self.alt_dist is not None:
-                    log_p = self.alt_dist.log_prob(z_tensor).cpu().numpy()
-                else:
-                    log_p = (
-                        self.flow.model.base_distribution_log_prob(z_tensor)
-                        .cpu()
-                        .numpy()
-                    )
+            log_p = self.compute_latent_log_prob(z, self.latent_temperature)
 
             fig, axs = plt.subplots(3, 1, figsize=(3, 9))
             axs = axs.ravel()

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -1,92 +1,51 @@
-"""Proposal class that uses normalising flows and rejection sampling.
+"""Proposal class that uses normalising flows and rejection sampling."""
 
-This is the default proposal used by nessai.
-"""
+from __future__ import annotations
 
 import datetime
 import logging
-from functools import partial
+import warnings
 
 import numpy as np
 from scipy.special import logsumexp
 
 from ... import config
-from ...livepoint import (
-    empty_structured_array,
-)
-from ...utils import (
-    compute_radius,
-    get_uniform_distribution,
-)
-from ...utils.sampling import NDimensionalTruncatedGaussian
+from ...livepoint import empty_structured_array
 from ...utils.structures import get_subset_arrays
 from .base import BaseFlowProposal
+from .truncation import (
+    LatentRadiusTruncation,
+    LikelihoodThresholdTruncation,
+    MinLogQTruncation,
+    TruncationScheme,
+    apply_default_truncation_config,
+    build_truncation_methods,
+    get_deprecated_latent_radius_arguments,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class FlowProposal(BaseFlowProposal):
-    """
-    Object that handles training and proposal points
+    """Proposal that samples in latent space using the trained flow."""
 
-    Parameters
-    ----------
-    model : :obj:`nessai.model.Model`
-        User defined model.
-    latent_prior : {'truncated_gaussian', 'gaussian', 'uniform_nsphere', \
-            'gaussian'}, optional
-        Prior distribution in the latent space. Defaults to
-        'truncated_gaussian'.
-    poolsize : int, optional
-        Size of the proposal pool. Defaults to 10000.
-    drawsize : int, optional
-        Number of points to simultaneously draw when populating the proposal
-        Defaults to 10000
-    min_radius : float, optional
-        Minimum radius used for population. If not specified not minimum is
-        used.
-    max_radius : float, optional
-        If a float then this value is used as an upper limit for the
-        computed radius when populating the proposal. If unspecified no
-        upper limit is used.
-    fixed_radius : float, optional
-        If specified and the chosen latent distribution is compatible, this
-        radius will be used to draw new samples instead of the value computed
-        with the flow.
-    constant_volume_mode : bool
-        If True, then a constant volume is used for the latent contour used to
-        draw new samples. The exact volume can be set using `volume_fraction`
-    volume_fraction : float
-        Fraction of the total probability to contain with the latent contour
-        when using a constant volume.
-    compute_radius_with_all : bool, optional
-        If True all the radius of the latent contour is computed using the
-        maximum radius of all the samples used to train the flow.
-    fuzz : float, optional
-        Fuzz-factor applied to the radius. If unspecified no fuzz-factor is
-        applied.
-    expansion_fraction : float, optional
-        Similar to ``fuzz`` but instead a scaling factor applied to the radius
-        this specifies a rescaling for volume of the n-ball used to draw
-        samples. This is translated to a value for ``fuzz``.
-    truncate_log_q : bool, optional
-        Truncate proposals using minimum log-probability of the training data.
-    enforce_likelihood_threshold : bool
-        If True, enforce the likelihood threshold when performing rejection
-        sampling. If false, the likelihood is not checked when populating the
-        proposal.
-    """
+    truncation_registry = {
+        "latent_radius": LatentRadiusTruncation,
+        "min_log_q": MinLogQTruncation,
+        "likelihood_threshold": LikelihoodThresholdTruncation,
+    }
 
     def __init__(
         self,
         model,
         poolsize=None,
-        latent_prior="truncated_gaussian",
+        latent_prior="flow",
         latent_temperature=None,
         constant_volume_mode=True,
         volume_fraction=0.95,
         fuzz=1.0,
         fixed_radius=False,
+        radius_mode=None,
         drawsize=None,
         truncate_log_q=False,
         expansion_fraction=4.0,
@@ -94,237 +53,197 @@ class FlowProposal(BaseFlowProposal):
         max_radius=50.0,
         compute_radius_with_all=False,
         enforce_likelihood_threshold=False,
+        truncation_method=None,
+        truncation_methods=None,
+        truncation_kwargs=None,
         **kwargs,
     ):
-        super().__init__(
-            model,
-            poolsize=poolsize,
-            **kwargs,
-        )
+        super().__init__(model, poolsize=poolsize, **kwargs)
         logger.debug("Initialising FlowProposal")
-
-        self._draw_func = None
-        self._populate_dist = None
 
         self.configure_population(
             drawsize,
-            fuzz,
-            expansion_fraction,
-            latent_prior,
-            latent_temperature,
+            latent_prior=latent_prior,
+            latent_temperature=latent_temperature,
         )
 
-        self.truncate_log_q = truncate_log_q
-        self.constant_volume_mode = constant_volume_mode
-        self.volume_fraction = volume_fraction
-        self.enforce_likelihood_threshold = enforce_likelihood_threshold
+        self._truncation_scheme = TruncationScheme()
+        self.truncation_method = truncation_method
+        self.truncation_methods = []
+        self.truncation_kwargs = {}
+        latent_radius_kwargs = dict(
+            fixed_radius=fixed_radius,
+            radius_mode=radius_mode,
+            min_radius=min_radius,
+            max_radius=max_radius,
+            compute_radius_with_all=compute_radius_with_all,
+            constant_volume_mode=constant_volume_mode,
+            volume_fraction=volume_fraction,
+            fuzz=fuzz,
+            expansion_fraction=expansion_fraction,
+        )
+        self._warn_for_deprecated_truncation_arguments(**latent_radius_kwargs)
+        self._warn_for_deprecated_likelihood_threshold(
+            enforce_likelihood_threshold
+        )
 
-        self.compute_radius_with_all = compute_radius_with_all
-        self.configure_fixed_radius(fixed_radius)
-        self.configure_min_max_radius(min_radius, max_radius)
+        self.configure_truncation(
+            truncation_method=truncation_method,
+            truncation_methods=truncation_methods,
+            truncation_kwargs=truncation_kwargs,
+            truncate_log_q=truncate_log_q,
+            enforce_likelihood_threshold=enforce_likelihood_threshold,
+            latent_radius_kwargs=latent_radius_kwargs,
+            default_latent_radius=True,
+        )
+        self._log_truncation_configuration()
 
-        self.configure_latent_prior()
-        self.alt_dist = None
+    @property
+    def truncation(self) -> TruncationScheme:
+        return self._truncation_scheme
+
+    def get_truncation_rule(self, name: str):
+        return self.truncation.get_rule(name)
+
+    def _get_latent_radius_rule(self):
+        return self._truncation_scheme.get_rule("latent_radius")
+
+    def _sync_truncation_state(self) -> None:
+        self.truncation_methods = self._truncation_scheme.rule_names
+        self.truncate_log_q = "min_log_q" in self.truncation_methods
+        self.enforce_likelihood_threshold = (
+            "likelihood_threshold" in self.truncation_methods
+        )
+
+    def _log_truncation_configuration(self) -> None:
+        logger.info(
+            "FlowProposal truncation methods: %s",
+            self.truncation_methods,
+        )
+        for rule in self._truncation_scheme.rules:
+            if hasattr(rule, "to_kwargs"):
+                logger.info(
+                    "FlowProposal truncation rule %s config: %s",
+                    rule.name,
+                    rule.to_kwargs(),
+                )
+            else:
+                logger.info(
+                    "FlowProposal truncation rule enabled: %s",
+                    rule.name,
+                )
+
+    def _warn_for_deprecated_truncation_arguments(self, **kwargs) -> None:
+        deprecated = get_deprecated_latent_radius_arguments(**kwargs)
+        if not deprecated:
+            return
+
+        warnings.warn(
+            "The following FlowProposal arguments are deprecated and should "
+            "be configured via truncation_kwargs['latent_radius'] instead: "
+            f"{', '.join(deprecated)}.",
+            FutureWarning,
+            stacklevel=3,
+        )
+
+    @staticmethod
+    def _warn_for_deprecated_likelihood_threshold(
+        enforce_likelihood_threshold: bool,
+    ) -> None:
+        if not enforce_likelihood_threshold:
+            return
+        warnings.warn(
+            "`enforce_likelihood_threshold` is deprecated and should be "
+            "configured via "
+            "`truncation_methods=['likelihood_threshold']` instead.",
+            FutureWarning,
+            stacklevel=3,
+        )
 
     def configure_population(
         self,
         drawsize,
-        fuzz,
-        expansion_fraction,
-        latent_prior,
+        latent_prior="flow",
         latent_temperature=None,
-    ):
-        """
-        Configure settings related to population
-        """
+    ) -> None:
+        """Configure settings related to population."""
         if drawsize is None:
             drawsize = self.poolsize
 
-        self.drawsize = drawsize
-        self.fuzz = fuzz
-        self.expansion_fraction = expansion_fraction
-        self.latent_prior = latent_prior
+        if latent_prior not in (None, "flow"):
+            raise ValueError(
+                "Only the flow latent prior is supported. "
+                "Use truncation rules to filter latent samples."
+            )
         if latent_temperature is not None:
-            if latent_prior != "gaussian":
-                raise ValueError(
-                    "Latent temperature can only be used with a Gaussian latent prior"
-                )
-            else:
-                logger.warning("`latent_temperature` is experimental!")
+            if isinstance(latent_temperature, bool) or not isinstance(
+                latent_temperature, (int, float)
+            ):
+                raise TypeError("latent_temperature must be a float")
+            latent_temperature = float(latent_temperature)
+            if latent_temperature <= 0.0:
+                raise ValueError("latent_temperature must be positive")
+
+        self.drawsize = drawsize
+        self.latent_prior = "flow"
         self.latent_temperature = latent_temperature
 
-    def configure_latent_prior(self):
-        """Configure the latent prior"""
-        if self.latent_prior == "truncated_gaussian":
-            from ...utils import draw_truncated_gaussian
+    def configure_truncation(
+        self,
+        truncation_method=None,
+        truncation_methods=None,
+        truncation_kwargs=None,
+        truncate_log_q=False,
+        enforce_likelihood_threshold=False,
+        latent_radius_kwargs=None,
+        default_latent_radius=False,
+    ) -> None:
+        existing_rule = self._get_latent_radius_rule()
+        if latent_radius_kwargs is None and existing_rule is not None:
+            latent_radius_kwargs = existing_rule.to_kwargs()
 
-            self._draw_latent_prior = draw_truncated_gaussian
+        methods = build_truncation_methods(
+            truncation_method=truncation_method,
+            truncation_methods=truncation_methods,
+            truncate_log_q=truncate_log_q,
+            enforce_likelihood_threshold=enforce_likelihood_threshold,
+            latent_radius_kwargs=latent_radius_kwargs,
+            default_latent_radius=default_latent_radius,
+        )
+        self.truncation_method = truncation_method
+        methods, self.truncation_kwargs = apply_default_truncation_config(
+            methods,
+            truncation_kwargs=truncation_kwargs,
+            default_latent_radius=default_latent_radius,
+        )
 
-        elif self.latent_prior == "gaussian":
-            logger.warning("Using a gaussian latent prior WITHOUT truncation")
-            from ...utils import draw_gaussian
-
-            self._draw_latent_prior = draw_gaussian
-        elif self.latent_prior == "uniform":
-            from ...utils import draw_uniform
-
-            self._draw_latent_prior = draw_uniform
-        elif self.latent_prior in ["uniform_nsphere", "uniform_nball"]:
-            from ...utils import draw_nsphere
-
-            self._draw_latent_prior = draw_nsphere
-        elif self.latent_prior == "flow":
-            self._draw_latent_prior = None
-        else:
-            raise RuntimeError(
-                f"Unknown latent prior: {self.latent_prior}, choose from: "
-                "truncated_gaussian (default), gaussian, "
-                "uniform, uniform_nsphere"
-            )
-
-    def configure_fixed_radius(self, fixed_radius):
-        """Configure the fixed radius"""
-        if fixed_radius:
+        rules = []
+        for method in methods:
             try:
-                self.fixed_radius = float(fixed_radius)
-            except ValueError:
-                logger.error(
-                    "Fixed radius enabled but could not be converted to a "
-                    "float. Setting fixed_radius=False"
-                )
-                self.fixed_radius = False
-        else:
-            self.fixed_radius = False
+                rule_cls = self.truncation_registry[method]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Unknown truncation method: {method}"
+                ) from exc
 
-    def configure_min_max_radius(self, min_radius, max_radius):
-        """
-        Configure the minimum and maximum radius
-        """
-        if isinstance(min_radius, (int, float)):
-            self.min_radius = float(min_radius)
-        else:
-            raise RuntimeError("Min radius must be an int or float")
-
-        if max_radius:
-            if isinstance(max_radius, (int, float)):
-                self.max_radius = float(max_radius)
-            else:
-                raise RuntimeError("Max radius must be an int or float")
-        else:
-            logger.warning(
-                "Running without a maximum radius! The proposal "
-                "process may get stuck if very large radii are "
-                "returned by the worst point."
-            )
-            self.max_radius = False
-
-    def configure_constant_volume(self):
-        """Configure using constant volume latent contour."""
-        if self.constant_volume_mode:
-            logger.debug("Configuring constant volume latent contour")
-            if self.latent_prior == "truncated_gaussian":
-                pass
-            elif self.latent_prior in ["uniform_nball", "uniform_nsphere"]:
-                logger.warning(
-                    "Constant volume mode with latent_prior="
-                    f"{self.latent_prior} is experimental!"
+            raw_kwargs = self.truncation_kwargs.get(method, {})
+            if not isinstance(raw_kwargs, dict):
+                raise TypeError(
+                    f"Truncation kwargs for {method} must be a dictionary"
                 )
-            else:
-                raise RuntimeError(
-                    "Constant volume mode is not supported for latent_prior="
-                    f"{self.latent_prior}"
-                )
-            self.fixed_radius = compute_radius(
-                self.prime_dims, self.volume_fraction
-            )
-            self.fuzz = 1.0
-            if self.max_radius < self.fixed_radius:
-                logger.warning(
-                    "Max radius is less than the radius need to use a "
-                    "constant volume latent contour. Max radius will be "
-                    "disabled."
-                )
-                self.max_radius = False
-            if self.min_radius > self.fixed_radius:
-                logger.warning(
-                    "Min radius is greater than the radius need to use a "
-                    "constant volume latent contour. Min radius will be "
-                    "disabled."
-                )
-                self.min_radius = False
-        else:
-            logger.debug(
-                "Nothing to configure for constant volume latent contour."
-            )
 
-    def set_rescaling(self):
-        """Set the rescaling functions.
+            kwargs = dict(raw_kwargs)
+            if method == "latent_radius":
+                kwargs = {**(latent_radius_kwargs or {}), **kwargs}
+            rules.append(rule_cls(**kwargs))
 
-        Also configures constant volume mode since this must be done AFTER
-        the reparameterisations are configured.
-        """
+        self._truncation_scheme = TruncationScheme(rules)
+        self._sync_truncation_state()
+
+    def set_rescaling(self) -> None:
+        """Set the rescaling functions."""
         super().set_rescaling()
-        if self.expansion_fraction and self.expansion_fraction is not None:
-            logger.info("Overwriting fuzz factor with expansion fraction")
-            self.fuzz = (1 + self.expansion_fraction) ** (1 / self.prime_dims)
-            logger.info(f"New fuzz factor: {self.fuzz}")
-        self.configure_constant_volume()
-
-    def radius(self, z, *arrays):
-        """
-        Calculate the radius of a latent point or set of latent points.
-        If multiple points are parsed the maximum radius is returned.
-
-        Parameters
-        ----------
-        z : :obj:`np.ndarray`
-            Array of points in the latent space
-        *arrays :
-            Additional arrays to return the corresponding value
-
-        Returns
-        -------
-        tuple of arrays
-            Tuple of array with the maximum radius and corresponding values
-            from any additional arrays that were passed.
-        """
-        r = np.sqrt(np.sum(z**2.0, axis=-1))
-        i = np.nanargmax(r)
-        if arrays:
-            return (r[i],) + tuple(a[i] for a in arrays)
-        else:
-            return r[i]
-
-    def prep_latent_prior(self):
-        """Prepare the latent prior."""
-        if self.latent_prior == "truncated_gaussian":
-            self._populate_dist = NDimensionalTruncatedGaussian(
-                self.prime_dims,
-                self.r,
-                fuzz=self.fuzz,
-                rng=self.rng,
-            )
-            self._draw_func = self._populate_dist.sample
-        elif self.latent_prior == "flow":
-            self._draw_func = lambda N: self.flow.sample_latent_distribution(N)
-        else:
-            draw_kwargs = dict(
-                dims=self.prime_dims,
-                r=self.r,
-                fuzz=self.fuzz,
-                rng=self.rng,
-            )
-            if self.latent_temperature is not None:
-                draw_kwargs["temperature"] = self.latent_temperature
-            assert self.rng is not None
-            self._draw_func = partial(
-                self._draw_latent_prior,
-                **draw_kwargs,
-            )
-
-    def draw_latent_prior(self, n):
-        """Draw n samples from the latent prior."""
-        return self._draw_func(N=n)
+        self._truncation_scheme.configure(self)
 
     def backward_pass(
         self,
@@ -334,49 +253,26 @@ class FlowProposal(BaseFlowProposal):
         return_z=False,
         return_unit_hypercube=False,
     ):
-        """
-        A backwards pass from the model (latent -> real)
-
-        Parameters
-        ----------
-        z : array_like
-            Structured array of points in the latent space
-        rescale : bool, optional (True)
-            Apply inverse rescaling function
-        discard_nan: bool
-            If True, samples with NaNs or Infs in log_q are removed.
-        return_z : bool
-            If True, return the array of latent samples, this may differ from
-            the input since samples can be discarded.
-
-        Returns
-        -------
-        x : array_like
-            Samples in the data space
-        log_prob : array_like
-            Log probabilities corresponding to each sample (including the
-            Jacobian)
-        z : array_like
-            Samples in the latent space, only returned if :code:`return_z=True`
-        """
-        # Compute the log probability
+        """Apply the inverse flow and inverse rescaling."""
         try:
-            x, log_prob = self.flow.sample_and_log_prob(
-                z=z, alt_dist=self.alt_dist
+            x, log_j = self.flow.inverse(z)
+            log_prob = (
+                self.compute_latent_log_prob(z, self.latent_temperature)
+                - log_j
             )
         except AssertionError as e:
             logger.warning(
-                "Assertion error raised when sampling from the flow."
-                f"Error: {e}"
+                "Assertion error raised when sampling from the flow. Error: %s",
+                e,
             )
             if return_z:
                 return np.array([]), np.array([]), np.array([])
-            else:
-                return np.array([]), np.array([])
+            return np.array([]), np.array([])
 
         if discard_nans:
             valid = np.isfinite(log_prob)
             x, log_prob, z = get_subset_arrays(valid, x, log_prob, z)
+
         x_array = np.asarray(x, dtype=config.livepoints.default_float_dtype)
         if x_array.ndim == 1:
             x_array = x_array[np.newaxis, :]
@@ -385,19 +281,18 @@ class FlowProposal(BaseFlowProposal):
         )
         for i, parameter in enumerate(self.prime_parameters):
             x[parameter] = x_array[:, i]
-        # Apply rescaling in rescale=True
+
         if rescale:
             x, log_J = self.inverse_rescale(
                 x, return_unit_hypercube=return_unit_hypercube
             )
-            # Include Jacobian for the rescaling
             log_prob -= log_J
             if not return_unit_hypercube:
                 x, z, log_prob = self.check_prior_bounds(x, z, log_prob)
+
         if return_z:
             return x, log_prob, z
-        else:
-            return x, log_prob
+        return x, log_prob
 
     def populate(
         self,
@@ -406,67 +301,21 @@ class FlowProposal(BaseFlowProposal):
         plot=True,
         r=None,
         max_samples=1_000_000,
-    ):
-        """
-        Populate a pool of latent points given the current worst point.
-
-        Parameters
-        ----------
-        worst_point : structured_array
-            The current worst point used to compute the radius of the contour
-            in the latent space.
-        n_samples : int, optional (10000)
-            The total number of points to populate in the pool
-        plot : {True, False, 'all'}
-            Enable or disable plots for during training. By default the plots
-            are only one-dimensional histograms, `'all'` includes corner
-            plots with samples, these are often a few MB in size so
-            proceed with caution!
-        """
+    ) -> None:
+        """Populate a pool of samples using staged truncation."""
         st = datetime.datetime.now()
         if not self.initialised:
             raise RuntimeError(
-                "Proposal has not been initialised. "
-                "Try calling `initialise()` first."
+                "Proposal has not been initialised. Try calling `initialise()` "
+                "first."
             )
-        if r is not None:
-            logger.debug(f"Using user inputs for radius {r}")
-        elif self.fixed_radius:
-            r = self.fixed_radius
-        else:
-            logger.debug(f"Populating with worst point: {worst_point}")
-            if self.compute_radius_with_all:
-                logger.debug("Using previous live points to compute radius")
-                worst_point = self.training_data
-            worst_z = self.forward_pass(
-                worst_point, rescale=True, compute_radius=True
-            )[0]
-            r = self.radius(worst_z)
-            if self.max_radius and r > self.max_radius:
-                r = self.max_radius
-            if self.min_radius and r < self.min_radius:
-                r = self.min_radius
 
-        if self.truncate_log_q:
-            log_q_live_points = self.forward_pass(self.training_data)[1]
-            min_log_q = log_q_live_points.min()
-            logger.debug(f"Truncating with log_q={min_log_q:.3f}")
-        else:
-            min_log_q = None
-
-        logger.debug(f"Populating proposal with latent radius: {r:.5}")
-        # Radius is not used for the flow or Gaussian latent priors
-        if self.latent_prior in ["flow", "gaussian"]:
-            self.r = np.nan
-        else:
-            self.r = r
-
-        self.alt_dist = self.get_alt_distribution()
+        self._truncation_scheme.prepare(self, worst_point, radius=r)
 
         if self.indices:
             logger.debug(
-                "Existing pool of samples is not empty. "
-                "Discarding existing samples."
+                "Existing pool of samples is not empty. Discarding existing "
+                "samples."
             )
         self.indices = []
 
@@ -477,8 +326,6 @@ class FlowProposal(BaseFlowProposal):
                 n_samples, dtype=self.population_dtype
             )
 
-        self.prep_latent_prior()
-
         log_n = np.log(n_samples)
         log_n_expected = -np.inf
         n_proposed = 0
@@ -486,43 +333,36 @@ class FlowProposal(BaseFlowProposal):
         log_constant = -np.inf
         n_accepted = 0
         accept = None
-        log_likelihood_threshold = worst_point["logL"]
 
         while n_accepted < n_samples:
-            z = self.draw_latent_prior(self.drawsize)
+            z = self.sample_latent_distribution(self.drawsize)
             n_proposed += z.shape[0]
+            z = self._truncation_scheme.apply_latent(self, z)
+            if not len(z):
+                continue
 
-            x, log_q = self.backward_pass(
+            x, log_q, z = self.backward_pass(
                 z,
                 rescale=True,
+                return_z=True,
                 return_unit_hypercube=self.map_to_unit_hypercube,
             )
-            if self.truncate_log_q:
-                above_min_log_q = log_q > min_log_q
-                logger.debug(
-                    "Discarding %s samples below log_q_min",
-                    self.drawsize - above_min_log_q.sum(),
-                )
-                x, log_q = get_subset_arrays(above_min_log_q, x, log_q)
+            x, log_q, z = self._truncation_scheme.apply_after_backward(
+                self, x, log_q, z
+            )
+            if not len(x):
+                continue
 
-            if self.enforce_likelihood_threshold:
+            if self._truncation_scheme.requires_log_likelihood:
                 x["logL"] = self.model.batch_evaluate_log_likelihood(
                     x, unit_hypercube=self.map_to_unit_hypercube
                 )
-                above_threshold = x["logL"] > log_likelihood_threshold
-                x, log_q = get_subset_arrays(above_threshold, x, log_q)
-                logger.debug(
-                    "Accepting %s / %s samples above logL threshold",
-                    len(x),
-                    self.drawsize,
+                x, log_q, z = self._truncation_scheme.apply_after_likelihood(
+                    self, x, log_q, z
                 )
-            # Handle case where all samples have been discarded
-            if not len(x):
-                logger.warning(
-                    "All samples were discard before performing rejection "
-                    "sampling."
-                )
-                continue
+                if not len(x):
+                    continue
+
             log_w = self.compute_weights(x, log_q)
 
             if self.accumulate_weights:
@@ -538,9 +378,6 @@ class FlowProposal(BaseFlowProposal):
                     n_samples,
                 )
 
-                # Only try rejection sampling if we expected to accept enough
-                # points. In the case where we don't, we continue drawing
-                # samples
                 if log_n_expected >= log_n:
                     log_u = np.log(self.rng.random(len(log_weights)))
                     accept = (log_weights - log_constant) > log_u
@@ -548,7 +385,6 @@ class FlowProposal(BaseFlowProposal):
                 if n_proposed > max_samples:
                     logger.warning("Reached max samples (%s)", max_samples)
                     break
-
             else:
                 log_w -= log_w.max()
                 log_u = np.log(self.rng.random(len(log_w)))
@@ -570,13 +406,12 @@ class FlowProposal(BaseFlowProposal):
             self.x = samples[:n_samples]
 
         self.samples = self.convert_to_samples(self.x, plot=plot)
-
         if self._plot_pool and plot:
             self.plot_pool(self.samples)
 
         self.population_time += datetime.datetime.now() - st
-        logger.debug("Evaluating log-likelihoods")
-        if not self.enforce_likelihood_threshold:
+        if not self._truncation_scheme.requires_log_likelihood:
+            logger.debug("Evaluating log-likelihoods")
             self.samples["logL"] = self.model.batch_evaluate_log_likelihood(
                 self.samples
             )
@@ -584,39 +419,18 @@ class FlowProposal(BaseFlowProposal):
             self.acceptance.append(
                 self.compute_acceptance(worst_point["logL"])
             )
-            logger.debug(f"Current acceptance {self.acceptance[-1]}")
+            logger.debug("Current acceptance %s", self.acceptance[-1])
 
         self.indices = self.rng.permutation(self.samples.size).tolist()
         self.population_acceptance = n_accepted / n_proposed
         self.populated_count += 1
         self.populated = True
         self._checked_population = False
-        logger.debug(f"Proposal populated with {len(self.indices)} samples")
-        logger.debug(
-            f"Overall proposal acceptance: {self.x.size / n_proposed:.4}"
-        )
 
-    def get_alt_distribution(self):
-        """
-        Get a distribution for the latent prior used to draw samples.
-        """
-        if self.latent_prior in ["uniform_nsphere", "uniform_nball"]:
-            return get_uniform_distribution(
-                self.prime_dims, self.r * self.fuzz, device=self.flow.device
-            )
-
-    def reset(self):
-        """Reset the proposal"""
+    def reset(self) -> None:
+        """Reset the proposal."""
         super().reset()
-        self.r = np.nan
-        self.alt_dist = None
-        self._populate_dist = None
-        self._draw_func = None
-        self.alt_dist = None
+        self._truncation_scheme.reset()
 
     def __getstate__(self):
-        state = super().__getstate__()
-        state["_draw_func"] = None
-        state["_populate_dist"] = None
-        state["alt_dist"] = None
-        return state
+        return super().__getstate__()

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -20,6 +20,7 @@ from .truncation import (
     get_deprecated_latent_radius_arguments,
     get_deprecated_latent_radius_kwargs,
     get_truncation_rule_class,
+    normalise_truncation_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -234,10 +235,11 @@ class FlowProposal(BaseFlowProposal):
         )
         self.truncation_method = truncation_method
 
-        truncation_kwargs = {
-            name: dict(value)
-            for name, value in (truncation_kwargs or {}).items()
-        }
+        truncation_kwargs = normalise_truncation_kwargs(
+            truncation_method=truncation_method,
+            truncation_methods=truncation_methods,
+            truncation_kwargs=truncation_kwargs,
+        )
         if latent_radius_kwargs is not None and "latent_radius" in methods:
             truncation_kwargs["latent_radius"] = {
                 **latent_radius_kwargs,
@@ -281,10 +283,7 @@ class FlowProposal(BaseFlowProposal):
         """Apply the inverse flow and inverse rescaling."""
         try:
             x, log_j = self.flow.inverse(z)
-            log_prob = (
-                self.compute_latent_log_prob(z, self.latent_temperature)
-                - log_j
-            )
+            log_prob = self.latent_log_prob(z, self.latent_temperature) - log_j
         except AssertionError as e:
             logger.warning(
                 "Assertion error raised when sampling from the flow. Error: %s",

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -21,6 +21,7 @@ from .truncation import (
     apply_default_truncation_config,
     build_truncation_methods,
     get_deprecated_latent_radius_arguments,
+    get_deprecated_latent_radius_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,19 +40,19 @@ class FlowProposal(BaseFlowProposal):
         self,
         model,
         poolsize=None,
-        latent_prior="flow",
+        latent_prior=None,
         latent_temperature=None,
-        constant_volume_mode=True,
-        volume_fraction=0.95,
-        fuzz=1.0,
-        fixed_radius=False,
+        constant_volume_mode=None,
+        volume_fraction=None,
+        fuzz=None,
+        fixed_radius=None,
         radius_mode=None,
         drawsize=None,
         truncate_log_q=False,
-        expansion_fraction=4.0,
-        min_radius=False,
-        max_radius=50.0,
-        compute_radius_with_all=False,
+        expansion_fraction=None,
+        min_radius=None,
+        max_radius=None,
+        compute_radius_with_all=None,
         enforce_likelihood_threshold=False,
         truncation_method=None,
         truncation_methods=None,
@@ -60,6 +61,7 @@ class FlowProposal(BaseFlowProposal):
     ):
         super().__init__(model, poolsize=poolsize, **kwargs)
         logger.debug("Initialising FlowProposal")
+        self._warn_for_deprecated_latent_prior(latent_prior)
 
         self.configure_population(
             drawsize,
@@ -71,7 +73,7 @@ class FlowProposal(BaseFlowProposal):
         self.truncation_method = truncation_method
         self.truncation_methods = []
         self.truncation_kwargs = {}
-        latent_radius_kwargs = dict(
+        deprecated_latent_radius_arguments = dict(
             fixed_radius=fixed_radius,
             radius_mode=radius_mode,
             min_radius=min_radius,
@@ -82,9 +84,14 @@ class FlowProposal(BaseFlowProposal):
             fuzz=fuzz,
             expansion_fraction=expansion_fraction,
         )
-        self._warn_for_deprecated_truncation_arguments(**latent_radius_kwargs)
+        self._warn_for_deprecated_truncation_arguments(
+            **deprecated_latent_radius_arguments
+        )
         self._warn_for_deprecated_likelihood_threshold(
             enforce_likelihood_threshold
+        )
+        latent_radius_kwargs = get_deprecated_latent_radius_kwargs(
+            **deprecated_latent_radius_arguments
         )
 
         self.configure_truncation(
@@ -93,10 +100,10 @@ class FlowProposal(BaseFlowProposal):
             truncation_kwargs=truncation_kwargs,
             truncate_log_q=truncate_log_q,
             enforce_likelihood_threshold=enforce_likelihood_threshold,
-            latent_radius_kwargs=latent_radius_kwargs,
+            latent_radius_kwargs=latent_radius_kwargs or None,
             default_latent_radius=True,
         )
-        self._log_truncation_configuration()
+        self._log_configuration()
 
     @property
     def truncation(self) -> TruncationScheme:
@@ -115,15 +122,19 @@ class FlowProposal(BaseFlowProposal):
             "likelihood_threshold" in self.truncation_methods
         )
 
-    def _log_truncation_configuration(self) -> None:
+    def _log_configuration(self) -> None:
         logger.info(
-            "FlowProposal truncation methods: %s",
+            "FlowProposal configuration: drawsize=%s, latent_prior=%s, "
+            "latent_temperature=%s, truncation_methods=%s",
+            self.drawsize,
+            self.latent_prior,
+            self.latent_temperature,
             self.truncation_methods,
         )
         for rule in self._truncation_scheme.rules:
             if hasattr(rule, "to_kwargs"):
                 logger.info(
-                    "FlowProposal truncation rule %s config: %s",
+                    "FlowProposal truncation rule %s: %s",
                     rule.name,
                     rule.to_kwargs(),
                 )
@@ -147,6 +158,17 @@ class FlowProposal(BaseFlowProposal):
         )
 
     @staticmethod
+    def _warn_for_deprecated_latent_prior(latent_prior) -> None:
+        if latent_prior != "flow":
+            return
+        warnings.warn(
+            "`latent_prior` is deprecated and will be removed. "
+            "FlowProposal always uses the flow latent distribution.",
+            FutureWarning,
+            stacklevel=3,
+        )
+
+    @staticmethod
     def _warn_for_deprecated_likelihood_threshold(
         enforce_likelihood_threshold: bool,
     ) -> None:
@@ -163,7 +185,7 @@ class FlowProposal(BaseFlowProposal):
     def configure_population(
         self,
         drawsize,
-        latent_prior="flow",
+        latent_prior=None,
         latent_temperature=None,
     ) -> None:
         """Configure settings related to population."""
@@ -198,8 +220,16 @@ class FlowProposal(BaseFlowProposal):
         latent_radius_kwargs=None,
         default_latent_radius=False,
     ) -> None:
+        use_default_latent_radius = default_latent_radius and (
+            truncation_method is None and truncation_methods is None
+        )
         existing_rule = self._get_latent_radius_rule()
-        if latent_radius_kwargs is None and existing_rule is not None:
+        if (
+            latent_radius_kwargs is None
+            and truncation_method is None
+            and truncation_methods is None
+            and existing_rule is not None
+        ):
             latent_radius_kwargs = existing_rule.to_kwargs()
 
         methods = build_truncation_methods(
@@ -208,13 +238,13 @@ class FlowProposal(BaseFlowProposal):
             truncate_log_q=truncate_log_q,
             enforce_likelihood_threshold=enforce_likelihood_threshold,
             latent_radius_kwargs=latent_radius_kwargs,
-            default_latent_radius=default_latent_radius,
+            default_latent_radius=use_default_latent_radius,
         )
         self.truncation_method = truncation_method
         methods, self.truncation_kwargs = apply_default_truncation_config(
             methods,
             truncation_kwargs=truncation_kwargs,
-            default_latent_radius=default_latent_radius,
+            default_latent_radius=use_default_latent_radius,
         )
 
         rules = []

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -14,14 +14,12 @@ from ...livepoint import empty_structured_array
 from ...utils.structures import get_subset_arrays
 from .base import BaseFlowProposal
 from .truncation import (
-    LatentRadiusTruncation,
-    LikelihoodThresholdTruncation,
-    MinLogQTruncation,
     TruncationScheme,
     apply_default_truncation_config,
     build_truncation_methods,
     get_deprecated_latent_radius_arguments,
     get_deprecated_latent_radius_kwargs,
+    get_truncation_rule_class,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,12 +27,6 @@ logger = logging.getLogger(__name__)
 
 class FlowProposal(BaseFlowProposal):
     """Proposal that samples in latent space using the trained flow."""
-
-    truncation_registry = {
-        "latent_radius": LatentRadiusTruncation,
-        "min_log_q": MinLogQTruncation,
-        "likelihood_threshold": LikelihoodThresholdTruncation,
-    }
 
     def __init__(
         self,
@@ -249,13 +241,7 @@ class FlowProposal(BaseFlowProposal):
 
         rules = []
         for method in methods:
-            try:
-                rule_cls = self.truncation_registry[method]
-            except KeyError as exc:
-                raise ValueError(
-                    f"Unknown truncation method: {method}"
-                ) from exc
-
+            rule_cls = get_truncation_rule_class(method)
             raw_kwargs = self.truncation_kwargs.get(method, {})
             if not isinstance(raw_kwargs, dict):
                 raise TypeError(

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -27,7 +27,77 @@ logger = logging.getLogger(__name__)
 
 
 class FlowProposal(BaseFlowProposal):
-    """Proposal that samples in latent space using the trained flow."""
+    """Proposal that samples in latent space using the trained flow.
+
+    Parameters
+    ----------
+    model : nessai.model.Model
+        The model to use for the proposal.
+    poolsize : int, optional
+        The number of samples to draw from the flow when populating the pool.
+    latent_prior : str, optional
+        The prior to use for the latent space. This argument is deprecated and
+        only 'flow' is supported.
+    latent_temperature : float, optional
+        The temperature to use for the latent space. If None, no scaling is
+        applied.
+    constant_volume_mode : bool, optional
+        Whether to use constant volume mode for the latent radius. This argument
+        is deprecated and should be configured via :code:`truncation_methods`
+        and :code:`truncation_kwargs` instead.
+    volume_fraction : float, optional
+        The volume fraction to use for the latent radius. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    fuzz : float, optional
+        The fuzz to use for the latent radius. This argument is deprecated and
+        should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    fixed_radius : float, optional
+        The fixed radius to use for the latent radius. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    radius_mode : str, optional
+        The radius mode to use for the latent radius. This argument is deprecated
+        and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    drawsize : int, optional
+        The number of samples to draw from the flow when populating the pool.
+    truncate_log_q : bool, optional
+        Whether to truncate the log q values when populating the pool. This
+        argument is deprecated and should be configured via
+        :code:`truncation_methods` and :code:`truncation_kwargs` instead.
+    expansion_fraction : float, optional
+        The expansion fraction to use for the latent radius. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    min_radius : float, optional
+        The minimum radius to use for the latent radius. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    max_radius : float, optional
+        The maximum radius to use for the latent radius. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    compute_radius_with_all : bool, optional
+        Whether to compute the latent radius using all samples. This argument is
+        deprecated and should be configured via :code:`truncation_methods` and
+        :code:`truncation_kwargs` instead.
+    enforce_likelihood_threshold : bool, optional
+        Whether to enforce a likelihood threshold when populating the pool. This
+        argument is deprecated and should be configured via
+        :code:`truncation_methods` and :code:`truncation_kwargs` instead.
+    truncation_method : str, optional
+        The truncation method to use when populating the pool.
+    truncation_methods : list of str, optional
+        The truncation methods to use when populating the pool.
+    truncation_kwargs : dict, optional
+        The keyword arguments to use for the truncation methods when populating
+        the pool. When using :code:`truncation_methods`, the keys of this
+        dictionary should match the names of the truncation methods.
+    **kwargs
+        Additional keyword arguments to pass to the base class.
+    """
 
     def __init__(
         self,

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -363,6 +363,9 @@ class FlowProposal(BaseFlowProposal):
             n_proposed += z.shape[0]
             z = self._truncation_scheme.apply_latent(self, z)
             if not len(z):
+                if n_proposed > max_samples:
+                    logger.warning("Reached max samples (%s)", max_samples)
+                    break
                 continue
 
             x, log_q, z = self.backward_pass(
@@ -375,6 +378,9 @@ class FlowProposal(BaseFlowProposal):
                 self, x, log_q, z
             )
             if not len(x):
+                if n_proposed > max_samples:
+                    logger.warning("Reached max samples (%s)", max_samples)
+                    break
                 continue
 
             if self._truncation_scheme.requires_log_likelihood:
@@ -385,6 +391,9 @@ class FlowProposal(BaseFlowProposal):
                     self, x, log_q, z
                 )
                 if not len(x):
+                    if n_proposed > max_samples:
+                        logger.warning("Reached max samples (%s)", max_samples)
+                        break
                     continue
 
             log_w = self.compute_weights(x, log_q)
@@ -430,7 +439,7 @@ class FlowProposal(BaseFlowProposal):
             n_accepted = np.sum(accept)
             self.x = samples[accept][:n_samples]
         else:
-            self.x = samples[:n_samples]
+            self.x = samples[: min(n_accepted, n_samples)]
 
         self.samples = self.convert_to_samples(self.x, plot=plot)
         if self._plot_pool and plot:

--- a/src/nessai/proposal/flowproposal/flowproposal.py
+++ b/src/nessai/proposal/flowproposal/flowproposal.py
@@ -233,6 +233,17 @@ class FlowProposal(BaseFlowProposal):
             default_latent_radius=use_default_latent_radius,
         )
         self.truncation_method = truncation_method
+
+        truncation_kwargs = {
+            name: dict(value)
+            for name, value in (truncation_kwargs or {}).items()
+        }
+        if latent_radius_kwargs is not None and "latent_radius" in methods:
+            truncation_kwargs["latent_radius"] = {
+                **latent_radius_kwargs,
+                **truncation_kwargs.get("latent_radius", {}),
+            }
+
         methods, self.truncation_kwargs = apply_default_truncation_config(
             methods,
             truncation_kwargs=truncation_kwargs,
@@ -249,8 +260,6 @@ class FlowProposal(BaseFlowProposal):
                 )
 
             kwargs = dict(raw_kwargs)
-            if method == "latent_radius":
-                kwargs = {**(latent_radius_kwargs or {}), **kwargs}
             rules.append(rule_cls(**kwargs))
 
         self._truncation_scheme = TruncationScheme(rules)
@@ -410,6 +419,9 @@ class FlowProposal(BaseFlowProposal):
                 samples[n_accepted : n_accepted + m] = x[accept][:m]
                 n_accepted += n_accept_batch
                 logger.debug("n accepted: %s / %s", n_accepted, n_samples)
+                if n_proposed > max_samples:
+                    logger.warning("Reached max samples (%s)", max_samples)
+                    break
 
         if self.accumulate_weights:
             if accept is None or len(accept) != len(samples):

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -1,0 +1,460 @@
+"""Truncation rules for flow proposals."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from ...utils import compute_radius
+from ...utils.structures import get_subset_arrays
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TRUNCATION_METHODS = ["latent_radius"]
+DEFAULT_TRUNCATION_KWARGS = {
+    "latent_radius": {
+        "radius_mode": "constant_volume",
+        "volume_fraction": 0.95,
+    }
+}
+
+LEGACY_LATENT_RADIUS_DEFAULTS = {
+    "constant_volume_mode": True,
+    "volume_fraction": 0.95,
+    "fuzz": 1.0,
+    "expansion_fraction": 4.0,
+    "fixed_radius": False,
+    "radius_mode": None,
+    "min_radius": False,
+    "max_radius": 50.0,
+    "compute_radius_with_all": False,
+}
+
+
+def get_deprecated_latent_radius_arguments(**kwargs) -> list[str]:
+    """Return legacy latent-radius arguments that differ from defaults."""
+    deprecated = []
+    for name, default in LEGACY_LATENT_RADIUS_DEFAULTS.items():
+        value = kwargs[name]
+        if default is False:
+            if value not in (False, None):
+                deprecated.append(name)
+        elif value != default:
+            deprecated.append(name)
+    return deprecated
+
+
+def normalise_truncation_methods(
+    truncation_method=None, truncation_methods=None
+) -> list[str]:
+    """Normalise truncation-method input into an ordered unique list."""
+    methods = (
+        truncation_methods
+        if truncation_methods is not None
+        else truncation_method
+    )
+    if methods is None:
+        return []
+    if isinstance(methods, str):
+        methods = [methods]
+    return list(dict.fromkeys(methods))
+
+
+def should_enable_latent_radius(latent_radius_kwargs=None) -> bool:
+    """Check if legacy radius configuration implies latent-radius truncation."""
+    latent_radius_kwargs = latent_radius_kwargs or {}
+    return any(
+        [
+            latent_radius_kwargs.get("fixed_radius") not in (False, None),
+            latent_radius_kwargs.get("min_radius") not in (False, None),
+            latent_radius_kwargs.get("max_radius") not in (False, None, 50.0),
+            latent_radius_kwargs.get("compute_radius_with_all", False),
+            latent_radius_kwargs.get("fuzz", 1.0) != 1.0,
+            latent_radius_kwargs.get("expansion_fraction", 4.0) != 4.0,
+            latent_radius_kwargs.get("radius_mode")
+            in {"fixed", "constant_volume"},
+            latent_radius_kwargs.get("constant_volume_mode", False),
+        ]
+    )
+
+
+def build_truncation_methods(
+    truncation_method=None,
+    truncation_methods=None,
+    truncate_log_q=False,
+    enforce_likelihood_threshold=False,
+    latent_radius_kwargs=None,
+    default_latent_radius: bool = False,
+) -> list[str]:
+    """Build the effective truncation-method list from legacy and new inputs."""
+    if truncation_method is not None and truncation_methods is not None:
+        raise ValueError(
+            "Specify only one of truncation_method or truncation_methods"
+        )
+
+    methods = normalise_truncation_methods(
+        truncation_method, truncation_methods
+    )
+
+    if default_latent_radius and "latent_radius" not in methods:
+        methods.insert(0, "latent_radius")
+    elif (
+        should_enable_latent_radius(latent_radius_kwargs)
+        and "latent_radius" not in methods
+    ):
+        methods.insert(0, "latent_radius")
+    if truncate_log_q and "min_log_q" not in methods:
+        methods.append("min_log_q")
+    if enforce_likelihood_threshold and "likelihood_threshold" not in methods:
+        methods.append("likelihood_threshold")
+    return methods
+
+
+def apply_default_truncation_config(
+    methods,
+    truncation_kwargs=None,
+    *,
+    default_latent_radius: bool = False,
+):
+    """Apply canonical default truncation configuration."""
+    if default_latent_radius and not methods:
+        methods = list(DEFAULT_TRUNCATION_METHODS)
+    else:
+        methods = list(methods)
+
+    kwargs = {
+        name: dict(value) for name, value in (truncation_kwargs or {}).items()
+    }
+
+    for name, default_kwargs in DEFAULT_TRUNCATION_KWARGS.items():
+        if name not in methods:
+            continue
+        kwargs.setdefault(name, {})
+        for key, value in default_kwargs.items():
+            kwargs[name].setdefault(key, value)
+
+    return methods, kwargs
+
+
+class BaseTruncationRule:
+    """Base class for truncation rules."""
+
+    name = "base"
+    _transient_defaults = {}
+
+    def __init__(self) -> None:
+        self.reset()
+
+    @property
+    def requires_log_likelihood(self) -> bool:
+        """Indicate if the rule needs log-likelihood values."""
+        return False
+
+    def configure(self, proposal) -> None:
+        """Apply any proposal-level configuration needed by the rule."""
+        return None
+
+    def prepare(self, proposal, worst_point, radius=None):
+        """Prepare per-population data for the rule."""
+        return None
+
+    def apply_latent(self, proposal, z):
+        """Apply truncation in latent space before the inverse pass."""
+        return z
+
+    def apply_after_backward(self, proposal, x, log_q, z):
+        """Apply truncation after the inverse pass and rescaling."""
+        return x, log_q, z
+
+    def apply_after_likelihood(self, proposal, x, log_q, z):
+        """Apply truncation after likelihood evaluation."""
+        return x, log_q, z
+
+    def reset(self) -> None:
+        """Reset transient state."""
+        for key, value in self._transient_defaults.items():
+            setattr(self, key, value)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for key, value in self._transient_defaults.items():
+            state[key] = value
+        return state
+
+
+class LatentRadiusTruncation(BaseTruncationRule):
+    """Filter latent samples using a radial threshold."""
+
+    name = "latent_radius"
+    _transient_defaults = {"_radius": np.nan, "_threshold": np.nan}
+
+    def __init__(
+        self,
+        radius_mode: str | None = None,
+        fixed_radius: float | bool = False,
+        min_radius: float | bool = False,
+        max_radius: float | bool = 50.0,
+        compute_radius_with_all: bool = False,
+        constant_volume_mode: bool = False,
+        volume_fraction: float = 0.95,
+        fuzz: float = 1.0,
+        expansion_fraction: float | None = 4.0,
+    ) -> None:
+        super().__init__()
+        self.fixed_radius = self._coerce_radius(
+            fixed_radius, name="fixed_radius"
+        )
+        self.min_radius = self._coerce_radius(min_radius, name="min_radius")
+        self.max_radius = self._coerce_radius(max_radius, name="max_radius")
+        self.compute_radius_with_all = compute_radius_with_all
+        self.volume_fraction = float(volume_fraction)
+        self.fuzz = float(fuzz)
+        self.expansion_fraction = expansion_fraction
+        self.radius_mode = self._resolve_radius_mode(
+            radius_mode,
+            fixed_radius=self.fixed_radius,
+            constant_volume_mode=constant_volume_mode,
+        )
+
+    @property
+    def radius(self) -> float:
+        return self._radius
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @staticmethod
+    def _coerce_radius(value, *, name):
+        if value in (False, None):
+            return False
+        if not isinstance(value, (int, float)):
+            raise RuntimeError(f"{name} must be an int or float")
+        return float(value)
+
+    @staticmethod
+    def _resolve_radius_mode(
+        radius_mode, *, fixed_radius, constant_volume_mode
+    ):
+        if radius_mode is None:
+            if constant_volume_mode:
+                radius_mode = "constant_volume"
+            elif fixed_radius is not False:
+                radius_mode = "fixed"
+            else:
+                radius_mode = "adaptive"
+
+        if radius_mode not in {"adaptive", "fixed", "constant_volume"}:
+            raise ValueError(
+                "Unknown radius mode: "
+                f"{radius_mode}. Choose from: adaptive, fixed, constant_volume"
+            )
+        if radius_mode == "fixed" and fixed_radius is False:
+            raise ValueError(
+                "Fixed radius mode requires `fixed_radius` to be specified"
+            )
+        return radius_mode
+
+    @property
+    def constant_volume_mode(self) -> bool:
+        return self.radius_mode == "constant_volume"
+
+    def to_kwargs(self) -> dict:
+        """Return keyword arguments that reconstruct the rule."""
+        return {
+            "radius_mode": self.radius_mode,
+            "fixed_radius": self.fixed_radius,
+            "min_radius": self.min_radius,
+            "max_radius": self.max_radius,
+            "compute_radius_with_all": self.compute_radius_with_all,
+            "constant_volume_mode": self.constant_volume_mode,
+            "volume_fraction": self.volume_fraction,
+            "fuzz": self.fuzz,
+            "expansion_fraction": self.expansion_fraction,
+        }
+
+    def configure(self, proposal) -> None:
+        if self.expansion_fraction and self.expansion_fraction is not None:
+            logger.info(
+                "Overwriting latent-radius fuzz factor with expansion fraction"
+            )
+            self.fuzz = (1 + self.expansion_fraction) ** (
+                1 / proposal.prime_dims
+            )
+            logger.info(f"New latent-radius fuzz factor: {self.fuzz}")
+
+        if not self.constant_volume_mode:
+            return
+
+        self.fixed_radius = compute_radius(
+            proposal.prime_dims, self.volume_fraction
+        )
+        self.fuzz = 1.0
+
+        if self.max_radius and self.max_radius < self.fixed_radius:
+            logger.warning(
+                "Max radius is less than the constant-volume radius. "
+                "Disabling max radius."
+            )
+            self.max_radius = False
+        if self.min_radius and self.min_radius > self.fixed_radius:
+            logger.warning(
+                "Min radius is greater than the constant-volume radius. "
+                "Disabling min radius."
+            )
+            self.min_radius = False
+
+    def _compute_radius(self, proposal, worst_point, radius=None) -> float:
+        if radius is not None:
+            return float(radius)
+
+        if self.radius_mode in {"fixed", "constant_volume"}:
+            if self.fixed_radius is False:
+                raise RuntimeError(
+                    "Fixed radius mode requires `fixed_radius` to be specified"
+                )
+            return float(self.fixed_radius)
+
+        if self.compute_radius_with_all:
+            worst_point = proposal.training_data
+
+        worst_z = proposal.forward_pass(
+            worst_point, rescale=True, compute_radius=True
+        )[0]
+        radius = float(np.sqrt(np.sum(worst_z**2.0, axis=-1)).max())
+        if self.max_radius and radius > self.max_radius:
+            radius = self.max_radius
+        if self.min_radius and radius < self.min_radius:
+            radius = self.min_radius
+        return float(radius)
+
+    def prepare(self, proposal, worst_point, radius=None):
+        radius = self._compute_radius(proposal, worst_point, radius=radius)
+        self._radius = radius
+        self._threshold = self.fuzz * radius
+
+    def apply_latent(self, proposal, z):
+        radius = np.sqrt(np.sum(z**2.0, axis=-1))
+        keep = radius <= self.threshold
+        logger.debug(
+            "Discarding %s latent samples outside radius threshold",
+            len(z) - int(keep.sum()),
+        )
+        return z[keep]
+
+
+class MinLogQTruncation(BaseTruncationRule):
+    """Truncate samples using the minimum live-point log q."""
+
+    name = "min_log_q"
+    _transient_defaults = {"_min_log_q": np.nan}
+
+    @property
+    def min_log_q(self) -> float:
+        return self._min_log_q
+
+    def prepare(self, proposal, worst_point, radius=None):
+        self._min_log_q = float(
+            proposal.forward_pass(proposal.training_data)[1].min()
+        )
+        logger.debug("Truncating with log_q=%0.3f", self.min_log_q)
+
+    def apply_after_backward(self, proposal, x, log_q, z):
+        keep = log_q > self.min_log_q
+        logger.debug(
+            "Discarding %s samples below log_q_min",
+            len(log_q) - int(keep.sum()),
+        )
+        return get_subset_arrays(keep, x, log_q, z)
+
+
+class LikelihoodThresholdTruncation(BaseTruncationRule):
+    """Truncate samples using the current likelihood threshold."""
+
+    name = "likelihood_threshold"
+    _transient_defaults = {"_threshold": np.nan}
+
+    @property
+    def requires_log_likelihood(self) -> bool:
+        return True
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    def prepare(self, proposal, worst_point, radius=None):
+        self._threshold = float(worst_point["logL"])
+
+    def apply_after_likelihood(self, proposal, x, log_q, z):
+        keep = x["logL"] > self.threshold
+        logger.debug(
+            "Accepting %s / %s samples above logL threshold",
+            int(keep.sum()),
+            len(x),
+        )
+        return get_subset_arrays(keep, x, log_q, z)
+
+
+class TruncationScheme:
+    """Apply an ordered set of truncation rules."""
+
+    def __init__(self, rules: list[BaseTruncationRule] | None = None) -> None:
+        self.rules = []
+        for rule in rules or []:
+            self.add_rule(rule)
+
+    @property
+    def rule_names(self) -> list[str]:
+        return [rule.name for rule in self.rules]
+
+    @property
+    def requires_log_likelihood(self) -> bool:
+        return any(rule.requires_log_likelihood for rule in self.rules)
+
+    def has_rule(self, name: str) -> bool:
+        return any(rule.name == name for rule in self.rules)
+
+    def get_rule(self, name: str):
+        for rule in self.rules:
+            if rule.name == name:
+                return rule
+        return None
+
+    def add_rule(
+        self, rule: BaseTruncationRule, index: int | None = None
+    ) -> None:
+        if self.has_rule(rule.name):
+            raise ValueError(f"Duplicate truncation rule: {rule.name}")
+        if index is None:
+            self.rules.append(rule)
+        else:
+            self.rules.insert(index, rule)
+
+    def configure(self, proposal) -> None:
+        for rule in self.rules:
+            rule.configure(proposal)
+
+    def prepare(self, proposal, worst_point, radius=None):
+        self.reset()
+        for rule in self.rules:
+            rule.prepare(proposal, worst_point, radius=radius)
+
+    def apply_latent(self, proposal, z):
+        for rule in self.rules:
+            z = rule.apply_latent(proposal, z)
+        return z
+
+    def apply_after_backward(self, proposal, x, log_q, z):
+        for rule in self.rules:
+            x, log_q, z = rule.apply_after_backward(proposal, x, log_q, z)
+        return x, log_q, z
+
+    def apply_after_likelihood(self, proposal, x, log_q, z):
+        for rule in self.rules:
+            x, log_q, z = rule.apply_after_likelihood(proposal, x, log_q, z)
+        return x, log_q, z
+
+    def reset(self) -> None:
+        for rule in self.rules:
+            rule.reset()

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -388,6 +388,21 @@ class LikelihoodThresholdTruncation(BaseTruncationRule):
         return get_subset_arrays(keep, x, log_q, z)
 
 
+TRUNCATION_REGISTRY = {
+    "latent_radius": LatentRadiusTruncation,
+    "min_log_q": MinLogQTruncation,
+    "likelihood_threshold": LikelihoodThresholdTruncation,
+}
+
+
+def get_truncation_rule_class(name: str):
+    """Get the truncation rule class for a configured method name."""
+    try:
+        return TRUNCATION_REGISTRY[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown truncation method: {name}") from exc
+
+
 class TruncationScheme:
     """Apply an ordered set of truncation rules."""
 

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -129,6 +129,31 @@ def apply_default_truncation_config(
     return methods, kwargs
 
 
+def normalise_truncation_kwargs(
+    truncation_method=None,
+    truncation_methods=None,
+    truncation_kwargs=None,
+):
+    """Normalise truncation kwargs into the canonical method-keyed form."""
+    if truncation_kwargs is None:
+        return {}
+
+    kwargs = {
+        name: dict(value) if isinstance(value, dict) else value
+        for name, value in truncation_kwargs.items()
+    }
+
+    if (
+        isinstance(truncation_method, str)
+        and truncation_methods is None
+        and truncation_method not in kwargs
+        and not any(isinstance(value, dict) for value in kwargs.values())
+    ):
+        return {truncation_method: kwargs}
+
+    return kwargs
+
+
 class BaseTruncationRule:
     """Base class for truncation rules."""
 

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -309,6 +309,12 @@ class LatentRadiusTruncation(BaseTruncationRule):
             return float(self.fixed_radius)
 
         if self.compute_radius_with_all:
+            if proposal.training_data is None or not len(
+                proposal.training_data
+            ):
+                raise RuntimeError(
+                    "compute_radius_with_all requires training_data to be set"
+                )
             worst_point = proposal.training_data
 
         worst_z = proposal.forward_pass(
@@ -347,6 +353,11 @@ class MinLogQTruncation(BaseTruncationRule):
         return self._min_log_q
 
     def prepare(self, proposal, worst_point, radius=None):
+        if proposal.training_data is None or not len(proposal.training_data):
+            raise RuntimeError(
+                "min_log_q truncation requires training_data to be set"
+            )
+
         self._min_log_q = float(
             proposal.forward_pass(proposal.training_data)[1].min()
         )
@@ -376,7 +387,14 @@ class LikelihoodThresholdTruncation(BaseTruncationRule):
         return self._threshold
 
     def prepare(self, proposal, worst_point, radius=None):
-        self._threshold = float(worst_point["logL"])
+        threshold = np.asarray(worst_point["logL"], dtype=float).reshape(-1)[0]
+        if not np.isfinite(threshold):
+            logger.debug(
+                "Worst point does not have a finite log-likelihood. "
+                "Disabling likelihood-threshold truncation."
+            )
+            threshold = -np.inf
+        self._threshold = float(threshold)
 
     def apply_after_likelihood(self, proposal, x, log_q, z):
         keep = x["logL"] > self.threshold

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 
 import numpy as np
 
@@ -115,14 +116,14 @@ def apply_default_truncation_config(
     else:
         methods = list(methods)
 
-    kwargs = {
-        name: dict(value) for name, value in (truncation_kwargs or {}).items()
-    }
+    kwargs = deepcopy(truncation_kwargs or {})
 
     for name, default_kwargs in DEFAULT_TRUNCATION_KWARGS.items():
         if name not in methods:
             continue
         kwargs.setdefault(name, {})
+        if not isinstance(kwargs[name], dict):
+            continue
         for key, value in default_kwargs.items():
             kwargs[name].setdefault(key, value)
 
@@ -138,10 +139,7 @@ def normalise_truncation_kwargs(
     if truncation_kwargs is None:
         return {}
 
-    kwargs = {
-        name: dict(value) if isinstance(value, dict) else value
-        for name, value in truncation_kwargs.items()
-    }
+    kwargs = deepcopy(truncation_kwargs)
 
     if (
         isinstance(truncation_method, str)

--- a/src/nessai/proposal/flowproposal/truncation.py
+++ b/src/nessai/proposal/flowproposal/truncation.py
@@ -19,30 +19,35 @@ DEFAULT_TRUNCATION_KWARGS = {
     }
 }
 
-LEGACY_LATENT_RADIUS_DEFAULTS = {
-    "constant_volume_mode": True,
-    "volume_fraction": 0.95,
-    "fuzz": 1.0,
-    "expansion_fraction": 4.0,
-    "fixed_radius": False,
-    "radius_mode": None,
-    "min_radius": False,
-    "max_radius": 50.0,
-    "compute_radius_with_all": False,
-}
+LEGACY_LATENT_RADIUS_ARGUMENTS = (
+    "constant_volume_mode",
+    "volume_fraction",
+    "fuzz",
+    "expansion_fraction",
+    "fixed_radius",
+    "radius_mode",
+    "min_radius",
+    "max_radius",
+    "compute_radius_with_all",
+)
 
 
 def get_deprecated_latent_radius_arguments(**kwargs) -> list[str]:
-    """Return legacy latent-radius arguments that differ from defaults."""
-    deprecated = []
-    for name, default in LEGACY_LATENT_RADIUS_DEFAULTS.items():
-        value = kwargs[name]
-        if default is False:
-            if value not in (False, None):
-                deprecated.append(name)
-        elif value != default:
-            deprecated.append(name)
-    return deprecated
+    """Return deprecated latent-radius arguments that were explicitly set."""
+    return [
+        name
+        for name in LEGACY_LATENT_RADIUS_ARGUMENTS
+        if kwargs[name] is not None
+    ]
+
+
+def get_deprecated_latent_radius_kwargs(**kwargs) -> dict:
+    """Build sparse latent-radius kwargs from deprecated proposal arguments."""
+    return {
+        name: kwargs[name]
+        for name in LEGACY_LATENT_RADIUS_ARGUMENTS
+        if kwargs[name] is not None
+    }
 
 
 def normalise_truncation_methods(
@@ -62,21 +67,8 @@ def normalise_truncation_methods(
 
 
 def should_enable_latent_radius(latent_radius_kwargs=None) -> bool:
-    """Check if legacy radius configuration implies latent-radius truncation."""
-    latent_radius_kwargs = latent_radius_kwargs or {}
-    return any(
-        [
-            latent_radius_kwargs.get("fixed_radius") not in (False, None),
-            latent_radius_kwargs.get("min_radius") not in (False, None),
-            latent_radius_kwargs.get("max_radius") not in (False, None, 50.0),
-            latent_radius_kwargs.get("compute_radius_with_all", False),
-            latent_radius_kwargs.get("fuzz", 1.0) != 1.0,
-            latent_radius_kwargs.get("expansion_fraction", 4.0) != 4.0,
-            latent_radius_kwargs.get("radius_mode")
-            in {"fixed", "constant_volume"},
-            latent_radius_kwargs.get("constant_volume_mode", False),
-        ]
-    )
+    """Check if latent-radius truncation should be enabled from kwargs."""
+    return bool(latent_radius_kwargs)
 
 
 def build_truncation_methods(

--- a/tests/test_flowmodel/test_flowmodel_base.py
+++ b/tests/test_flowmodel/test_flowmodel_base.py
@@ -549,8 +549,8 @@ def test_numpy_array_to_tensor(model, n_samples):
     np.testing.assert_equal(x, out.numpy())
 
 
-def test_sample_log_prob_alt_dist(model):
-    """Assert the alternate distribution is used."""
+def test_sample_log_prob_with_latent_uses_base_distribution(model):
+    """Assert latent samples use the flow base distribution."""
     z = torch.randn(5, 2)
     x = torch.randn(5, 2)
     log_prob = torch.randn(5)
@@ -559,18 +559,13 @@ def test_sample_log_prob_alt_dist(model):
     model.model = MagicMock()
     model.model.device = "cpu"
     model.model.eval = MagicMock()
-    model.model.base_distribution_log_prob = MagicMock()
+    model.model.base_distribution_log_prob = MagicMock(return_value=log_prob)
     model.model.inverse = MagicMock(return_value=(x, log_j))
-    alt_dist = MagicMock()
-    alt_dist.log_prob = MagicMock(return_value=log_prob)
 
-    x_out, log_prob_out = FlowModel.sample_and_log_prob(
-        model, z=z, alt_dist=alt_dist
-    )
+    x_out, log_prob_out = FlowModel.sample_and_log_prob(model, z=z)
 
     model.model.inverse.assert_called_once_with(z, context=None)
-    model.model.base_distribution_log_prob.assert_not_called()
-    alt_dist.log_prob.assert_called_once_with(z)
+    model.model.base_distribution_log_prob.assert_called_once_with(z)
     np.testing.assert_equal(x_out, x.numpy())
     np.testing.assert_equal(log_prob_out, log_prob_expected)
 

--- a/tests/test_proposal/test_augmented.py
+++ b/tests/test_proposal/test_augmented.py
@@ -218,7 +218,6 @@ def test_backward_pass(proposal, model, log_p, marg, rng, return_z):
         side_effect=lambda a, return_unit_hypercube: (a, np.ones(a.size))
     )
     proposal.prime_parameters = model.names
-    proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
     )
@@ -236,9 +235,7 @@ def test_backward_pass(proposal, model, log_p, marg, rng, return_z):
 
     assert len(out[0]) == acc
     proposal.inverse_rescale.assert_called_once()
-    proposal.flow.sample_and_log_prob.assert_called_once_with(
-        z=z, alt_dist=None
-    )
+    proposal.flow.sample_and_log_prob.assert_called_once_with(z=z)
 
     assert proposal._marginalise_augment.called is marg
 

--- a/tests/test_proposal/test_flowproposal/test_base/test_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_flow.py
@@ -102,9 +102,7 @@ def test_compute_latent_log_prob_with_temperature(proposal):
     proposal.flow.model.base_distribution_log_prob = MagicMock(
         return_value=torch.zeros(1, dtype=torch.get_default_dtype())
     )
-    out = BaseFlowProposal.compute_latent_log_prob(
-        proposal, z, temperature=4.0
-    )
+    out = BaseFlowProposal.latent_log_prob(proposal, z, temperature=4.0)
     proposal.flow.model.base_distribution_log_prob.assert_called_once()
     np.testing.assert_allclose(out, np.array([-np.log(2.0) * 2]))
 

--- a/tests/test_proposal/test_flowproposal/test_base/test_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+import torch
 
 from nessai.livepoint import get_dtype, numpy_array_to_live_points
 from nessai.proposal.flowproposal.base import BaseFlowProposal
@@ -76,6 +77,36 @@ def test_forward_pass(proposal, model, n):
     assert np.array_equal(log_p, 3 * np.ones(n))
     proposal.rescale.assert_called_once_with(x, compute_radius=False)
     proposal.flow.forward_and_log_prob.assert_called_once()
+
+
+def test_sample_latent_distribution_with_temperature(proposal):
+    proposal.latent_temperature = 4.0
+    proposal.flow = MagicMock()
+    proposal.flow.sample_latent_distribution = MagicMock(
+        return_value=np.array([[1.0, -2.0]])
+    )
+    out = BaseFlowProposal.sample_latent_distribution(proposal, 1)
+    proposal.flow.sample_latent_distribution.assert_called_once_with(1)
+    np.testing.assert_array_equal(out, np.array([[2.0, -4.0]]))
+
+
+def test_compute_latent_log_prob_with_temperature(proposal):
+    z = np.array([[2.0, 0.0]])
+    proposal.flow = MagicMock()
+    proposal.flow.numpy_array_to_tensor = MagicMock(
+        side_effect=lambda x: torch.from_numpy(x).type(
+            torch.get_default_dtype()
+        )
+    )
+    proposal.flow.model = MagicMock()
+    proposal.flow.model.base_distribution_log_prob = MagicMock(
+        return_value=torch.zeros(1, dtype=torch.get_default_dtype())
+    )
+    out = BaseFlowProposal.compute_latent_log_prob(
+        proposal, z, temperature=4.0
+    )
+    proposal.flow.model.base_distribution_log_prob.assert_called_once()
+    np.testing.assert_allclose(out, np.array([-np.log(2.0) * 2]))
 
 
 @pytest.mark.parametrize("rescale", [True, False])

--- a/tests/test_proposal/test_flowproposal/test_base/test_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_flow.py
@@ -90,6 +90,20 @@ def test_sample_latent_distribution_with_temperature(proposal):
     np.testing.assert_array_equal(out, np.array([[2.0, -4.0]]))
 
 
+@pytest.mark.parametrize("temperature", [None, 1.0])
+def test_sample_latent_distribution_without_temperature_scaling(
+    proposal, temperature
+):
+    proposal.latent_temperature = temperature
+    proposal.flow = MagicMock()
+    proposal.flow.sample_latent_distribution = MagicMock(
+        return_value=np.array([[1.0, -2.0]])
+    )
+    out = BaseFlowProposal.sample_latent_distribution(proposal, 1)
+    proposal.flow.sample_latent_distribution.assert_called_once_with(1)
+    np.testing.assert_array_equal(out, np.array([[1.0, -2.0]]))
+
+
 def test_compute_latent_log_prob_with_temperature(proposal):
     z = np.array([[2.0, 0.0]])
     proposal.flow = MagicMock()
@@ -105,6 +119,28 @@ def test_compute_latent_log_prob_with_temperature(proposal):
     out = BaseFlowProposal.latent_log_prob(proposal, z, temperature=4.0)
     proposal.flow.model.base_distribution_log_prob.assert_called_once()
     np.testing.assert_allclose(out, np.array([-np.log(2.0) * 2]))
+
+
+@pytest.mark.parametrize("temperature", [None, 1.0])
+def test_compute_latent_log_prob_without_temperature_scaling(
+    proposal, temperature
+):
+    z = np.array([[2.0, 0.0]])
+    proposal.flow = MagicMock()
+    proposal.flow.numpy_array_to_tensor = MagicMock(
+        side_effect=lambda x: torch.from_numpy(x).type(
+            torch.get_default_dtype()
+        )
+    )
+    proposal.flow.model = MagicMock()
+    proposal.flow.model.base_distribution_log_prob = MagicMock(
+        return_value=torch.zeros(1, dtype=torch.get_default_dtype())
+    )
+    out = BaseFlowProposal.latent_log_prob(
+        proposal, z, temperature=temperature
+    )
+    proposal.flow.model.base_distribution_log_prob.assert_called_once()
+    np.testing.assert_allclose(out, np.array([0.0]))
 
 
 @pytest.mark.parametrize("rescale", [True, False])

--- a/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
@@ -44,7 +44,8 @@ def test_training_plots(proposal, tmp_path, plot):
     proposal.dims = 2
     proposal.prime_parameters = prime_names
     proposal.flow = MagicMock()
-    proposal.flow.sample_latent_distribution = MagicMock(return_value=z_gen)
+    # proposal.flow.sample_latent_distribution = MagicMock(return_value=z_gen)
+    proposal.sample_latent_distribution = MagicMock(return_value=z_gen)
 
     proposal.forward_pass = MagicMock(return_value=(z, None))
     proposal.backward_pass = MagicMock(return_value=(x_prime_gen, np.ones(10)))
@@ -54,6 +55,9 @@ def test_training_plots(proposal, tmp_path, plot):
     proposal.model.names = names
 
     FlowProposal._plot_training_data(proposal, output)
+    proposal.sample_latent_distribution.assert_called_once_with(
+        proposal.training_data.size
+    )
 
     assert os.path.exists(os.path.join(output, "x_samples.png")) is bool(plot)
     assert os.path.exists(os.path.join(output, "x_generated.png")) is bool(

--- a/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
@@ -112,7 +112,7 @@ def test_plot_pool_1d(proposal, tmpdir, custom_log_prob):
     proposal.forward_pass = MagicMock(return_value=(z, log_q))
     proposal.flow = MagicMock()
     proposal.flow.device = "cpu"
-    proposal.compute_latent_log_prob = MagicMock(return_value=log_p.numpy())
+    proposal.latent_log_prob = MagicMock(return_value=log_p.numpy())
     if not custom_log_prob:
         proposal.flow.model.base_distribution_log_prob = MagicMock(
             return_value=log_p
@@ -128,4 +128,4 @@ def test_plot_pool_1d(proposal, tmpdir, custom_log_prob):
     )
     assert os.path.exists(os.path.join(output, "pool_0_log_q.png"))
 
-    proposal.compute_latent_log_prob.assert_called_once_with(z, None)
+    proposal.latent_log_prob.assert_called_once_with(z, None)

--- a/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
+++ b/tests/test_proposal/test_flowproposal/test_base/test_plotting.py
@@ -80,8 +80,8 @@ def test_plot_pool_all(proposal):
     )
 
 
-@pytest.mark.parametrize("alt_dist", [False, True])
-def test_plot_pool_1d(proposal, tmpdir, alt_dist):
+@pytest.mark.parametrize("custom_log_prob", [False, True])
+def test_plot_pool_1d(proposal, tmpdir, custom_log_prob):
     """Test `plot_pool` when plotting is not 'all'.
 
     Test cases when there is an alternative base distribution is used and
@@ -102,19 +102,17 @@ def test_plot_pool_1d(proposal, tmpdir, alt_dist):
     training_data["logP"] = np.random.randn(10)
     training_data["logP"] = np.random.randn(10)
     proposal.training_data = training_data
+    proposal.latent_temperature = None
     log_p = torch.arange(10)
 
     proposal.forward_pass = MagicMock(return_value=(z, log_q))
     proposal.flow = MagicMock()
     proposal.flow.device = "cpu"
-    if alt_dist:
-        proposal.alt_dist = MagicMock()
-        proposal.alt_dist.log_prob = MagicMock(return_value=log_p)
-    else:
+    proposal.compute_latent_log_prob = MagicMock(return_value=log_p.numpy())
+    if not custom_log_prob:
         proposal.flow.model.base_distribution_log_prob = MagicMock(
             return_value=log_p
         )
-        proposal.alt_dist = None
     with patch("nessai.proposal.flowproposal.base.plot_1d_comparison") as plot:
         FlowProposal.plot_pool(proposal, x)
 
@@ -126,7 +124,4 @@ def test_plot_pool_1d(proposal, tmpdir, alt_dist):
     )
     assert os.path.exists(os.path.join(output, "pool_0_log_q.png"))
 
-    if alt_dist:
-        proposal.alt_dist.log_prob.assert_called_once()
-    else:
-        proposal.flow.model.base_distribution_log_prob.assert_called_once()
+    proposal.compute_latent_log_prob.assert_called_once_with(z, None)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import create_autospec
 import numpy as np
 import pytest
 
+from nessai.livepoint import empty_structured_array
 from nessai.proposal.flowproposal import FlowProposal
 from nessai.proposal.flowproposal.truncation import TruncationScheme
 
@@ -48,9 +49,7 @@ def point():
 @pytest.fixture
 def samples():
     def _samples(values):
-        out = np.zeros(
-            len(values), dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
-        )
+        out = empty_structured_array(len(values), names=["x", "y"])
         out["x"] = [v[0] for v in values]
         out["y"] = [v[1] for v in values]
         return out

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/conftest.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import create_autospec
 
+import numpy as np
 import pytest
 
 from nessai.proposal.flowproposal import FlowProposal
+from nessai.proposal.flowproposal.truncation import TruncationScheme
 
 
 @pytest.fixture(params=[True, False])
@@ -13,10 +15,44 @@ def map_to_unit_hypercube(request):
 
 @pytest.fixture()
 def proposal(rng):
-    proposal = create_autospec(FlowProposal)
+    proposal = create_autospec(FlowProposal, instance=True)
     proposal._initialised = False
+    proposal.initialised = False
     proposal.accumulate_weights = False
+    proposal.truncate_log_q = False
     proposal.enforce_likelihood_threshold = False
     proposal.map_to_unit_hypercube = False
+    proposal.truncation_method = None
+    proposal.truncation_methods = []
+    proposal.truncation_kwargs = {}
+    proposal._truncation_scheme = TruncationScheme()
+    proposal.poolsize = 2000
+    proposal.drawsize = 2000
+    proposal.latent_temperature = None
     proposal.rng = rng
     return proposal
+
+
+@pytest.fixture
+def point():
+    def _point(x, y, logl=0.0):
+        out = np.zeros(1, dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")])
+        out["x"] = x
+        out["y"] = y
+        out["logL"] = logl
+        return out[0]
+
+    return _point
+
+
+@pytest.fixture
+def samples():
+    def _samples(values):
+        out = np.zeros(
+            len(values), dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
+        )
+        out["x"] = [v[0] for v in values]
+        out["y"] = [v[1] for v in values]
+        return out
+
+    return _samples

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for FlowProposal truncation configuration."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from nessai.proposal import FlowProposal
@@ -9,6 +11,13 @@ from nessai.proposal.flowproposal.truncation import (
     LikelihoodThresholdTruncation,
     MinLogQTruncation,
 )
+
+
+def configure_truncation_mocks(proposal, latent_radius_rule=None):
+    proposal._get_latent_radius_rule = MagicMock(
+        return_value=latent_radius_rule
+    )
+    proposal._sync_truncation_state = MagicMock(return_value=None)
 
 
 def test_configure_population_sets_defaults(proposal):
@@ -53,11 +62,12 @@ def test_configure_population_rejects_invalid_latent_temperature_type(
 
 
 def test_configure_truncation_normalises_string(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal, truncation_method="likelihood_threshold"
     )
-    assert proposal.truncation_methods == ["likelihood_threshold"]
-    assert proposal.enforce_likelihood_threshold is True
+    assert proposal._truncation_scheme.rule_names == ["likelihood_threshold"]
+    proposal._sync_truncation_state.assert_called_once_with()
     assert isinstance(
         proposal._truncation_scheme.get_rule("likelihood_threshold"),
         LikelihoodThresholdTruncation,
@@ -65,17 +75,20 @@ def test_configure_truncation_normalises_string(proposal):
 
 
 def test_configure_truncation_deduplicates_methods(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         truncation_methods=["min_log_q", "min_log_q", "likelihood_threshold"],
     )
-    assert proposal.truncation_methods == [
+    assert proposal._truncation_scheme.rule_names == [
         "min_log_q",
         "likelihood_threshold",
     ]
+    proposal._sync_truncation_state.assert_called_once_with()
 
 
 def test_configure_truncation_unknown_method(proposal):
+    configure_truncation_mocks(proposal)
     with pytest.raises(ValueError, match="Unknown truncation method"):
         FlowProposal.configure_truncation(
             proposal, truncation_methods=["unknown"]
@@ -83,6 +96,7 @@ def test_configure_truncation_unknown_method(proposal):
 
 
 def test_configure_truncation_rejects_method_and_methods(proposal):
+    configure_truncation_mocks(proposal)
     with pytest.raises(
         ValueError, match="Specify only one of truncation_method"
     ):
@@ -94,26 +108,30 @@ def test_configure_truncation_rejects_method_and_methods(proposal):
 
 
 def test_configure_truncation_enables_legacy_flags(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         truncate_log_q=True,
         enforce_likelihood_threshold=True,
     )
-    assert proposal.truncation_methods == [
+    assert proposal._truncation_scheme.rule_names == [
         "min_log_q",
         "likelihood_threshold",
     ]
+    proposal._sync_truncation_state.assert_called_once_with()
     assert isinstance(
         proposal._truncation_scheme.get_rule("min_log_q"), MinLogQTruncation
     )
 
 
 def test_configure_truncation_enables_latent_radius_from_kwargs(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         latent_radius_kwargs=dict(fixed_radius=4.0, radius_mode="fixed"),
     )
-    assert proposal.truncation_methods == ["latent_radius"]
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    proposal._sync_truncation_state.assert_called_once_with()
     rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert isinstance(rule, LatentRadiusTruncation)
     assert rule.fixed_radius == 4.0
@@ -121,23 +139,27 @@ def test_configure_truncation_enables_latent_radius_from_kwargs(proposal):
 
 
 def test_configure_truncation_creates_radius_rule(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         latent_radius_kwargs=dict(fixed_radius=5.0, radius_mode="fixed"),
     )
-    assert proposal.truncation_methods == ["latent_radius"]
-    rule = proposal.get_truncation_rule("latent_radius")
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    proposal._sync_truncation_state.assert_called_once_with()
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert rule.fixed_radius == 5.0
     assert rule.radius_mode == "fixed"
 
 
 def test_configure_truncation_applies_default_radius_kwargs(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         default_latent_radius=True,
     )
-    assert proposal.truncation_methods == ["latent_radius"]
-    rule = proposal.get_truncation_rule("latent_radius")
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    proposal._sync_truncation_state.assert_called_once_with()
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert rule.radius_mode == "constant_volume"
     assert rule.volume_fraction == 0.95
 
@@ -145,49 +167,58 @@ def test_configure_truncation_applies_default_radius_kwargs(proposal):
 def test_configure_truncation_does_not_apply_default_radius_to_explicit_methods(
     proposal,
 ):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         truncation_methods=["min_log_q"],
         default_latent_radius=True,
     )
-    assert proposal.truncation_methods == ["min_log_q"]
-    assert proposal.get_truncation_rule("latent_radius") is None
+    assert proposal._truncation_scheme.rule_names == ["min_log_q"]
+    proposal._sync_truncation_state.assert_called_once_with()
+    assert proposal._truncation_scheme.get_rule("latent_radius") is None
 
 
 def test_configure_truncation_explicit_empty_list_disables_default_radius(
     proposal,
 ):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         truncation_methods=[],
         default_latent_radius=True,
     )
-    assert proposal.truncation_methods == []
-    assert proposal.get_truncation_rule("latent_radius") is None
+    assert proposal._truncation_scheme.rule_names == []
+    proposal._sync_truncation_state.assert_called_once_with()
+    assert proposal._truncation_scheme.get_rule("latent_radius") is None
 
 
 def test_configure_truncation_enables_radius_from_expansion_fraction(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         latent_radius_kwargs=dict(expansion_fraction=None),
     )
-    assert proposal.truncation_methods == ["latent_radius"]
-    rule = proposal.get_truncation_rule("latent_radius")
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    proposal._sync_truncation_state.assert_called_once_with()
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert rule.expansion_fraction is None
 
 
 def test_configure_truncation_constant_volume_updates_rule(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         latent_radius_kwargs=dict(fixed_radius=5.0, constant_volume_mode=True),
     )
-    assert proposal.truncation_methods == ["latent_radius"]
-    rule = proposal.get_truncation_rule("latent_radius")
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    proposal._sync_truncation_state.assert_called_once_with()
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert rule.constant_volume_mode is True
     assert rule.radius_mode == "constant_volume"
 
 
 def test_configure_truncation_rejects_invalid_fixed_radius(proposal):
+    configure_truncation_mocks(proposal)
     with pytest.raises(
         RuntimeError, match="fixed_radius must be an int or float"
     ):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 """Tests for FlowProposal truncation configuration."""
 
+import logging
+import warnings
 from unittest.mock import MagicMock
 
 import pytest
 
 from nessai.proposal import FlowProposal
 from nessai.proposal.flowproposal.truncation import (
+    BaseTruncationRule,
     LatentRadiusTruncation,
     LikelihoodThresholdTruncation,
     MinLogQTruncation,
+    TruncationScheme,
 )
 
 
@@ -59,6 +63,77 @@ def test_configure_population_rejects_invalid_latent_temperature_type(
         FlowProposal.configure_population(
             proposal, 1000, latent_temperature="bad"
         )
+
+
+def test_truncation_property_and_rule_helpers(proposal):
+    proposal._truncation_scheme = TruncationScheme(
+        [LatentRadiusTruncation(fixed_radius=1.0, radius_mode="fixed")]
+    )
+    proposal.truncation = proposal._truncation_scheme
+    assert (
+        FlowProposal.truncation.fget(proposal) is proposal._truncation_scheme
+    )
+    assert isinstance(
+        FlowProposal.get_truncation_rule(proposal, "latent_radius"),
+        LatentRadiusTruncation,
+    )
+    assert isinstance(
+        FlowProposal._get_latent_radius_rule(proposal),
+        LatentRadiusTruncation,
+    )
+
+
+def test_sync_truncation_state_updates_legacy_flags(proposal):
+    proposal._truncation_scheme = TruncationScheme(
+        [MinLogQTruncation(), LikelihoodThresholdTruncation()]
+    )
+    FlowProposal._sync_truncation_state(proposal)
+    assert proposal.truncation_methods == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+    assert proposal.truncate_log_q is True
+    assert proposal.enforce_likelihood_threshold is True
+
+
+def test_warning_helpers_do_nothing_when_disabled():
+    with warnings.catch_warnings(record=True) as record:
+        FlowProposal._warn_for_deprecated_latent_prior(None)
+        FlowProposal._warn_for_deprecated_likelihood_threshold(False)
+        FlowProposal._warn_for_deprecated_truncation_arguments(
+            MagicMock(),
+            fixed_radius=None,
+            radius_mode=None,
+            min_radius=None,
+            max_radius=None,
+            compute_radius_with_all=None,
+            constant_volume_mode=None,
+            volume_fraction=None,
+            fuzz=None,
+            expansion_fraction=None,
+        )
+    assert not record
+
+
+def test_log_configuration_logs_rules(proposal, caplog):
+    class DummyRule(BaseTruncationRule):
+        name = "dummy"
+
+    proposal.drawsize = 10
+    proposal.latent_prior = "flow"
+    proposal.latent_temperature = None
+    proposal.truncation_methods = ["latent_radius", "dummy"]
+    proposal._truncation_scheme = TruncationScheme(
+        [
+            LatentRadiusTruncation(fixed_radius=1.0, radius_mode="fixed"),
+            DummyRule(),
+        ]
+    )
+    with caplog.at_level(logging.INFO):
+        FlowProposal._log_configuration(proposal)
+    assert "FlowProposal configuration" in caplog.text
+    assert "FlowProposal truncation rule latent_radius" in caplog.text
+    assert "FlowProposal truncation rule enabled: dummy" in caplog.text
 
 
 def test_configure_truncation_normalises_string(proposal):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -1,148 +1,197 @@
 # -*- coding: utf-8 -*-
-"""Test general configuration functions"""
-
-from unittest.mock import patch
+"""Tests for FlowProposal truncation configuration."""
 
 import pytest
 
-from nessai import utils
 from nessai.proposal import FlowProposal
+from nessai.proposal.flowproposal.truncation import (
+    LatentRadiusTruncation,
+    LikelihoodThresholdTruncation,
+    MinLogQTruncation,
+)
 
 
-def test_config_drawsize_none(proposal):
-    """Test the popluation configuration with no drawsize given"""
+def test_configure_population_sets_defaults(proposal):
     proposal.poolsize = 2000
-    FlowProposal.configure_population(proposal, None, 1.0, 0.0, "gaussian")
+    FlowProposal.configure_population(proposal, None)
     assert proposal.drawsize == 2000
+    assert proposal.latent_prior == "flow"
+    assert proposal.latent_temperature is None
 
 
-def test_configure_latent_temperature(proposal):
-    """Test the configuration of the latent temperature"""
-    FlowProposal.configure_population(
-        proposal, 1000, 1.0, 0.0, "gaussian", 0.9
-    )
-    assert proposal.latent_temperature == 0.9
-
-
-def test_configure_latent_temperature_invalid(proposal):
-    """Test the configuration of the latent temperature"""
-    with pytest.raises(
-        ValueError,
-        match="Latent temperature can only be used with a Gaussian latent",
-    ):
+def test_configure_population_rejects_non_flow_prior(proposal):
+    with pytest.raises(ValueError, match="Only the flow latent prior"):
         FlowProposal.configure_population(
-            proposal, 1000, 1.0, 0.0, "truncated_gaussian", 0.9
+            proposal, 1000, latent_prior="gaussian"
         )
 
 
-@pytest.mark.parametrize("fixed_radius", [False, 5.0, 1])
-def test_config_fixed_radius(proposal, fixed_radius):
-    """Test the configuration for a fixed radius"""
-    FlowProposal.configure_fixed_radius(proposal, fixed_radius)
-    assert proposal.fixed_radius == fixed_radius
+def test_configure_population_sets_latent_temperature(proposal):
+    FlowProposal.configure_population(proposal, 1000, latent_temperature=0.9)
+    assert proposal.latent_temperature == 0.9
 
 
-def test_config_fixed_radius_not_float(proposal):
-    """
-    Test the fixed radius is disabled when the radius cannot be converted to
-    a float.
-    """
-    FlowProposal.configure_fixed_radius(proposal, "four")
-    assert proposal.fixed_radius is False
+@pytest.mark.parametrize("temperature", [0.0, -1.0])
+def test_configure_population_rejects_non_positive_latent_temperature(
+    proposal, temperature
+):
+    with pytest.raises(
+        ValueError, match="latent_temperature must be positive"
+    ):
+        FlowProposal.configure_population(
+            proposal, 1000, latent_temperature=temperature
+        )
 
 
-def test_min_radius_no_max(proposal):
-    """Test configuration of min radius and no max radius"""
-    FlowProposal.configure_min_max_radius(proposal, 5.0, False)
-    assert proposal.min_radius == 5.0
-    assert proposal.max_radius is False
+def test_configure_population_rejects_invalid_latent_temperature_type(
+    proposal,
+):
+    with pytest.raises(TypeError, match="latent_temperature must be a float"):
+        FlowProposal.configure_population(
+            proposal, 1000, latent_temperature="bad"
+        )
 
 
-def test_min_max_radius(proposal):
-    """Test configuration of min radius and no max radius"""
-    FlowProposal.configure_min_max_radius(proposal, 5, 10)
-    assert proposal.min_radius == 5.0
-    assert proposal.max_radius == 10.0
+def test_configure_truncation_normalises_string(proposal):
+    FlowProposal.configure_truncation(
+        proposal, truncation_method="likelihood_threshold"
+    )
+    assert proposal.truncation_methods == ["likelihood_threshold"]
+    assert proposal.enforce_likelihood_threshold is True
+    assert isinstance(
+        proposal._truncation_scheme.get_rule("likelihood_threshold"),
+        LikelihoodThresholdTruncation,
+    )
 
 
-@pytest.mark.parametrize("rmin, rmax", [(None, 1.0), (1.0, "2")])
-def test_min_max_radius_invalid_input(proposal, rmin, rmax):
-    """Test configuration of min radius and no max radius"""
-    with pytest.raises(RuntimeError):
-        FlowProposal.configure_min_max_radius(proposal, rmin, rmax)
+def test_configure_truncation_deduplicates_methods(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        truncation_methods=["min_log_q", "min_log_q", "likelihood_threshold"],
+    )
+    assert proposal.truncation_methods == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
 
 
-@pytest.mark.parametrize(
-    "latent_prior, prior_func",
-    [
-        ("gaussian", "draw_gaussian"),
-        ("truncated_gaussian", "draw_truncated_gaussian"),
-        ("uniform", "draw_uniform"),
-        ("uniform_nsphere", "draw_nsphere"),
-        ("uniform_nball", "draw_nsphere"),
-        ("flow", None),
-    ],
-)
-def test_configure_latent_prior(proposal, latent_prior, prior_func):
-    """Test to make sure the correct latent priors are used."""
-    proposal.latent_prior = latent_prior
-    proposal.flow_config = {}
-    FlowProposal.configure_latent_prior(proposal)
-    if prior_func:
-        assert proposal._draw_latent_prior == getattr(utils, prior_func)
-    else:
-        assert proposal._draw_latent_prior is None
+def test_configure_truncation_unknown_method(proposal):
+    with pytest.raises(ValueError, match="Unknown truncation method"):
+        FlowProposal.configure_truncation(
+            proposal, truncation_methods=["unknown"]
+        )
 
 
-def test_configure_latent_prior_unknown(proposal):
-    """Make sure unknown latent priors raise an error"""
-    proposal.latent_prior = "truncated"
-    with pytest.raises(RuntimeError) as excinfo:
-        FlowProposal.configure_latent_prior(proposal)
-    assert "Unknown latent prior: truncated, " in str(excinfo.value)
+def test_configure_truncation_rejects_method_and_methods(proposal):
+    with pytest.raises(
+        ValueError, match="Specify only one of truncation_method"
+    ):
+        FlowProposal.configure_truncation(
+            proposal,
+            truncation_method="min_log_q",
+            truncation_methods=["likelihood_threshold"],
+        )
 
 
-@pytest.mark.parametrize(
-    "latent_prior",
-    ["truncated_gaussian", "uniform_nball", "uniform_nsphere"],
-)
-def test_configure_constant_volume(proposal, latent_prior):
-    """Test configuration for constant volume mode."""
-    proposal.constant_volume_mode = True
-    proposal.volume_fraction = 0.95
-    proposal.prime_dims = 5
-    proposal.latent_prior = latent_prior
-    proposal.max_radius = 3.0
-    proposal.min_radius = 5.0
-    proposal.fuzz = 1.5
-    with patch(
-        "nessai.proposal.flowproposal.flowproposal.compute_radius",
-        return_value=4.0,
-    ) as mock:
-        FlowProposal.configure_constant_volume(proposal)
-    mock.assert_called_once_with(5, 0.95)
-    assert proposal.fixed_radius == 4.0
-    assert proposal.min_radius is False
-    assert proposal.max_radius is False
-    assert proposal.fuzz == 1.0
+def test_configure_truncation_enables_legacy_flags(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        truncate_log_q=True,
+        enforce_likelihood_threshold=True,
+    )
+    assert proposal.truncation_methods == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+    assert isinstance(
+        proposal._truncation_scheme.get_rule("min_log_q"), MinLogQTruncation
+    )
 
 
-def test_configure_constant_volume_disabled(proposal):
-    """Assert nothing happens if constant_volume is False"""
-    proposal.constant_volume_mode = False
-    with patch(
-        "nessai.proposal.flowproposal.flowproposal.compute_radius"
-    ) as mock:
-        FlowProposal.configure_constant_volume(proposal)
-    mock.assert_not_called()
+def test_configure_truncation_enables_latent_radius_from_kwargs(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        latent_radius_kwargs=dict(fixed_radius=4.0, radius_mode="fixed"),
+    )
+    assert proposal.truncation_methods == ["latent_radius"]
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
+    assert isinstance(rule, LatentRadiusTruncation)
+    assert rule.fixed_radius == 4.0
+    assert rule.radius_mode == "fixed"
 
 
-def test_constant_volume_invalid_latent_prior(proposal):
-    """Assert an error is raised if the latent prior is not a truncated \
-        Gaussian
-    """
-    err = "Constant volume mode is not supported for latent_prior=gaussian"
-    proposal.constant_volume_mode = True
-    proposal.latent_prior = "gaussian"
-    with pytest.raises(RuntimeError, match=err):
-        FlowProposal.configure_constant_volume(proposal)
+def test_configure_truncation_creates_radius_rule(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        latent_radius_kwargs=dict(fixed_radius=5.0, radius_mode="fixed"),
+    )
+    assert proposal.truncation_methods == ["latent_radius"]
+    rule = proposal.get_truncation_rule("latent_radius")
+    assert rule.fixed_radius == 5.0
+    assert rule.radius_mode == "fixed"
+
+
+def test_configure_truncation_applies_default_radius_kwargs(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        default_latent_radius=True,
+    )
+    assert proposal.truncation_methods == ["latent_radius"]
+    rule = proposal.get_truncation_rule("latent_radius")
+    assert rule.radius_mode == "constant_volume"
+    assert rule.volume_fraction == 0.95
+
+
+def test_configure_truncation_does_not_apply_default_radius_to_explicit_methods(
+    proposal,
+):
+    FlowProposal.configure_truncation(
+        proposal,
+        truncation_methods=["min_log_q"],
+        default_latent_radius=True,
+    )
+    assert proposal.truncation_methods == ["min_log_q"]
+    assert proposal.get_truncation_rule("latent_radius") is None
+
+
+def test_configure_truncation_explicit_empty_list_disables_default_radius(
+    proposal,
+):
+    FlowProposal.configure_truncation(
+        proposal,
+        truncation_methods=[],
+        default_latent_radius=True,
+    )
+    assert proposal.truncation_methods == []
+    assert proposal.get_truncation_rule("latent_radius") is None
+
+
+def test_configure_truncation_enables_radius_from_expansion_fraction(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        latent_radius_kwargs=dict(expansion_fraction=None),
+    )
+    assert proposal.truncation_methods == ["latent_radius"]
+    rule = proposal.get_truncation_rule("latent_radius")
+    assert rule.expansion_fraction is None
+
+
+def test_configure_truncation_constant_volume_updates_rule(proposal):
+    FlowProposal.configure_truncation(
+        proposal,
+        latent_radius_kwargs=dict(fixed_radius=5.0, constant_volume_mode=True),
+    )
+    assert proposal.truncation_methods == ["latent_radius"]
+    rule = proposal.get_truncation_rule("latent_radius")
+    assert rule.constant_volume_mode is True
+    assert rule.radius_mode == "constant_volume"
+
+
+def test_configure_truncation_rejects_invalid_fixed_radius(proposal):
+    with pytest.raises(
+        RuntimeError, match="fixed_radius must be an int or float"
+    ):
+        FlowProposal.configure_truncation(
+            proposal,
+            latent_radius_kwargs=dict(fixed_radius="bad"),
+        )

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -305,6 +305,33 @@ def test_configure_truncation_supports_flat_kwargs_for_single_method(proposal):
     assert rule.radius_mode == "constant_volume"
 
 
+def test_configure_truncation_reuses_existing_latent_radius_rule(proposal):
+    existing_rule = LatentRadiusTruncation(
+        fixed_radius=3.0,
+        radius_mode="fixed",
+        fuzz=1.2,
+    )
+    configure_truncation_mocks(proposal, latent_radius_rule=existing_rule)
+    FlowProposal.configure_truncation(proposal)
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
+    assert rule.fixed_radius == 3.0
+    assert rule.radius_mode == "fixed"
+    assert rule.fuzz == 1.2
+
+
+def test_configure_truncation_rejects_non_dict_truncation_kwargs(proposal):
+    configure_truncation_mocks(proposal)
+    with pytest.raises(
+        TypeError,
+        match="Truncation kwargs for latent_radius must be a dictionary",
+    ):
+        FlowProposal.configure_truncation(
+            proposal,
+            truncation_method="latent_radius",
+            truncation_kwargs={"latent_radius": 1.0},
+        )
+
+
 def test_configure_truncation_rejects_invalid_fixed_radius(proposal):
     configure_truncation_mocks(proposal)
     with pytest.raises(

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_configuration.py
@@ -217,6 +217,19 @@ def test_configure_truncation_constant_volume_updates_rule(proposal):
     assert rule.radius_mode == "constant_volume"
 
 
+def test_configure_truncation_supports_flat_kwargs_for_single_method(proposal):
+    configure_truncation_mocks(proposal)
+    FlowProposal.configure_truncation(
+        proposal,
+        truncation_method="latent_radius",
+        truncation_kwargs=dict(constant_volume_mode=True),
+    )
+    assert proposal._truncation_scheme.rule_names == ["latent_radius"]
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
+    assert rule.constant_volume_mode is True
+    assert rule.radius_mode == "constant_volume"
+
+
 def test_configure_truncation_rejects_invalid_fixed_radius(proposal):
     configure_truncation_mocks(proposal)
     with pytest.raises(

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
@@ -40,12 +40,13 @@ def test_backward_pass(
     proposal.x_prime_internal_dtype = get_dtype(
         proposal._prime_parameters_internal
     )
-    proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
     )
     proposal.flow = MagicMock()
-    proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
+    proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(n)])
+    proposal.latent_temperature = None
+    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,
@@ -70,20 +71,19 @@ def test_backward_pass(
         proposal.inverse_rescale.call_args.kwargs["return_unit_hypercube"]
         is map_to_unit_hypercube
     )
-    proposal.flow.sample_and_log_prob.assert_called_once_with(
-        z=z, alt_dist=None
-    )
+    proposal.flow.inverse.assert_called_once_with(z)
+    proposal.compute_latent_log_prob.assert_called_once_with(z, None)
 
 
 @pytest.mark.parametrize("return_z", [False, True])
 def test_backwards_pass_assertion_error(proposal, caplog, return_z):
-    proposal.alt_dist = None
     proposal.flow = MagicMock()
+    proposal.latent_temperature = None
 
     def func(*args, **kwargs):
         raise AssertionError("Domain")
 
-    proposal.flow.sample_and_log_prob = MagicMock(side_effect=func)
+    proposal.flow.inverse = MagicMock(side_effect=func)
     out = FlowProposal.backward_pass(
         proposal, np.random.randn(10, 2), return_z=return_z
     )
@@ -115,12 +115,13 @@ def test_backward_pass_with_internal_prime_parameters(
     proposal.x_prime_internal_dtype = get_dtype(
         proposal._prime_parameters_internal
     )
-    proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
     )
     proposal.flow = MagicMock()
-    proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
+    proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(2)])
+    proposal.latent_temperature = None
+    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,
@@ -152,12 +153,13 @@ def test_backward_pass_with_1d_flow_output(
     proposal.x_prime_internal_dtype = get_dtype(
         proposal._prime_parameters_internal
     )
-    proposal.alt_dist = None
     proposal.check_prior_bounds = MagicMock(
         side_effect=lambda a, b, c: (a, b, c)
     )
     proposal.flow = MagicMock()
-    proposal.flow.sample_and_log_prob = MagicMock(return_value=[x, log_p])
+    proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(1)])
+    proposal.latent_temperature = None
+    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,
@@ -169,3 +171,14 @@ def test_backward_pass_with_1d_flow_output(
     assert len(out[0]) == 1
     assert len(out[1]) == 1
     proposal.inverse_rescale.assert_called_once()
+
+
+def test_sample_latent_distribution_with_temperature(proposal):
+    proposal.latent_temperature = 4.0
+    proposal.flow = MagicMock()
+    proposal.flow.sample_latent_distribution = MagicMock(
+        return_value=np.array([[1.0, -2.0]])
+    )
+    out = proposal.sample_latent_distribution(1)
+    proposal.flow.sample_latent_distribution.assert_called_once_with(1)
+    np.testing.assert_array_equal(out, np.array([[2.0, -4.0]]))

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
@@ -179,6 +179,6 @@ def test_sample_latent_distribution_with_temperature(proposal):
     proposal.flow.sample_latent_distribution = MagicMock(
         return_value=np.array([[1.0, -2.0]])
     )
-    out = proposal.sample_latent_distribution(1)
+    out = FlowProposal.sample_latent_distribution(proposal, 1)
     proposal.flow.sample_latent_distribution.assert_called_once_with(1)
     np.testing.assert_array_equal(out, np.array([[2.0, -4.0]]))

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_flow.py
@@ -46,7 +46,7 @@ def test_backward_pass(
     proposal.flow = MagicMock()
     proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(n)])
     proposal.latent_temperature = None
-    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
+    proposal.latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,
@@ -72,7 +72,7 @@ def test_backward_pass(
         is map_to_unit_hypercube
     )
     proposal.flow.inverse.assert_called_once_with(z)
-    proposal.compute_latent_log_prob.assert_called_once_with(z, None)
+    proposal.latent_log_prob.assert_called_once_with(z, None)
 
 
 @pytest.mark.parametrize("return_z", [False, True])
@@ -121,7 +121,7 @@ def test_backward_pass_with_internal_prime_parameters(
     proposal.flow = MagicMock()
     proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(2)])
     proposal.latent_temperature = None
-    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
+    proposal.latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,
@@ -159,7 +159,7 @@ def test_backward_pass_with_1d_flow_output(
     proposal.flow = MagicMock()
     proposal.flow.inverse = MagicMock(return_value=[x, np.zeros(1)])
     proposal.latent_temperature = None
-    proposal.compute_latent_log_prob = MagicMock(return_value=log_p)
+    proposal.latent_log_prob = MagicMock(return_value=log_p)
 
     out = FlowProposal.backward_pass(
         proposal,

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Test methods related to initialising and resuming the proposal method"""
+"""Tests for initialising, pickling, and resetting FlowProposal."""
 
 from unittest.mock import patch
 
@@ -10,19 +10,181 @@ from nessai.proposal import FlowProposal
 
 
 def test_init(model):
-    """Test init with some kwargs"""
-    fp = FlowProposal(model, poolsize=1000)
+    with pytest.warns(None) as record:
+        fp = FlowProposal(model, poolsize=1000)
+    assert not record
     assert fp.model == model
     assert fp.poolsize == 1000
+    assert fp.latent_prior == "flow"
+    assert fp.truncation_methods == ["latent_radius"]
+    rule = fp.get_truncation_rule("latent_radius")
+    assert rule.constant_volume_mode is True
+    assert rule.volume_fraction == 0.95
+
+
+def test_init_with_explicit_flow_latent_prior_warns(model):
+    with pytest.warns(FutureWarning, match="latent_prior"):
+        fp = FlowProposal(model, poolsize=1000, latent_prior="flow")
+    assert fp.latent_prior == "flow"
+
+
+def test_init_with_truncation_methods(model):
+    fp = FlowProposal(
+        model,
+        poolsize=1000,
+        truncation_methods=["min_log_q", "likelihood_threshold"],
+    )
+    assert fp.truncation_methods == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+    assert fp._truncation_scheme.rule_names == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+
+
+def test_init_with_radius_configuration(model):
+    with pytest.warns(
+        FutureWarning, match="truncation_kwargs\\['latent_radius'\\]"
+    ):
+        fp = FlowProposal(
+            model,
+            poolsize=1000,
+            fixed_radius=5.0,
+            radius_mode="fixed",
+            volume_fraction=0.8,
+        )
+    assert fp.truncation_methods == ["latent_radius"]
+    rule = fp.get_truncation_rule("latent_radius")
+    assert rule.radius_mode == "fixed"
+    assert rule.fixed_radius == 5.0
+    assert rule.volume_fraction == 0.8
+
+
+def test_init_with_truncation_kwargs_does_not_warn(model):
+    with pytest.warns(None) as record:
+        fp = FlowProposal(
+            model,
+            poolsize=1000,
+            truncation_methods=["latent_radius"],
+            truncation_kwargs={
+                "latent_radius": {
+                    "fixed_radius": 5.0,
+                    "radius_mode": "fixed",
+                    "volume_fraction": 0.8,
+                }
+            },
+        )
+    assert not record
+    assert fp.truncation_methods == ["latent_radius"]
+
+
+def test_deprecated_latent_radius_arguments_warn(model):
+    with pytest.warns(FutureWarning) as record:
+        FlowProposal(
+            model,
+            poolsize=1000,
+            fixed_radius=5.0,
+            radius_mode="fixed",
+            min_radius=1.0,
+            max_radius=10.0,
+            compute_radius_with_all=True,
+            constant_volume_mode=True,
+            volume_fraction=0.8,
+            fuzz=1.2,
+            expansion_fraction=1.2,
+        )
+    message = str(record[0].message)
+    for name in (
+        "fixed_radius",
+        "radius_mode",
+        "min_radius",
+        "max_radius",
+        "compute_radius_with_all",
+        "constant_volume_mode",
+        "volume_fraction",
+        "fuzz",
+        "expansion_fraction",
+    ):
+        assert name in message
+
+
+def test_deprecated_enforce_likelihood_threshold_warns(model):
+    with pytest.warns(FutureWarning, match="enforce_likelihood_threshold"):
+        FlowProposal(
+            model,
+            poolsize=1000,
+            enforce_likelihood_threshold=True,
+        )
+
+
+def test_init_rejects_non_flow_latent_prior(model):
+    with pytest.raises(ValueError, match="Only the flow latent prior"):
+        FlowProposal(model, poolsize=1000, latent_prior="gaussian")
+
+
+def test_pickle_with_truncation_methods(model, tmpdir):
+    import pickle
+
+    proposal = FlowProposal(
+        model,
+        poolsize=1000,
+        plot=False,
+        output=tmpdir.mkdir("truncation_pickle"),
+        truncation_methods=["min_log_q", "likelihood_threshold"],
+    )
+    proposal._truncation_scheme.get_rule("min_log_q")._min_log_q = -10.0
+    proposal._truncation_scheme.get_rule(
+        "likelihood_threshold"
+    )._threshold = 1.0
+    proposal_re = pickle.loads(pickle.dumps(proposal))
+    assert proposal_re.truncation_methods == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+    assert proposal_re._truncation_scheme.rule_names == [
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+    assert np.isnan(
+        proposal_re._truncation_scheme.get_rule("min_log_q").min_log_q
+    )
+    assert np.isnan(
+        proposal_re._truncation_scheme.get_rule(
+            "likelihood_threshold"
+        ).threshold
+    )
+
+
+def test_pickle_with_radius_rule(model, tmpdir):
+    import pickle
+
+    with pytest.warns(
+        FutureWarning, match="truncation_kwargs\\['latent_radius'\\]"
+    ):
+        proposal = FlowProposal(
+            model,
+            poolsize=1000,
+            plot=False,
+            output=tmpdir.mkdir("radius_pickle"),
+            fixed_radius=5.0,
+            radius_mode="fixed",
+        )
+    proposal._truncation_scheme.get_rule("latent_radius")._radius = 3.0
+    proposal._truncation_scheme.get_rule("latent_radius")._threshold = 4.0
+    proposal_re = pickle.loads(pickle.dumps(proposal))
+    assert proposal_re.truncation_methods == ["latent_radius"]
+    rule = proposal_re.get_truncation_rule("latent_radius")
+    assert rule.fixed_radius == 5.0
+    assert rule.radius_mode == "fixed"
+    assert np.isnan(rule.radius)
+    assert np.isnan(rule.threshold)
 
 
 @pytest.mark.parametrize("populated", [False, True])
 @pytest.mark.parametrize("mask", [None, [1, 0]])
 def test_get_state(proposal, populated, mask):
-    """Test the get state method used for pickling the proposal.
-
-    Tests cases where the proposal is and isn't populated.
-    """
     parent_state = {"a": "val"}
     with patch(
         "nessai.proposal.flowproposal.base.BaseFlowProposal.__getstate__",
@@ -31,140 +193,18 @@ def test_get_state(proposal, populated, mask):
         state = FlowProposal.__getstate__(proposal)
 
     mock.assert_called_once()
-    assert state["_draw_func"] is None
-    assert state["_populate_dist"] is None
-    assert state["alt_dist"] is None
     assert state["a"] == "val"
 
 
-@pytest.mark.integration_test
-@pytest.mark.parametrize("reparameterisation", [False, True])
-@pytest.mark.parametrize("init", [False, True])
-@pytest.mark.parametrize(
-    "latent_prior", ["truncated_gaussian", "uniform_nball", "gaussian"]
-)
-def test_resume_pickle(model, tmpdir, reparameterisation, init, latent_prior):
-    """Test pickling and resuming the proposal.
-
-    Tests both with and without reparameterisations and before and after
-    initialise has been called.
-    """
-    import pickle
-
-    output = tmpdir.mkdir("test_integration")
-    if reparameterisation:
-        reparameterisations = {"default": {"parameters": model.names}}
-    else:
-        reparameterisations = None
-
-    if latent_prior != "truncated_gaussian":
-        constant_volume_mode = False
-    else:
-        constant_volume_mode = True
-
-    proposal = FlowProposal(
-        model,
-        poolsize=1000,
-        plot=False,
-        expansion_fraction=1,
-        output=output,
-        reparameterisations=reparameterisations,
-        latent_prior=latent_prior,
-        constant_volume_mode=constant_volume_mode,
-    )
-    if init:
-        proposal.initialise()
-
-    proposal.mask = None
-    proposal.resume_populated = False
-
-    proposal_data = pickle.dumps(proposal)
-    proposal_re = pickle.loads(proposal_data)
-    proposal_re.resume(model, {})
-
-    assert proposal._plot_pool == proposal_re._plot_pool
-    assert proposal._plot_training == proposal_re._plot_training
-
-    if init:
-        assert proposal.fuzz == proposal_re.fuzz
-
-
 def test_reset(proposal):
-    """Test reset method"""
+    FlowProposal.configure_truncation(
+        proposal,
+        latent_radius_kwargs=dict(fixed_radius=2.0, radius_mode="fixed"),
+    )
+    proposal.get_truncation_rule("latent_radius")._radius = 1.0
     with patch(
         "nessai.proposal.flowproposal.base.BaseFlowProposal.reset"
     ) as mock:
         FlowProposal.reset(proposal)
     mock.assert_called_once()
-    assert proposal.r is np.nan
-    assert proposal.alt_dist is None
-
-
-@pytest.mark.timeout(60)
-@pytest.mark.integration_test
-@pytest.mark.parametrize(
-    "latent_prior", ["truncated_gaussian", "uniform_nball", "gaussian"]
-)
-def test_reset_integration(tmpdir, model, latent_prior):
-    """Test reset method iteration with other methods"""
-    flow_config = dict(
-        n_neurons=1,
-        n_blocks=1,
-        n_layers=1,
-        batch_norm_between_layers=False,
-        linear_transform=None,
-    )
-    training_config = dict(patience=20)
-    output = str(tmpdir.mkdir("reset_integration"))
-    poolsize = 2
-    drawsize = 100
-    if latent_prior != "truncated_gaussian":
-        constant_volume_mode = False
-    else:
-        constant_volume_mode = True
-    proposal = FlowProposal(
-        model,
-        output=output,
-        flow_config=flow_config,
-        training_config=training_config,
-        plot=False,
-        poolsize=poolsize,
-        drawsize=drawsize,
-        expansion_fraction=None,
-        latent_prior=latent_prior,
-        constant_volume_mode=constant_volume_mode,
-    )
-
-    modified_proposal = FlowProposal(
-        model,
-        output=output,
-        flow_config=flow_config,
-        training_config=training_config,
-        plot=False,
-        poolsize=poolsize,
-        drawsize=drawsize,
-        expansion_fraction=None,
-        latent_prior=latent_prior,
-        constant_volume_mode=constant_volume_mode,
-    )
-    proposal.initialise()
-    modified_proposal.initialise()
-
-    modified_proposal.populate(model.new_point())
-    modified_proposal.reset()
-
-    # attributes that should be different
-    ignore = [
-        "population_time",
-        "_reparameterisation",
-        "rng",
-    ]
-
-    d1 = proposal.__getstate__()
-    d2 = modified_proposal.__getstate__()
-
-    for key in ignore:
-        d1.pop(key)
-        d2.pop(key)
-
-    assert d1 == d2
+    assert np.isnan(proposal.get_truncation_rule("latent_radius").radius)

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_init_resume.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for initialising, pickling, and resetting FlowProposal."""
 
-from unittest.mock import patch
+import warnings
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -9,8 +10,13 @@ import pytest
 from nessai.proposal import FlowProposal
 
 
+def configure_truncation_mocks(proposal):
+    proposal._get_latent_radius_rule = MagicMock(return_value=None)
+    proposal._sync_truncation_state = MagicMock(return_value=None)
+
+
 def test_init(model):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         fp = FlowProposal(model, poolsize=1000)
     assert not record
     assert fp.model == model
@@ -63,7 +69,7 @@ def test_init_with_radius_configuration(model):
 
 
 def test_init_with_truncation_kwargs_does_not_warn(model):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         fp = FlowProposal(
             model,
             poolsize=1000,
@@ -197,14 +203,18 @@ def test_get_state(proposal, populated, mask):
 
 
 def test_reset(proposal):
+    configure_truncation_mocks(proposal)
     FlowProposal.configure_truncation(
         proposal,
         latent_radius_kwargs=dict(fixed_radius=2.0, radius_mode="fixed"),
     )
-    proposal.get_truncation_rule("latent_radius")._radius = 1.0
+    proposal._sync_truncation_state.assert_called_once_with()
+    proposal._truncation_scheme.get_rule("latent_radius")._radius = 1.0
     with patch(
         "nessai.proposal.flowproposal.base.BaseFlowProposal.reset"
     ) as mock:
         FlowProposal.reset(proposal)
     mock.assert_called_once()
-    assert np.isnan(proposal.get_truncation_rule("latent_radius").radius)
+    assert np.isnan(
+        proposal._truncation_scheme.get_rule("latent_radius").radius
+    )

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_integration.py
@@ -61,7 +61,7 @@ def test_flowproposal_populate(
 
 @pytest.mark.parametrize(
     "truncation_methods",
-    [[], ["min_log_q"], ["likelihood_threshold"]],
+    [[], ["likelihood_threshold"]],
 )
 @pytest.mark.integration_test
 @pytest.mark.timeout(30)
@@ -91,6 +91,34 @@ def test_flowproposal_populate_edge_cases(
     fp.populate(worst, n_samples=n_draw)
 
     assert fp.x.size == n_draw
+
+
+@pytest.mark.integration_test
+def test_flowproposal_populate_min_log_q_requires_training_data(
+    tmp_path, model, flow_config
+):
+    """min_log_q truncation should fail without training data."""
+    output = tmp_path / "flowproposal"
+    output.mkdir()
+    fp = FlowProposal(
+        model,
+        output=output,
+        flow_config=flow_config,
+        plot=False,
+        poolsize=10,
+        expansion_fraction=None,
+        fixed_radius=0.1,
+        radius_mode="fixed",
+        truncation_methods=["min_log_q"],
+        fallback_reparameterisation=None,
+    )
+
+    fp.initialise()
+    worst = numpy_array_to_live_points(0.01 * np.ones(fp.dims), fp.parameters)
+    with pytest.raises(
+        RuntimeError, match="min_log_q truncation requires training_data"
+    ):
+        fp.populate(worst, n_samples=2)
 
 
 @pytest.mark.parametrize("plot", [False, True])

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_integration.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_integration.py
@@ -12,7 +12,7 @@ from nessai.utils.testing import assert_structured_arrays_equal
 torch.set_num_threads(1)
 
 
-@pytest.mark.parametrize()
+@pytest.fixture()
 def flow_config():
     return dict(
         n_neurons=1,
@@ -45,11 +45,11 @@ def test_flowproposal_populate(
         flow_config=flow_config,
         plot=False,
         poolsize=10,
-        latent_prior="truncated_gaussian",
+        fixed_radius=1.0,
+        radius_mode="fixed",
         expansion_fraction=expansion_fraction,
         check_acceptance=check_acceptance,
         max_radius=1.0,
-        constant_volume_mode=False,
     )
 
     fp.initialise()
@@ -60,19 +60,13 @@ def test_flowproposal_populate(
 
 
 @pytest.mark.parametrize(
-    "latent_prior",
-    [
-        "gaussian",
-        "truncated_gaussian",
-        "uniform_nball",
-        "uniform_nsphere",
-        "uniform",
-    ],
+    "truncation_methods",
+    [[], ["min_log_q"], ["likelihood_threshold"]],
 )
 @pytest.mark.integration_test
 @pytest.mark.timeout(30)
 def test_flowproposal_populate_edge_cases(
-    tmp_path, model, flow_config, latent_prior
+    tmp_path, model, flow_config, truncation_methods
 ):
     """Tests some less common settings for flowproposal"""
     output = tmp_path / "flowproposal"
@@ -84,10 +78,10 @@ def test_flowproposal_populate_edge_cases(
         flow_config=flow_config,
         plot=False,
         poolsize=10,
-        latent_prior=latent_prior,
         expansion_fraction=None,
-        max_radius=0.1,
-        constant_volume_mode=False,
+        fixed_radius=0.1,
+        radius_mode="fixed",
+        truncation_methods=truncation_methods,
         fallback_reparameterisation=None,
     )
 
@@ -154,8 +148,9 @@ def test_constant_volume_mode(
     fp.populate(worst, n_samples=10)
     assert fp.x.size == 10
 
-    np.testing.assert_approx_equal(fp.r, expected_radius, 4)
-    np.testing.assert_approx_equal(fp.fixed_radius, expected_radius, 4)
+    rule = fp.get_truncation_rule("latent_radius")
+    np.testing.assert_approx_equal(rule.radius, expected_radius, 4)
+    np.testing.assert_approx_equal(rule.fixed_radius, expected_radius, 4)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
@@ -1,810 +1,112 @@
 # -*- coding: utf-8 -*-
-"""Test methods related to popluation of the proposal after training"""
+"""Tests for staged truncation during FlowProposal population."""
 
 import datetime
-from functools import partial
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
 
-from nessai.livepoint import (
-    get_dtype,
-    numpy_array_to_live_points,
-    parameters_to_live_point,
-)
 from nessai.proposal import FlowProposal
-from nessai.utils.testing import assert_structured_arrays_equal
+from nessai.proposal.flowproposal.truncation import (
+    LatentRadiusTruncation,
+    LikelihoodThresholdTruncation,
+    MinLogQTruncation,
+    TruncationScheme,
+)
 
 
-@pytest.fixture()
-def z(rng):
-    return rng.standard_normal((2, 2))
-
-
-@pytest.fixture()
-def x(z, rng):
-    return numpy_array_to_live_points(rng.standard_normal(z.shape), ["x", "y"])
-
-
-@pytest.fixture()
-def log_q(x, rng):
-    return rng.standard_normal(x.size)
-
-
-def test_get_alt_distribution_truncated_gaussian(proposal):
-    """
-    Test getting the alternative distribution for the default latent prior, the
-    truncated Gaussian with var=1. This should return None.
-    """
-    proposal.draw_latent_kwargs = {}
-    proposal.latent_prior = "truncated_gaussian"
-    dist = FlowProposal.get_alt_distribution(proposal)
-    assert dist is None
-
-
-@pytest.mark.parametrize("prior", ["uniform_nsphere", "uniform_nball"])
-def test_get_alt_distribution_uniform(proposal, prior):
-    """
-    Test getting the alternative distribution for priors that are uniform in
-    the n-ball.
-    """
-    proposal.latent_prior = prior
-    proposal.prime_dims = 2
-    proposal.r = 2.0
-    proposal.fuzz = 1.2
-    proposal.flow = Mock()
-    proposal.flow.device = "cpu"
-    with patch(
-        "nessai.proposal.flowproposal.flowproposal.get_uniform_distribution"
-    ) as mock:
-        dist = FlowProposal.get_alt_distribution(proposal)
-
-    assert dist is not None
-    mock.assert_called_once_with(2, 2.4, device="cpu")
-
-
-def test_radius(proposal):
-    """Test computing the radius"""
-    z = np.array([[1, 2, 3], [0, 1, 2]])
-    expected_r = np.sqrt(14)
-    r = FlowProposal.radius(proposal, z)
-    np.testing.assert_equal(r, expected_r)
-
-
-def test_radius_w_log_q(proposal):
-    """Test computing the radius with log_q"""
-    z = np.array([[1, 2, 3], [0, 1, 2]])
-    log_q = np.array([1, 2])
-    expected_r = np.sqrt(14)
-    r, log_q_r = FlowProposal.radius(proposal, z, log_q)
-    assert r == expected_r
-    assert log_q_r == log_q[0]
-
-
-def test_prep_latent_prior_truncated(proposal):
-    """Assert prep latent prior calls the correct values"""
-
-    proposal.latent_prior = "truncated_gaussian"
-    proposal.prime_dims = 2
-    proposal.r = 3.0
-    proposal.fuzz = 1.2
-    dist = MagicMock()
-    dist.sample = MagicMock()
-
-    with patch(
-        "nessai.proposal.flowproposal.flowproposal.NDimensionalTruncatedGaussian",  # noqa: E501
-        return_value=dist,
-    ) as mock_dist:
-        FlowProposal.prep_latent_prior(proposal)
-
-    mock_dist.assert_called_once_with(2, 3.0, fuzz=1.2, rng=proposal.rng)
-
-    assert proposal._populate_dist is dist
-    assert proposal._draw_func is dist.sample
-
-
-def test_prep_latent_prior_other(proposal):
-    """Assert partial acts as expected"""
-    proposal.latent_prior = "gaussian"
-    proposal.latent_temperature = 0.9
-    proposal.prime_dims = 2
-    proposal.r = 3.0
-    proposal.fuzz = 1.2
-
-    def draw(dims, N=None, r=None, fuzz=None, rng=None, temperature=None):
-        return np.zeros((N, dims))
-
-    proposal._draw_latent_prior = draw
-
-    with patch(
-        "nessai.proposal.flowproposal.flowproposal.partial",
-        side_effect=partial,
-    ) as mock_partial:
-        FlowProposal.prep_latent_prior(proposal)
-
-    mock_partial.assert_called_once_with(
-        draw, dims=2, r=3.0, fuzz=1.2, rng=proposal.rng, temperature=0.9
+def configure_population_test_proposal(proposal, samples):
+    proposal.population_time = datetime.timedelta()
+    proposal.initialised = True
+    proposal.indices = []
+    proposal.acceptance = []
+    proposal.keep_samples = False
+    proposal.check_acceptance = False
+    proposal._plot_pool = False
+    proposal.populated_count = 0
+    proposal.map_to_unit_hypercube = False
+    proposal.population_dtype = np.dtype(
+        [("x", "f8"), ("y", "f8"), ("logL", "f8")]
     )
-
-    assert proposal._draw_func(N=10).shape == (10, 2)
-
-
-def test_prep_latent_prior_flow(proposal):
-    proposal.latent_prior = "flow"
+    proposal.convert_to_samples = MagicMock(
+        side_effect=lambda x, plot: x.copy()
+    )
+    proposal.compute_weights = MagicMock(
+        side_effect=lambda x, log_q: np.zeros(x.size)
+    )
+    proposal.rng = MagicMock()
+    proposal.rng.random = MagicMock(side_effect=lambda n: np.full(n, 0.5))
+    proposal.rng.permutation = MagicMock(side_effect=lambda n: np.arange(n))
+    proposal.model = MagicMock()
+    proposal.training_data = samples([(0.0, 0.0), (1.0, 1.0)])
+    proposal._truncation_scheme = TruncationScheme()
+    proposal.drawsize = 3
     proposal.flow = MagicMock()
-    proposal.flow.sample_latent_distribution = MagicMock()
-    FlowProposal.prep_latent_prior(proposal)
-    proposal._draw_func(10)
-    proposal.flow.sample_latent_distribution.assert_called_once_with(10)
 
 
-def test_draw_latent_prior(proposal):
-    proposal._draw_func = MagicMock(return_value=[1, 2])
-    out = FlowProposal.draw_latent_prior(proposal, 2)
-    proposal._draw_func.assert_called_once_with(N=2)
-    assert out == [1, 2]
-
-
-@pytest.mark.parametrize("check_acceptance", [False, True])
-@pytest.mark.parametrize("indices", [[], [1]])
-@pytest.mark.parametrize("r", [None, 1.0])
-@pytest.mark.parametrize(
-    "max_radius, min_radius",
-    [(0.5, None), (None, 1.5), (None, None)],
-)
-def test_populate_accumulate_weights(
-    proposal,
-    check_acceptance,
-    indices,
-    r,
-    min_radius,
-    max_radius,
-    wait,
-    rng,
-):
-    """Test the main populate method"""
-    n_dims = 2
-    poolsize = 10
-    drawsize = 5
-    names = ["x", "y"]
-    worst_point = np.array(
-        [[1, 2, 3]], dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
+def test_populate_applies_truncation_in_stages(proposal, rng, point, samples):
+    configure_population_test_proposal(proposal, rng, samples)
+    proposal._truncation_scheme = TruncationScheme(
+        [
+            LatentRadiusTruncation(fixed_radius=1.0, radius_mode="fixed"),
+            MinLogQTruncation(),
+            LikelihoodThresholdTruncation(),
+        ]
     )
-    worst_z = rng.standard_normal((1, n_dims))
-    z = [
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-    ]
-    x = [
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-    ]
-    log_q = [
-        np.log(rng.random(drawsize)),
-        np.log(rng.random(drawsize)),
-        np.log(rng.random(drawsize)),
-    ]
-    log_w = [
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-    ]
-    # Control rejection sampling using log_w
-    rand_u = 0.5 * np.ones(3 * drawsize)
-
-    log_l = rng.random(poolsize)
-    log_p = rng.random(poolsize)
-
-    r_flow = 1.0
-
-    if r is None:
-        r_out = r_flow
-        if min_radius is not None:
-            r_out = max(r_out, min_radius)
-        if max_radius is not None:
-            r_out = min(r_out, max_radius)
-    else:
-        r_out = r
-
-    proposal.population_time = datetime.timedelta()
-    proposal.initialised = True
-    proposal.max_radius = max_radius
-    proposal.dims = n_dims
-    proposal.poolsize = poolsize
-    proposal.drawsize = drawsize
-    proposal.min_radius = min_radius
-    proposal.fuzz = 1.0
-    proposal.indices = indices
-    proposal.acceptance = [0.7]
-    proposal.keep_samples = False
-    proposal.fixed_radius = False
-    proposal.compute_radius_with_all = False
-    proposal.check_acceptance = check_acceptance
-    proposal._plot_pool = True
-    proposal.populated_count = 1
-    proposal.population_dtype = get_dtype(names)
-    proposal.truncate_log_q = False
-    proposal.accumulate_weights = True
-
-    proposal.forward_pass = MagicMock(return_value=(worst_z, np.nan))
-    proposal.backward_pass = MagicMock(side_effect=zip(x, log_q))
-    proposal.radius = MagicMock(return_value=r_flow)
-    proposal.get_alt_distribution = MagicMock(return_value=None)
-    proposal.prep_latent_prior = MagicMock()
-    proposal.draw_latent_prior = MagicMock(side_effect=z)
-    proposal.latent_prior = "truncated_gaussian"
-    proposal.compute_weights = MagicMock(side_effect=log_w)
-    proposal.compute_acceptance = MagicMock(return_value=0.8)
-    proposal.model = MagicMock()
-    proposal.model.batch_evaluate_log_likelihood = MagicMock(
-        return_value=log_l
+    proposal.flow.sample_latent_distribution.return_value = np.array(
+        [[0.0, 0.0], [2.0, 0.0], [0.5, 0.0]]
     )
-    proposal.rng = MagicMock()
-    proposal.rng.random = MagicMock(return_value=rand_u)
-    proposal.rng.permutation = rng.permutation
-
-    def convert_to_samples(samples, plot):
-        samples["logP"] = log_p
-        # wait for windows
-        wait()
-        return samples
-
-    proposal.plot_pool = MagicMock()
-    proposal.convert_to_samples = MagicMock(side_effect=convert_to_samples)
-
-    x_empty = np.empty(0, dtype=proposal.population_dtype)
-    with (
-        patch(
-            "nessai.proposal.flowproposal.flowproposal.empty_structured_array",
-            return_value=x_empty,
-        ) as mock_empty,
-    ):
-        FlowProposal.populate(
-            proposal, worst_point, n_samples=poolsize, plot=True, r=r
-        )
-
-    mock_empty.assert_called_once_with(
-        0,
-        dtype=proposal.population_dtype,
-    )
-    proposal.rng.random.assert_called_once_with(3 * drawsize)
-
-    if r is None:
-        proposal.forward_pass.assert_called_once_with(
-            worst_point,
-            rescale=True,
-            compute_radius=True,
-        )
-        proposal.radius.assert_called_once_with(worst_z)
-    else:
-        assert proposal.r is r
-
-    assert proposal.r == r_out
-
-    proposal.prep_latent_prior.assert_called_once()
-
-    draw_calls = 3 * [call(5)]
-    proposal.draw_latent_prior.assert_has_calls(draw_calls)
-
-    backwards_calls = [
-        call(
-            zz,
-            rescale=True,
-            return_unit_hypercube=proposal.map_to_unit_hypercube,
-        )
-        for zz in z
-    ]
-    proposal.backward_pass.assert_has_calls(backwards_calls)
-
-    compute_weights_calls = [call(xx, lq) for xx, lq in zip(x, log_q)]
-    proposal.compute_weights.assert_has_calls(compute_weights_calls)
-
-    proposal.plot_pool.assert_called_once()
-    proposal.convert_to_samples.assert_called_once()
-    assert_structured_arrays_equal(
-        proposal.convert_to_samples.call_args[0][0], proposal.x
-    )
-    assert proposal.convert_to_samples.call_args[1]["plot"] is True
-
-    assert proposal.population_acceptance == (12 / 15)
-    assert proposal.populated_count == 2
-    assert proposal.populated is True
-    assert proposal.x.size == 10
-
-    if check_acceptance:
-        proposal.compute_acceptance.assert_called()
-        assert proposal.acceptance == [0.7, 0.8]
-    else:
-        proposal.compute_acceptance.assert_not_called()
-
-    proposal.model.batch_evaluate_log_likelihood.assert_called_once_with(
-        proposal.samples
-    )
-    np.testing.assert_array_equal(proposal.samples["logL"], log_l)
-
-    assert proposal.population_time.total_seconds() > 0.0
-
-
-@pytest.mark.parametrize("check_acceptance", [False, True])
-@pytest.mark.parametrize("indices", [[], [1]])
-@pytest.mark.parametrize("r", [None, 1.0])
-@pytest.mark.parametrize(
-    "max_radius, min_radius",
-    [(0.5, None), (None, 1.5), (None, None)],
-)
-@pytest.mark.parametrize("latent_prior", ["truncated_gaussian", "gaussian"])
-def test_populate_not_accumulate_weights(
-    proposal,
-    check_acceptance,
-    indices,
-    r,
-    min_radius,
-    max_radius,
-    latent_prior,
-    wait,
-    rng,
-):
-    """Test the main populate method"""
-    n_dims = 2
-    poolsize = 10
-    drawsize = 5
-    names = ["x", "y"]
-    worst_point = np.array(
-        [[1, 2, 3]], dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
-    )
-    worst_z = rng.standard_normal((1, n_dims))
-    z = [
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-    ]
-    x = [
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-    ]
-    log_q = [
-        np.log(rng.random(drawsize)),
-        np.log(rng.random(drawsize)),
-        np.log(rng.random(drawsize)),
-    ]
-    log_w = [
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 1), np.zeros(1)])),
-    ]
-    # Control rejection sampling using log_w
-    rand_u = [
-        0.5 * np.ones(drawsize),
-        0.5 * np.ones(drawsize),
-        0.5 * np.ones(drawsize),
-    ]
-
-    log_l = rng.random(poolsize)
-    log_p = rng.random(poolsize)
-
-    r_flow = 1.0
-
-    if r is None:
-        r_out = r_flow
-        if min_radius is not None:
-            r_out = max(r_out, min_radius)
-        if max_radius is not None:
-            r_out = min(r_out, max_radius)
-    else:
-        r_out = r
-
-    proposal.population_time = datetime.timedelta()
-    proposal.initialised = True
-    proposal.max_radius = max_radius
-    proposal.dims = n_dims
-    proposal.poolsize = poolsize
-    proposal.drawsize = drawsize
-    proposal.min_radius = min_radius
-    proposal.fuzz = 1.0
-    proposal.indices = indices
-    proposal.acceptance = [0.7]
-    proposal.keep_samples = False
-    proposal.fixed_radius = False
-    proposal.compute_radius_with_all = False
-    proposal.check_acceptance = check_acceptance
-    proposal._plot_pool = True
-    proposal.populated_count = 1
-    proposal.population_dtype = get_dtype(names)
-    proposal.truncate_log_q = False
-    proposal.accumulate_weights = False
-
-    proposal.forward_pass = MagicMock(return_value=(worst_z, np.nan))
-    proposal.backward_pass = MagicMock(side_effect=zip(x, log_q))
-    proposal.radius = MagicMock(return_value=r_flow)
-    proposal.get_alt_distribution = MagicMock(return_value=None)
-    proposal.latent_prior = latent_prior
-    proposal.prep_latent_prior = MagicMock()
-    proposal.draw_latent_prior = MagicMock(side_effect=z)
-    proposal.compute_weights = MagicMock(side_effect=log_w)
-    proposal.compute_acceptance = MagicMock(return_value=0.8)
-    proposal.model = MagicMock()
-    proposal.model.batch_evaluate_log_likelihood = MagicMock(
-        return_value=log_l
-    )
-    proposal.rng = MagicMock()
-    proposal.rng.random = MagicMock(side_effect=rand_u)
-    proposal.rng.permutation = rng.permutation
-
-    def convert_to_samples(samples, plot):
-        samples["logP"] = log_p
-        # wait for windows
-        wait()
-        return samples
-
-    proposal.plot_pool = MagicMock()
-    proposal.convert_to_samples = MagicMock(side_effect=convert_to_samples)
-
-    x_empty = np.empty(poolsize, dtype=proposal.population_dtype)
-    with (
-        patch(
-            "nessai.proposal.flowproposal.flowproposal.empty_structured_array",
-            return_value=x_empty,
-        ) as mock_empty,
-    ):
-        FlowProposal.populate(
-            proposal, worst_point, n_samples=poolsize, plot=True, r=r
-        )
-
-    mock_empty.assert_called_once_with(
-        poolsize,
-        dtype=proposal.population_dtype,
-    )
-    proposal.rng.random.assert_has_calls(3 * [call(drawsize)])
-
-    if r is None:
-        proposal.forward_pass.assert_called_once_with(
-            worst_point,
-            rescale=True,
-            compute_radius=True,
-        )
-        proposal.radius.assert_called_once_with(worst_z)
-    elif latent_prior == "truncated_gaussian":
-        assert proposal.r is r
-
-    if latent_prior == "truncated_gaussian":
-        assert proposal.r == r_out
-    else:
-        assert proposal.r is np.nan
-
-    proposal.prep_latent_prior.assert_called_once()
-
-    draw_calls = 3 * [call(5)]
-    proposal.draw_latent_prior.assert_has_calls(draw_calls)
-
-    backwards_calls = [
-        call(
-            zz,
-            rescale=True,
-            return_unit_hypercube=proposal.map_to_unit_hypercube,
-        )
-        for zz in z
-    ]
-    proposal.backward_pass.assert_has_calls(backwards_calls)
-
-    compute_weights_calls = [call(xx, lq) for xx, lq in zip(x, log_q)]
-    proposal.compute_weights.assert_has_calls(compute_weights_calls)
-
-    proposal.plot_pool.assert_called_once()
-    proposal.convert_to_samples.assert_called_once()
-    assert_structured_arrays_equal(
-        proposal.convert_to_samples.call_args[0][0], proposal.x
-    )
-    assert proposal.convert_to_samples.call_args[1]["plot"] is True
-
-    assert proposal.population_acceptance == (12 / 15)
-    assert proposal.populated_count == 2
-    assert proposal.populated is True
-    assert proposal.x.size == 10
-
-    if check_acceptance:
-        proposal.compute_acceptance.assert_called()
-        assert proposal.acceptance == [0.7, 0.8]
-    else:
-        proposal.compute_acceptance.assert_not_called()
-
-    proposal.model.batch_evaluate_log_likelihood.assert_called_once_with(
-        proposal.samples
-    )
-    np.testing.assert_array_equal(proposal.samples["logL"], log_l)
-
-    assert proposal.population_time.total_seconds() > 0.0
-
-
-def test_populate_not_initialised(proposal):
-    """Assert populate fails if the proposal is not initialised"""
-    proposal.initialised = False
-    with pytest.raises(RuntimeError) as excinfo:
-        FlowProposal.populate(proposal, 1.0)
-    assert "Proposal has not been initialised. " in str(excinfo.value)
-
-
-def test_populate_truncate_log_q(proposal, rng):
-    n_dims = 2
-    nlive = 8
-    poolsize = 8
-    drawsize = 5
-    names = ["x", "y"]
-    r_flow = 2.0
-    worst_point = np.array(
-        [[1, 2, 3]], dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
-    )
-    z = [
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-    ]
-    x = [
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-    ]
-    log_q = [
-        np.zeros(drawsize),
-        np.zeros(drawsize),
-        np.zeros(drawsize),
-    ]
-    # This sample will be discarded because of the logq min check
-    for i in range(3):
-        log_q[i][-1] = np.nan_to_num(-np.inf)
-    log_w = [
-        np.log(np.concatenate([np.ones(drawsize - 2), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 2), np.zeros(1)])),
-        np.log(np.concatenate([np.ones(drawsize - 2), np.zeros(1)])),
-    ]
-    # Control rejection sampling using log_w
-    rand_u = 0.5 * np.ones(3 * (drawsize - 1))
-
-    log_l = rng.random(poolsize)
-
-    proposal.population_time = datetime.timedelta()
-    proposal.initialised = True
-    proposal.dims = n_dims
-    proposal.poolsize = poolsize
-    proposal.drawsize = drawsize
-    proposal.fuzz = 1.0
-    proposal.indices = None
-    proposal.acceptance = [0.7]
-    proposal.keep_samples = False
-    proposal.fixed_radius = 2.0
-    proposal.compute_radius_with_all = False
-    proposal.check_acceptance = False
-    proposal._plot_pool = False
-    proposal.populated_count = 1
-    proposal.population_dtype = get_dtype(names)
-    proposal.truncate_log_q = True
-    proposal.training_data = numpy_array_to_live_points(
-        np.random.randn(nlive, n_dims),
-        names=names,
-    )
-    proposal.accumulate_weights = True
-    proposal.latent_prior = "truncated_gaussian"
-
-    log_q_live = np.zeros(nlive)
-    log_q_live[-1] = -1.0
-
     proposal.forward_pass = MagicMock(
-        return_value=(nlive * [None], log_q_live)
+        return_value=(np.zeros((2, 2)), np.array([0.0, -1.0]))
     )
-    proposal.backward_pass = MagicMock(side_effect=zip(x, log_q))
-    proposal.compute_weights = MagicMock(side_effect=log_w)
-    proposal.radius = MagicMock(return_value=r_flow)
-    proposal.get_alt_distribution = MagicMock(return_value=None)
-    proposal.prep_latent_prior = MagicMock()
-    proposal.draw_latent_prior = MagicMock(side_effect=z)
-    proposal.rejection_sampling = MagicMock(
-        side_effect=[(a[:-1], b[:-1]) for a, b in zip(z, x)]
-    )
-    proposal.compute_acceptance = MagicMock(return_value=0.8)
-    proposal.model = MagicMock()
-    proposal.model.batch_evaluate_log_likelihood = MagicMock(
-        return_value=log_l
-    )
-    proposal.rng = MagicMock()
-    proposal.rng.random = MagicMock(return_value=rand_u)
-    proposal.rng.permutation = rng.permutation
-
-    proposal.convert_to_samples = MagicMock(
-        side_effect=lambda *args, **kwargs: args[0]
-    )
-
-    x_empty = np.empty(0, dtype=proposal.population_dtype)
-    with (
-        patch(
-            "nessai.proposal.flowproposal.flowproposal.empty_structured_array",
-            return_value=x_empty,
-        ) as mock_empty,
-    ):
-        FlowProposal.populate(
-            proposal, worst_point, n_samples=poolsize, plot=False
+    proposal.backward_pass = MagicMock(
+        return_value=(
+            samples([(1.0, 1.0), (2.0, 2.0)]),
+            np.array([0.5, -2.0]),
+            np.array([[0.0, 0.0], [0.5, 0.0]]),
         )
-
-    mock_empty.assert_called_once_with(
-        0,
-        dtype=proposal.population_dtype,
     )
-    proposal.rng.random.assert_called_once_with(3 * drawsize - 3)
+    proposal.model.batch_evaluate_log_likelihood.return_value = np.array([1.0])
 
-    assert proposal.population_acceptance == (9 / 15)
+    FlowProposal.populate(
+        proposal, point(0.0, 0.0, logl=0.5), n_samples=1, plot=False
+    )
 
-    proposal.forward_pass.assert_called_once_with(proposal.training_data)
+    proposal.flow.sample_latent_distribution.assert_called_once_with(3)
+    proposal.backward_pass.assert_called_once()
+    proposal.model.batch_evaluate_log_likelihood.assert_called_once()
+    proposal.compute_weights.assert_called_once()
+    assert proposal.x.size == 1
+    assert proposal.samples.size == 1
+    assert proposal.get_truncation_rule("latent_radius").radius == 1.0
+    assert proposal.populated is True
 
-    backwards_calls = [
-        call(
-            zz,
-            rescale=True,
-            return_unit_hypercube=proposal.map_to_unit_hypercube,
+
+def test_populate_continues_after_empty_latent_batch(
+    proposal, rng, point, samples
+):
+    configure_population_test_proposal(proposal, rng, samples)
+    proposal._truncation_scheme = TruncationScheme(
+        [LatentRadiusTruncation(fixed_radius=1.0, radius_mode="fixed")]
+    )
+    proposal.flow.sample_latent_distribution.side_effect = [
+        np.array([[2.0, 0.0], [3.0, 0.0]]),
+        np.array([[0.0, 0.0], [2.0, 0.0]]),
+    ]
+    proposal.backward_pass = MagicMock(
+        return_value=(
+            samples([(1.0, 1.0)]),
+            np.array([0.5]),
+            np.array([[0.0, 0.0]]),
         )
-        for zz in z
-    ]
-    proposal.backward_pass.assert_has_calls(backwards_calls)
-
-    compute_weights_calls = [(xx[:-1], lq[:-1]) for xx, lq in zip(x, log_q)]
-    for actual_call, expected_call in zip(
-        proposal.compute_weights.call_args_list,
-        compute_weights_calls,
-    ):
-        assert_structured_arrays_equal(actual_call[0][0], expected_call[0])
-        np.testing.assert_array_equal(actual_call[0][1], expected_call[1])
-
-
-def test_populate_enforce_likelihood_threshold(proposal, rng):
-    n_dims = 2
-    nlive = 8
-    drawsize = 5
-    names = ["x", "y"]
-    r_flow = 2.0
-    worst_point = parameters_to_live_point([1, 2], names)
-    z = [
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-        rng.standard_normal((drawsize, n_dims)),
-    ]
-    x = [
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-        numpy_array_to_live_points(
-            rng.standard_normal((drawsize, n_dims)), names
-        ),
-    ]
-
-    log_l = [rng.random(drawsize) for _ in range(len(x))]
-
-    log_l_threshold = 0.0
-    log_l_accept_total = 0
-    while True:
-        log_l_accept = [sum(ll > log_l_threshold) for ll in log_l]
-        log_l_accept_total = sum(log_l_accept)
-        if log_l_accept_total > 5:
-            break
-        log_l_threshold -= 0.1
-
-    worst_point["logL"] = log_l_threshold
-    log_q = [
-        np.zeros(drawsize),
-        np.zeros(drawsize),
-        np.zeros(drawsize),
-    ]
-
-    # Reject one from each batch
-    log_w = [
-        np.log(np.concatenate([np.ones(naccept - 1), np.zeros(1)]))
-        for naccept in log_l_accept
-    ]
-    rand_u = [0.5 * np.ones(naccept) for naccept in log_l_accept]
-
-    poolsize = log_l_accept_total - 3
-    proposal.population_time = datetime.timedelta()
-    proposal.initialised = True
-    proposal.dims = n_dims
-    proposal.poolsize = poolsize
-    proposal.drawsize = drawsize
-    proposal.fuzz = 1.0
-    proposal.indices = None
-    proposal.acceptance = [0.7]
-    proposal.keep_samples = False
-    proposal.fixed_radius = None
-    proposal.max_radius = None
-    proposal.min_radius = None
-    proposal.compute_radius_with_all = False
-    proposal.check_acceptance = False
-    proposal._plot_pool = False
-    proposal.populated_count = 1
-    proposal.population_dtype = get_dtype(names)
-    proposal.truncate_log_q = False
-    proposal.training_data = numpy_array_to_live_points(
-        np.random.randn(nlive, n_dims),
-        names=names,
     )
-    proposal.accumulate_weights = False
-    proposal.latent_prior = "truncated_gaussian"
-    proposal.enforce_likelihood_threshold = True
-    proposal.log_likelihood_threshold = log_l_threshold
+    proposal.model.batch_evaluate_log_likelihood.return_value = np.array([1.0])
 
-    log_q_live = np.zeros(nlive)
-
-    proposal.forward_pass = MagicMock(
-        return_value=(nlive * [None], log_q_live)
-    )
-    proposal.backward_pass = MagicMock(side_effect=zip(x, log_q))
-    proposal.compute_weights = MagicMock(side_effect=log_w)
-    proposal.radius = MagicMock(return_value=r_flow)
-    proposal.get_alt_distribution = MagicMock(return_value=None)
-    proposal.prep_latent_prior = MagicMock()
-    proposal.draw_latent_prior = MagicMock(side_effect=z)
-    proposal.compute_acceptance = MagicMock(return_value=0.8)
-    proposal.model = MagicMock()
-    proposal.model.batch_evaluate_log_likelihood = MagicMock(side_effect=log_l)
-    proposal.rng = MagicMock()
-    proposal.rng.random = MagicMock(side_effect=rand_u)
-    proposal.rng.permutation = rng.permutation
-
-    proposal.convert_to_samples = MagicMock(
-        side_effect=lambda *args, **kwargs: args[0]
+    FlowProposal.populate(
+        proposal, point(0.0, 0.0, logl=0.5), n_samples=1, plot=False
     )
 
-    x_empty = np.empty(poolsize, dtype=proposal.population_dtype)
-    with (
-        patch(
-            "nessai.proposal.flowproposal.flowproposal.empty_structured_array",
-            return_value=x_empty,
-        ) as mock_empty,
-    ):
-        FlowProposal.populate(
-            proposal, worst_point, n_samples=poolsize, plot=False
-        )
-
-    mock_empty.assert_called_once_with(
-        poolsize,
-        dtype=proposal.population_dtype,
-    )
-    proposal.rng.random.assert_has_calls(3 * [call(drawsize)])
-
-    assert proposal.population_acceptance == (poolsize / (len(x) * drawsize))
-
-    proposal.forward_pass.assert_called_once_with(
-        worst_point, rescale=True, compute_radius=True
-    )
-
-    backwards_calls = [
-        call(
-            zz,
-            rescale=True,
-            return_unit_hypercube=proposal.map_to_unit_hypercube,
-        )
-        for zz in z
-    ]
-    proposal.backward_pass.assert_has_calls(backwards_calls)
-
-    assert proposal.compute_weights.call_count == len(x)
-    assert proposal.model.batch_evaluate_log_likelihood.call_count == len(x)
+    assert proposal.flow.sample_latent_distribution.call_count == 2
+    proposal.backward_pass.assert_called_once()
+    proposal.model.batch_evaluate_log_likelihood.assert_called_once()
+    assert proposal.x.size == 1

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
@@ -114,3 +114,93 @@ def test_populate_continues_after_empty_latent_batch(
     proposal.backward_pass.assert_called_once()
     proposal.model.batch_evaluate_log_likelihood.assert_called_once()
     assert proposal.x.size == 1
+
+
+def test_populate_accumulate_weights_recomputes_accept_on_max_samples(
+    proposal, rng, point, samples
+):
+    configure_population_test_proposal(proposal, rng, samples)
+    proposal.accumulate_weights = True
+    proposal.flow.sample_latent_distribution.return_value = np.zeros((3, 2))
+    proposal.backward_pass = MagicMock(
+        return_value=(
+            samples([(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]),
+            np.zeros(3),
+            np.zeros((3, 2)),
+        )
+    )
+    proposal.compute_weights.return_value = np.zeros(3)
+    proposal.model.batch_evaluate_log_likelihood.return_value = np.array(
+        [1.0, 2.0]
+    )
+
+    FlowProposal.populate(
+        proposal,
+        point(0.0, 0.0, logl=0.5),
+        n_samples=2,
+        plot=False,
+        max_samples=2,
+    )
+
+    assert proposal.x.size == 2
+    assert proposal.samples.size == 2
+    assert proposal.sample_latent_distribution.call_count == 1
+    assert proposal.rng.random.call_count == 1
+
+
+def test_populate_stops_at_max_samples_after_empty_latent_batches(
+    proposal, rng, point, samples
+):
+    configure_population_test_proposal(proposal, rng, samples)
+    proposal._truncation_scheme = TruncationScheme(
+        [LatentRadiusTruncation(fixed_radius=0.1, radius_mode="fixed")]
+    )
+    proposal.flow.sample_latent_distribution.return_value = np.array(
+        [[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]
+    )
+    proposal.model.batch_evaluate_log_likelihood.return_value = np.array([])
+
+    FlowProposal.populate(
+        proposal,
+        point(0.0, 0.0, logl=0.5),
+        n_samples=1,
+        plot=False,
+        max_samples=2,
+    )
+
+    proposal.sample_latent_distribution.assert_called_once_with(3)
+    assert proposal.backward_pass.call_count == 0
+    assert proposal.x.size == 0
+    assert proposal.population_acceptance == 0.0
+
+
+def test_populate_stops_at_max_samples_after_all_likelihood_rejected(
+    proposal, rng, point, samples
+):
+    configure_population_test_proposal(proposal, rng, samples)
+    proposal._truncation_scheme = TruncationScheme(
+        [LikelihoodThresholdTruncation()]
+    )
+    proposal.flow.sample_latent_distribution.return_value = np.zeros((3, 2))
+    proposal.backward_pass = MagicMock(
+        return_value=(
+            samples([(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]),
+            np.zeros(3),
+            np.zeros((3, 2)),
+        )
+    )
+    proposal.model.batch_evaluate_log_likelihood.return_value = np.zeros(3)
+
+    FlowProposal.populate(
+        proposal,
+        point(0.0, 0.0, logl=0.5),
+        n_samples=1,
+        plot=False,
+        max_samples=2,
+    )
+
+    proposal.sample_latent_distribution.assert_called_once_with(3)
+    proposal.backward_pass.assert_called_once()
+    proposal.compute_weights.assert_not_called()
+    assert proposal.x.size == 0
+    assert proposal.population_acceptance == 0.0

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_flowproposal_population.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
+from nessai.livepoint import empty_structured_array
 from nessai.proposal import FlowProposal
 from nessai.proposal.flowproposal.truncation import (
     LatentRadiusTruncation,
@@ -15,7 +16,7 @@ from nessai.proposal.flowproposal.truncation import (
 )
 
 
-def configure_population_test_proposal(proposal, samples):
+def configure_population_test_proposal(proposal, rng, samples):
     proposal.population_time = datetime.timedelta()
     proposal.initialised = True
     proposal.indices = []
@@ -25,16 +26,16 @@ def configure_population_test_proposal(proposal, samples):
     proposal._plot_pool = False
     proposal.populated_count = 0
     proposal.map_to_unit_hypercube = False
-    proposal.population_dtype = np.dtype(
-        [("x", "f8"), ("y", "f8"), ("logL", "f8")]
-    )
+    proposal.population_dtype = empty_structured_array(
+        0, names=["x", "y"]
+    ).dtype
     proposal.convert_to_samples = MagicMock(
         side_effect=lambda x, plot: x.copy()
     )
     proposal.compute_weights = MagicMock(
         side_effect=lambda x, log_q: np.zeros(x.size)
     )
-    proposal.rng = MagicMock()
+    proposal.rng = MagicMock(wraps=rng)
     proposal.rng.random = MagicMock(side_effect=lambda n: np.full(n, 0.5))
     proposal.rng.permutation = MagicMock(side_effect=lambda n: np.arange(n))
     proposal.model = MagicMock()
@@ -42,6 +43,9 @@ def configure_population_test_proposal(proposal, samples):
     proposal._truncation_scheme = TruncationScheme()
     proposal.drawsize = 3
     proposal.flow = MagicMock()
+    proposal.sample_latent_distribution = MagicMock(
+        side_effect=proposal.flow.sample_latent_distribution
+    )
 
 
 def test_populate_applies_truncation_in_stages(proposal, rng, point, samples):
@@ -72,13 +76,13 @@ def test_populate_applies_truncation_in_stages(proposal, rng, point, samples):
         proposal, point(0.0, 0.0, logl=0.5), n_samples=1, plot=False
     )
 
-    proposal.flow.sample_latent_distribution.assert_called_once_with(3)
+    proposal.sample_latent_distribution.assert_called_once_with(3)
     proposal.backward_pass.assert_called_once()
     proposal.model.batch_evaluate_log_likelihood.assert_called_once()
     proposal.compute_weights.assert_called_once()
     assert proposal.x.size == 1
     assert proposal.samples.size == 1
-    assert proposal.get_truncation_rule("latent_radius").radius == 1.0
+    assert proposal._truncation_scheme.get_rule("latent_radius").radius == 1.0
     assert proposal.populated is True
 
 
@@ -106,7 +110,7 @@ def test_populate_continues_after_empty_latent_batch(
         proposal, point(0.0, 0.0, logl=0.5), n_samples=1, plot=False
     )
 
-    assert proposal.flow.sample_latent_distribution.call_count == 2
+    assert proposal.sample_latent_distribution.call_count == 2
     proposal.backward_pass.assert_called_once()
     proposal.model.batch_evaluate_log_likelihood.assert_called_once()
     assert proposal.x.size == 1

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_reparameterisations.py
@@ -29,5 +29,5 @@ def test_set_rescaling(proposal, expansion_fraction, fuzz):
     ) as mock_parent:
         FlowProposal.set_rescaling(proposal)
     mock_parent.assert_called_once()
-    rule = proposal.get_truncation_rule("latent_radius")
+    rule = proposal._truncation_scheme.get_rule("latent_radius")
     assert rule.fuzz == fuzz

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_reparameterisations.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_reparameterisations.py
@@ -3,6 +3,10 @@ from unittest.mock import patch
 import pytest
 
 from nessai.proposal.flowproposal.flowproposal import FlowProposal
+from nessai.proposal.flowproposal.truncation import (
+    LatentRadiusTruncation,
+    TruncationScheme,
+)
 
 
 @pytest.mark.parametrize(
@@ -10,12 +14,20 @@ from nessai.proposal.flowproposal.flowproposal import FlowProposal
 )
 def test_set_rescaling(proposal, expansion_fraction, fuzz):
     proposal.prime_dims = 2
-    proposal.expansion_fraction = expansion_fraction
-    proposal.fuzz = 2.0
+    proposal._truncation_scheme = TruncationScheme(
+        [
+            LatentRadiusTruncation(
+                fuzz=2.0,
+                fixed_radius=1.0,
+                radius_mode="fixed",
+                expansion_fraction=expansion_fraction,
+            )
+        ]
+    )
     with patch(
         "nessai.proposal.flowproposal.flowproposal.BaseFlowProposal.set_rescaling"  # noqa: E501
     ) as mock_parent:
         FlowProposal.set_rescaling(proposal)
     mock_parent.assert_called_once()
-    proposal.configure_constant_volume.assert_called_once()
-    assert proposal.fuzz == fuzz
+    rule = proposal.get_truncation_rule("latent_radius")
+    assert rule.fuzz == fuzz

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Standalone tests for truncation rules and helpers."""
 
+import logging
 from unittest.mock import patch
 
 import numpy as np
@@ -163,6 +164,10 @@ def test_apply_default_truncation_config_with_default_methods():
     assert kwargs == DEFAULT_TRUNCATION_KWARGS
 
 
+def test_normalise_truncation_kwargs_none():
+    assert normalise_truncation_kwargs() == {}
+
+
 def test_normalise_truncation_kwargs_wraps_flat_kwargs_for_single_method():
     kwargs = normalise_truncation_kwargs(
         truncation_method="latent_radius",
@@ -179,6 +184,14 @@ def test_normalise_truncation_kwargs_keeps_nested_kwargs():
     assert kwargs == {"latent_radius": {"constant_volume_mode": True}}
 
 
+def test_normalise_truncation_kwargs_keeps_flat_kwargs_with_methods_list():
+    kwargs = normalise_truncation_kwargs(
+        truncation_methods=["latent_radius"],
+        truncation_kwargs={"constant_volume_mode": True},
+    )
+    assert kwargs == {"constant_volume_mode": True}
+
+
 def test_base_truncation_rule_reset_and_getstate():
     rule = DummyTruncationRule()
     rule._value = 2.0
@@ -187,6 +200,20 @@ def test_base_truncation_rule_reset_and_getstate():
     rule._value = 3.0
     state = rule.__getstate__()
     assert np.isnan(state["_value"])
+
+
+def test_base_truncation_rule_defaults_passthrough():
+    rule = BaseTruncationRule()
+    x = np.array([1.0])
+    log_q = np.array([2.0])
+    z = np.array([[3.0]])
+    assert rule.configure(None) is None
+    assert rule.prepare(None, None) is None
+    np.testing.assert_array_equal(rule.apply_latent(None, z), z)
+    out = rule.apply_after_backward(None, x, log_q, z)
+    assert out == (x, log_q, z)
+    out = rule.apply_after_likelihood(None, x, log_q, z)
+    assert out == (x, log_q, z)
 
 
 def test_latent_radius_invalid_radius_mode():
@@ -309,6 +336,16 @@ def test_likelihood_threshold_properties_and_prepare(point):
     assert rule.threshold == 0.5
 
 
+def test_likelihood_threshold_prepare_with_nan_disables_threshold(
+    point, caplog
+):
+    rule = LikelihoodThresholdTruncation()
+    with caplog.at_level(logging.DEBUG):
+        rule.prepare(None, point(0.0, 0.0, logl=np.nan))
+    assert rule.threshold == -np.inf
+    assert "Disabling likelihood-threshold truncation" in caplog.text
+
+
 def test_likelihood_threshold_filters_after_likelihood(proposal, samples):
     x = samples([(0.0, 0.0), (1.0, 1.0)])
     x["logL"] = [0.0, 1.0]
@@ -348,6 +385,13 @@ def test_truncation_scheme_rule_names_and_has_rule():
     assert scheme.has_rule("dummy") is True
     assert scheme.has_rule("missing") is False
     assert scheme.requires_log_likelihood is True
+    assert scheme.get_rule("missing") is None
+
+
+def test_truncation_scheme_add_rule_with_index():
+    scheme = TruncationScheme([DummyTruncationRule()])
+    scheme.add_rule(LikelihoodThresholdTruncation(), index=0)
+    assert scheme.rule_names == ["likelihood_threshold", "dummy"]
 
 
 def test_truncation_scheme_configure_and_apply_stages(proposal, samples):
@@ -383,6 +427,12 @@ def test_truncation_scheme_configure_and_apply_stages(proposal, samples):
     assert out_x.size == 1
     np.testing.assert_array_equal(out_log_q, np.array([0.0]))
     np.testing.assert_array_equal(out_z, np.array([[0.0, 0.0]]))
+    out_x, out_log_q, out_z = scheme.apply_after_likelihood(
+        proposal, x, log_q, z
+    )
+    assert out_x is x
+    assert out_log_q is log_q
+    assert out_z is z
 
 
 def test_truncation_scheme_prepare_and_reset(proposal):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
@@ -229,6 +229,17 @@ def test_latent_radius_compute_radius_with_adaptive_bounds(
     assert rule._compute_radius(proposal, point(0.0, 0.0)) == 7.0
 
 
+def test_latent_radius_compute_radius_with_all_requires_training_data(
+    proposal, point
+):
+    proposal.training_data = None
+    rule = LatentRadiusTruncation(compute_radius_with_all=True)
+    with pytest.raises(
+        RuntimeError, match="compute_radius_with_all requires training_data"
+    ):
+        rule._compute_radius(proposal, point(0.0, 0.0))
+
+
 def test_latent_radius_prepare_and_apply_latent(proposal):
     rule = LatentRadiusTruncation(
         fixed_radius=1.0, radius_mode="fixed", fuzz=2.0
@@ -250,6 +261,15 @@ def test_min_log_q_prepare(proposal, samples):
     rule = MinLogQTruncation()
     rule.prepare(proposal, None)
     assert rule.min_log_q == -1.5
+
+
+def test_min_log_q_prepare_requires_training_data(proposal):
+    proposal.training_data = None
+    rule = MinLogQTruncation()
+    with pytest.raises(
+        RuntimeError, match="min_log_q truncation requires training_data"
+    ):
+        rule.prepare(proposal, None)
 
 
 def test_min_log_q_filters_after_backward(proposal, samples):

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
@@ -19,6 +19,7 @@ from nessai.proposal.flowproposal.truncation import (
     get_deprecated_latent_radius_arguments,
     get_deprecated_latent_radius_kwargs,
     get_truncation_rule_class,
+    normalise_truncation_kwargs,
     normalise_truncation_methods,
 )
 
@@ -160,6 +161,22 @@ def test_apply_default_truncation_config_with_default_methods():
     )
     assert methods == DEFAULT_TRUNCATION_METHODS
     assert kwargs == DEFAULT_TRUNCATION_KWARGS
+
+
+def test_normalise_truncation_kwargs_wraps_flat_kwargs_for_single_method():
+    kwargs = normalise_truncation_kwargs(
+        truncation_method="latent_radius",
+        truncation_kwargs={"constant_volume_mode": True},
+    )
+    assert kwargs == {"latent_radius": {"constant_volume_mode": True}}
+
+
+def test_normalise_truncation_kwargs_keeps_nested_kwargs():
+    kwargs = normalise_truncation_kwargs(
+        truncation_method="latent_radius",
+        truncation_kwargs={"latent_radius": {"constant_volume_mode": True}},
+    )
+    assert kwargs == {"latent_radius": {"constant_volume_mode": True}}
 
 
 def test_base_truncation_rule_reset_and_getstate():

--- a/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
+++ b/tests/test_proposal/test_flowproposal/test_flowproposal/test_truncation.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+"""Standalone tests for truncation rules and helpers."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from nessai.proposal.flowproposal.truncation import (
+    DEFAULT_TRUNCATION_KWARGS,
+    DEFAULT_TRUNCATION_METHODS,
+    BaseTruncationRule,
+    LatentRadiusTruncation,
+    LikelihoodThresholdTruncation,
+    MinLogQTruncation,
+    TruncationScheme,
+    apply_default_truncation_config,
+    build_truncation_methods,
+    get_deprecated_latent_radius_arguments,
+    get_deprecated_latent_radius_kwargs,
+    get_truncation_rule_class,
+    normalise_truncation_methods,
+)
+
+
+@pytest.fixture
+def point():
+    def _point(x, y, logl=0.0):
+        out = np.zeros(1, dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")])
+        out["x"] = x
+        out["y"] = y
+        out["logL"] = logl
+        return out[0]
+
+    return _point
+
+
+@pytest.fixture
+def samples():
+    def _samples(values):
+        out = np.zeros(
+            len(values), dtype=[("x", "f8"), ("y", "f8"), ("logL", "f8")]
+        )
+        out["x"] = [v[0] for v in values]
+        out["y"] = [v[1] for v in values]
+        return out
+
+    return _samples
+
+
+class DummyTruncationRule(BaseTruncationRule):
+    name = "dummy"
+    _transient_defaults = {"_value": np.nan}
+
+    def prepare(self, proposal, worst_point, radius=None):
+        self._value = 1.0
+
+
+def test_get_deprecated_latent_radius_arguments():
+    out = get_deprecated_latent_radius_arguments(
+        constant_volume_mode=True,
+        volume_fraction=None,
+        fuzz=1.2,
+        expansion_fraction=None,
+        fixed_radius=None,
+        radius_mode=None,
+        min_radius=None,
+        max_radius=5.0,
+        compute_radius_with_all=None,
+    )
+    assert out == ["constant_volume_mode", "fuzz", "max_radius"]
+
+
+def test_get_deprecated_latent_radius_kwargs():
+    out = get_deprecated_latent_radius_kwargs(
+        constant_volume_mode=True,
+        volume_fraction=None,
+        fuzz=1.2,
+        expansion_fraction=None,
+        fixed_radius=None,
+        radius_mode=None,
+        min_radius=None,
+        max_radius=5.0,
+        compute_radius_with_all=None,
+    )
+    assert out == {
+        "constant_volume_mode": True,
+        "fuzz": 1.2,
+        "max_radius": 5.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "truncation_method,truncation_methods,expected",
+    [
+        (None, None, []),
+        ("min_log_q", None, ["min_log_q"]),
+        (None, "likelihood_threshold", ["likelihood_threshold"]),
+        (
+            None,
+            ["min_log_q", "min_log_q", "likelihood_threshold"],
+            ["min_log_q", "likelihood_threshold"],
+        ),
+    ],
+)
+def test_normalise_truncation_methods(
+    truncation_method, truncation_methods, expected
+):
+    assert (
+        normalise_truncation_methods(truncation_method, truncation_methods)
+        == expected
+    )
+
+
+def test_build_truncation_methods_rejects_both_method_and_methods():
+    with pytest.raises(
+        ValueError, match="Specify only one of truncation_method"
+    ):
+        build_truncation_methods(
+            truncation_method="min_log_q",
+            truncation_methods=["likelihood_threshold"],
+        )
+
+
+def test_build_truncation_methods_includes_default_latent_radius():
+    assert build_truncation_methods(default_latent_radius=True) == [
+        "latent_radius"
+    ]
+
+
+def test_build_truncation_methods_includes_legacy_radius_and_flags():
+    assert build_truncation_methods(
+        truncate_log_q=True,
+        enforce_likelihood_threshold=True,
+        latent_radius_kwargs={"fixed_radius": 2.0},
+    ) == [
+        "latent_radius",
+        "min_log_q",
+        "likelihood_threshold",
+    ]
+
+
+def test_apply_default_truncation_config():
+    methods, kwargs = apply_default_truncation_config(
+        ["latent_radius", "min_log_q"],
+        truncation_kwargs={"latent_radius": {"fuzz": 1.5}},
+    )
+    assert methods == ["latent_radius", "min_log_q"]
+    assert kwargs["latent_radius"] == {
+        **DEFAULT_TRUNCATION_KWARGS["latent_radius"],
+        "fuzz": 1.5,
+    }
+
+
+def test_apply_default_truncation_config_with_default_methods():
+    methods, kwargs = apply_default_truncation_config(
+        [],
+        truncation_kwargs=None,
+        default_latent_radius=True,
+    )
+    assert methods == DEFAULT_TRUNCATION_METHODS
+    assert kwargs == DEFAULT_TRUNCATION_KWARGS
+
+
+def test_base_truncation_rule_reset_and_getstate():
+    rule = DummyTruncationRule()
+    rule._value = 2.0
+    rule.reset()
+    assert np.isnan(rule._value)
+    rule._value = 3.0
+    state = rule.__getstate__()
+    assert np.isnan(state["_value"])
+
+
+def test_latent_radius_invalid_radius_mode():
+    with pytest.raises(ValueError, match="Unknown radius mode"):
+        LatentRadiusTruncation(radius_mode="bad")
+
+
+def test_latent_radius_fixed_mode_requires_fixed_radius():
+    with pytest.raises(ValueError, match="Fixed radius mode requires"):
+        LatentRadiusTruncation(radius_mode="fixed")
+
+
+def test_latent_radius_invalid_fixed_radius_type():
+    with pytest.raises(
+        RuntimeError, match="fixed_radius must be an int or float"
+    ):
+        LatentRadiusTruncation(fixed_radius="bad")
+
+
+def test_latent_radius_configure_constant_volume(proposal):
+    proposal.prime_dims = 5
+    rule = LatentRadiusTruncation(
+        radius_mode="constant_volume",
+        max_radius=3.0,
+        min_radius=5.0,
+        volume_fraction=0.95,
+        fuzz=1.5,
+    )
+    with patch(
+        "nessai.proposal.flowproposal.truncation.compute_radius",
+        return_value=4.0,
+    ) as mock:
+        rule.configure(proposal)
+    mock.assert_called_once_with(5, 0.95)
+    assert rule.fixed_radius == 4.0
+    assert rule.min_radius is False
+    assert rule.max_radius is False
+    assert rule.fuzz == 1.0
+
+
+def test_latent_radius_configure_expansion_fraction_updates_fuzz(proposal):
+    proposal.prime_dims = 4
+    rule = LatentRadiusTruncation(expansion_fraction=15.0, fuzz=1.0)
+    rule.configure(proposal)
+    assert rule.fuzz == pytest.approx(2.0)
+
+
+def test_latent_radius_compute_radius_with_adaptive_bounds(
+    proposal, point, samples
+):
+    proposal.training_data = samples([(0.0, 0.0), (1.0, 1.0)])
+    proposal.forward_pass = lambda *args, **kwargs: (
+        np.array([[3.0, 4.0], [6.0, 8.0]]),
+        np.array([0.0, 0.0]),
+    )
+    rule = LatentRadiusTruncation(min_radius=6.0, max_radius=7.0)
+    assert rule._compute_radius(proposal, point(0.0, 0.0)) == 7.0
+
+
+def test_latent_radius_prepare_and_apply_latent(proposal):
+    rule = LatentRadiusTruncation(
+        fixed_radius=1.0, radius_mode="fixed", fuzz=2.0
+    )
+    rule.prepare(proposal, None)
+    z = np.array([[0.0, 0.0], [1.5, 0.0], [2.5, 0.0]])
+    out = rule.apply_latent(proposal, z)
+    assert rule.radius == 1.0
+    assert rule.threshold == 2.0
+    np.testing.assert_array_equal(out, np.array([[0.0, 0.0], [1.5, 0.0]]))
+
+
+def test_min_log_q_prepare(proposal, samples):
+    proposal.training_data = samples([(0.0, 0.0), (1.0, 1.0)])
+    proposal.forward_pass = lambda *args, **kwargs: (
+        np.zeros((2, 2)),
+        np.array([0.5, -1.5]),
+    )
+    rule = MinLogQTruncation()
+    rule.prepare(proposal, None)
+    assert rule.min_log_q == -1.5
+
+
+def test_min_log_q_filters_after_backward(proposal, samples):
+    x = samples([(0.0, 0.0), (1.0, 1.0)])
+    log_q = np.array([0.5, -1.5])
+    z = np.array([[0.0, 0.0], [1.0, 1.0]])
+    rule = MinLogQTruncation()
+    rule._min_log_q = -1.0
+    out_x, out_log_q, out_z = rule.apply_after_backward(proposal, x, log_q, z)
+    assert out_x.size == 1
+    assert rule.min_log_q == -1.0
+    np.testing.assert_array_equal(out_log_q, np.array([0.5]))
+    np.testing.assert_array_equal(out_z, np.array([[0.0, 0.0]]))
+
+
+def test_likelihood_threshold_properties_and_prepare(point):
+    rule = LikelihoodThresholdTruncation()
+    assert rule.requires_log_likelihood is True
+    rule.prepare(None, point(0.0, 0.0, logl=0.5))
+    assert rule.threshold == 0.5
+
+
+def test_likelihood_threshold_filters_after_likelihood(proposal, samples):
+    x = samples([(0.0, 0.0), (1.0, 1.0)])
+    x["logL"] = [0.0, 1.0]
+    log_q = np.array([0.5, -1.5])
+    z = np.array([[0.0, 0.0], [1.0, 1.0]])
+    rule = LikelihoodThresholdTruncation()
+    rule._threshold = 0.5
+    out_x, out_log_q, out_z = rule.apply_after_likelihood(
+        proposal, x, log_q, z
+    )
+    assert out_x.size == 1
+    assert rule.threshold == 0.5
+    np.testing.assert_array_equal(out_log_q, np.array([-1.5]))
+    np.testing.assert_array_equal(out_z, np.array([[1.0, 1.0]]))
+
+
+def test_get_truncation_rule_class():
+    assert get_truncation_rule_class("latent_radius") is LatentRadiusTruncation
+
+
+def test_get_truncation_rule_class_unknown():
+    with pytest.raises(ValueError, match="Unknown truncation method"):
+        get_truncation_rule_class("unknown")
+
+
+def test_truncation_scheme_duplicate_rule_raises():
+    scheme = TruncationScheme([DummyTruncationRule()])
+    with pytest.raises(ValueError, match="Duplicate truncation rule"):
+        scheme.add_rule(DummyTruncationRule())
+
+
+def test_truncation_scheme_rule_names_and_has_rule():
+    scheme = TruncationScheme(
+        [DummyTruncationRule(), LikelihoodThresholdTruncation()]
+    )
+    assert scheme.rule_names == ["dummy", "likelihood_threshold"]
+    assert scheme.has_rule("dummy") is True
+    assert scheme.has_rule("missing") is False
+    assert scheme.requires_log_likelihood is True
+
+
+def test_truncation_scheme_configure_and_apply_stages(proposal, samples):
+    class AddOneRule(BaseTruncationRule):
+        name = "add_one"
+
+        def configure(self, proposal) -> None:
+            proposal.configured = True
+
+        def apply_latent(self, proposal, z):
+            return z + 1.0
+
+    class DropLastRule(BaseTruncationRule):
+        name = "drop_last"
+
+        def apply_after_backward(self, proposal, x, log_q, z):
+            return x[:-1], log_q[:-1], z[:-1]
+
+    scheme = TruncationScheme([AddOneRule(), DropLastRule()])
+    proposal.configured = False
+    scheme.configure(proposal)
+    assert proposal.configured is True
+    np.testing.assert_array_equal(
+        scheme.apply_latent(proposal, np.array([[0.0, 0.0]])),
+        np.array([[1.0, 1.0]]),
+    )
+    x = samples([(0.0, 0.0), (1.0, 1.0)])
+    log_q = np.array([0.0, 1.0])
+    z = np.array([[0.0, 0.0], [1.0, 1.0]])
+    out_x, out_log_q, out_z = scheme.apply_after_backward(
+        proposal, x, log_q, z
+    )
+    assert out_x.size == 1
+    np.testing.assert_array_equal(out_log_q, np.array([0.0]))
+    np.testing.assert_array_equal(out_z, np.array([[0.0, 0.0]]))
+
+
+def test_truncation_scheme_prepare_and_reset(proposal):
+    scheme = TruncationScheme(
+        [
+            LatentRadiusTruncation(
+                fixed_radius=2.0,
+                radius_mode="fixed",
+                volume_fraction=0.9,
+                fuzz=1.5,
+            ),
+            LikelihoodThresholdTruncation(),
+        ]
+    )
+    worst_point = np.zeros(1, dtype=[("logL", "f8")])[0]
+    scheme.prepare(proposal, worst_point)
+    radius_rule = scheme.get_rule("latent_radius")
+    likelihood_rule = scheme.get_rule("likelihood_threshold")
+    assert radius_rule.radius == 2.0
+    assert radius_rule.threshold == 3.0
+    assert radius_rule.volume_fraction == 0.9
+    assert likelihood_rule.threshold == 0.0
+    scheme.reset()
+    assert np.isnan(radius_rule.radius)
+    assert np.isnan(radius_rule.threshold)
+    assert np.isnan(likelihood_rule.threshold)


### PR DESCRIPTION
Refactor the truncation applied to new points in FlowProposal.

The aim of this PR is make it easier to implement new methods for truncating the samples drawn from the flow before performing rejection sampling.

The core design is around a series of truncation classes that implement:

- Truncation in the latent space
- Truncation according to log q
- Truncation according to log likelihood